### PR TITLE
feat: Phase 1 — core schema and domain model with lifecycle state machine

### DIFF
--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -38,6 +38,7 @@
 ### AA — After Action & Review
 
 - `012-AA-AACR-initial-aar.md` — Phase 0 after action review
+- `013-AA-AACR-phase1-schema.md` — Phase 1 core schema after action review
 
 ## Chronological Listing
 
@@ -56,5 +57,6 @@
 | 010 | WA-WFLW | internal-claude-operations | Claude workflows            |
 | 011 | PM-RISK | risk-register              | Risk tracking               |
 | 012 | AA-AACR | initial-aar                | Phase 0 AAR                 |
+| 013 | AA-AACR | phase1-schema              | Phase 1 AAR                 |
 
-## Next Available Sequence: 013
+## Next Available Sequence: 014

--- a/000-docs/004-PP-RMAP-phase-plan.md
+++ b/000-docs/004-PP-RMAP-phase-plan.md
@@ -35,7 +35,7 @@ The project is implemented in sequential phases, each building on the previous. 
 
 ## Phase 1 — Core Schema and Domain Model
 
-**Status**: NOT STARTED
+**Status**: COMPLETE
 
 **Scope**: Define the complete domain model as Zod schemas with derived TypeScript types. This phase establishes the data contracts that all other packages and apps depend on.
 

--- a/000-docs/013-AA-AACR-phase1-schema.md
+++ b/000-docs/013-AA-AACR-phase1-schema.md
@@ -1,0 +1,56 @@
+# After Action Review — Phase 1: Core Schema and Domain Model
+
+## Summary
+
+Implemented the complete domain model for qmd-team-intent-kb as Zod v3 schemas with derived TypeScript types, lifecycle state machine, and comprehensive test coverage.
+
+## What Was Delivered
+
+- **8 source modules** in `packages/schema/src/`:
+  - `enums.ts` — 12 enum definitions (MemorySource, TrustLevel, MemoryCategory, MemoryLifecycleState, CandidateStatus, SearchScope, PolicyRuleType, PolicyRuleAction, AuditAction, Confidence, Sensitivity, AuthorType)
+  - `common.ts` — Shared primitives (Uuid, Sha256Hash, IsoDatetime, NonEmptyString, SemVer, Tag, Author, TenantId, ContentMetadata)
+  - `memory-candidate.ts` — MemoryCandidate schema with inbox status and pre-policy flags
+  - `curated-memory.ts` — CuratedMemory schema with lifecycle refinement, PolicyEvaluation, SupersessionLink
+  - `governance-policy.ts` — GovernancePolicy and PolicyRule schemas
+  - `search.ts` — SearchQuery, SearchHit, SearchResult with curated-only default scope
+  - `audit-event.ts` — AuditEvent schema for immutable audit trail
+  - `lifecycle.ts` — State machine with isTransitionAllowed, validateTransition, getAllowedTransitionsFrom
+
+- **225 tests** across 8 test files, all passing
+- **Test fixture factory** in `__tests__/fixtures.ts` for reusable test data
+
+## Key Design Decisions
+
+1. Single CuratedMemory type with lifecycle enum field, not separate types per state
+2. Candidate → curated is a creation event, not a lifecycle transition
+3. camelCase field names (TypeScript convention)
+4. Zod `.refine()` enforces supersession link when lifecycle is superseded
+5. SearchScope defaults to curated, enforcing governed search at the schema level
+6. Archived is a terminal state — no transitions out
+
+## Lifecycle State Machine
+
+```
+active → deprecated, superseded, archived
+deprecated → active (un-deprecate), archived
+superseded → archived
+archived → (terminal)
+```
+
+## What Went Well
+
+- Clean separation of concerns across modules
+- Comprehensive test coverage with factory fixtures
+- All validation passes first try (format, lint, typecheck, test)
+
+## Lessons Learned
+
+- ESLint `consistent-type-imports` rule disallows `import()` type annotations in inline positions — use top-level type imports instead
+- Fixture factories using `Record<string, unknown>` return types avoid coupling fixtures to Zod output types while remaining compatible with `.parse()`
+
+## Dependencies Enabled
+
+Phase 1 unblocks:
+- Phase 2 (Claude Runtime Capture) — imports MemoryCandidate, MemorySource, TrustLevel
+- Phase 3 (qmd Adapter) — imports SearchQuery, SearchResult, SearchScope
+- Phase 4 (Policy Engine) — imports GovernancePolicy, PolicyRule, MemoryCandidate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Core domain model with Zod schemas for MemoryCandidate, CuratedMemory, GovernancePolicy, SearchQuery/Result, and AuditEvent
+- Lifecycle state machine with transition validation (active, deprecated, superseded, archived)
+- Shared primitive types (UUID, SHA-256 hash, ISO datetime, Author, ContentMetadata)
+- 12 enum definitions covering memory source, trust level, category, and governance actions
+- SearchScope defaults to curated-only, enforcing governed search behavior
+- CuratedMemory refinement requiring supersession link when lifecycle is superseded
+- 225 schema tests covering valid/invalid inputs, defaults, and edge cases
 - Monorepo scaffolding with pnpm workspaces (apps/, packages/, kb-export/, tests/, scripts/, examples/)
 - Architecture documentation and system thesis (000-docs/001-repo-blueprint)
 - Security policy with project-specific threat model covering memory integrity, MCP risk, and tenant isolation

--- a/packages/schema/src/__tests__/audit-event.test.ts
+++ b/packages/schema/src/__tests__/audit-event.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { AuditEvent } from '../audit-event.js';
+import { makeAuditEvent } from './fixtures.js';
+
+describe('AuditEvent', () => {
+  it('parses a valid event', () => {
+    const result = AuditEvent.parse(makeAuditEvent());
+    expect(result.action).toBe('promoted');
+    expect(result.tenantId).toBe('team-alpha');
+  });
+
+  it('accepts all audit actions', () => {
+    const actions = [
+      'promoted',
+      'demoted',
+      'superseded',
+      'archived',
+      'deleted',
+      'searched',
+      'exported',
+    ] as const;
+    for (const action of actions) {
+      const result = AuditEvent.parse(makeAuditEvent({ action }));
+      expect(result.action).toBe(action);
+    }
+  });
+
+  it('defaults details to empty object', () => {
+    const input = makeAuditEvent();
+    delete (input as Record<string, unknown>)['details'];
+    const result = AuditEvent.parse(input);
+    expect(result.details).toEqual({});
+  });
+
+  it('accepts optional reason', () => {
+    const input = makeAuditEvent();
+    delete (input as Record<string, unknown>)['reason'];
+    const result = AuditEvent.parse(input);
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('preserves custom details', () => {
+    const result = AuditEvent.parse(
+      makeAuditEvent({
+        details: { previousState: 'active', newState: 'deprecated', policyId: 'p-123' },
+      }),
+    );
+    expect(result.details).toEqual({
+      previousState: 'active',
+      newState: 'deprecated',
+      policyId: 'p-123',
+    });
+  });
+
+  it('rejects missing action', () => {
+    const input = makeAuditEvent();
+    delete (input as Record<string, unknown>)['action'];
+    expect(() => AuditEvent.parse(input)).toThrow();
+  });
+
+  it('rejects missing memoryId', () => {
+    const input = makeAuditEvent();
+    delete (input as Record<string, unknown>)['memoryId'];
+    expect(() => AuditEvent.parse(input)).toThrow();
+  });
+
+  it('rejects missing tenantId', () => {
+    const input = makeAuditEvent();
+    delete (input as Record<string, unknown>)['tenantId'];
+    expect(() => AuditEvent.parse(input)).toThrow();
+  });
+
+  it('rejects missing actor', () => {
+    const input = makeAuditEvent();
+    delete (input as Record<string, unknown>)['actor'];
+    expect(() => AuditEvent.parse(input)).toThrow();
+  });
+
+  it('rejects invalid action', () => {
+    expect(() => AuditEvent.parse(makeAuditEvent({ action: 'created' as 'promoted' }))).toThrow();
+  });
+
+  it('rejects invalid memoryId', () => {
+    expect(() => AuditEvent.parse(makeAuditEvent({ memoryId: 'not-uuid' }))).toThrow();
+  });
+
+  it('rejects invalid timestamp', () => {
+    expect(() => AuditEvent.parse(makeAuditEvent({ timestamp: 'not-a-date' }))).toThrow();
+  });
+});

--- a/packages/schema/src/__tests__/common.test.ts
+++ b/packages/schema/src/__tests__/common.test.ts
@@ -87,8 +87,17 @@ describe('SemVer', () => {
   it('rejects two-part versions', () => {
     expect(() => SemVer.parse('1.2')).toThrow();
   });
-  it('rejects prerelease suffixes', () => {
-    expect(() => SemVer.parse('1.2.3-alpha')).toThrow();
+  it('accepts prerelease identifiers', () => {
+    expect(SemVer.parse('1.2.3-alpha')).toBe('1.2.3-alpha');
+    expect(SemVer.parse('1.0.0-alpha.1')).toBe('1.0.0-alpha.1');
+    expect(SemVer.parse('1.0.0-0.3.7')).toBe('1.0.0-0.3.7');
+  });
+  it('accepts build metadata', () => {
+    expect(SemVer.parse('1.2.3+build.123')).toBe('1.2.3+build.123');
+    expect(SemVer.parse('1.0.0-alpha+001')).toBe('1.0.0-alpha+001');
+  });
+  it('rejects leading zeros in numeric identifiers', () => {
+    expect(() => SemVer.parse('01.2.3')).toThrow();
   });
 });
 

--- a/packages/schema/src/__tests__/common.test.ts
+++ b/packages/schema/src/__tests__/common.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import {
+  Uuid,
+  Sha256Hash,
+  IsoDatetime,
+  NonEmptyString,
+  SemVer,
+  Tag,
+  Author,
+  ContentMetadata,
+} from '../common.js';
+
+describe('Uuid', () => {
+  it('accepts a valid UUID v4', () => {
+    const id = randomUUID();
+    expect(Uuid.parse(id)).toBe(id);
+  });
+  it('rejects non-UUID strings', () => {
+    expect(() => Uuid.parse('not-a-uuid')).toThrow();
+  });
+  it('rejects empty string', () => {
+    expect(() => Uuid.parse('')).toThrow();
+  });
+});
+
+describe('Sha256Hash', () => {
+  it('accepts a valid 64-char hex hash', () => {
+    const hash = 'a'.repeat(64);
+    expect(Sha256Hash.parse(hash)).toBe(hash);
+  });
+  it('accepts mixed hex characters', () => {
+    const hash = 'abcdef0123456789'.repeat(4);
+    expect(Sha256Hash.parse(hash)).toBe(hash);
+  });
+  it('rejects uppercase hex', () => {
+    expect(() => Sha256Hash.parse('A'.repeat(64))).toThrow();
+  });
+  it('rejects wrong length', () => {
+    expect(() => Sha256Hash.parse('a'.repeat(63))).toThrow();
+    expect(() => Sha256Hash.parse('a'.repeat(65))).toThrow();
+  });
+  it('rejects non-hex characters', () => {
+    expect(() => Sha256Hash.parse('g'.repeat(64))).toThrow();
+  });
+});
+
+describe('IsoDatetime', () => {
+  it('accepts valid ISO datetime', () => {
+    const dt = '2026-01-15T10:00:00.000Z';
+    expect(IsoDatetime.parse(dt)).toBe(dt);
+  });
+  it('accepts datetime without milliseconds', () => {
+    const dt = '2026-01-15T10:00:00Z';
+    expect(IsoDatetime.parse(dt)).toBe(dt);
+  });
+  it('rejects date-only strings', () => {
+    expect(() => IsoDatetime.parse('2026-01-15')).toThrow();
+  });
+  it('rejects invalid dates', () => {
+    expect(() => IsoDatetime.parse('not-a-date')).toThrow();
+  });
+});
+
+describe('NonEmptyString', () => {
+  it('accepts non-empty string', () => {
+    expect(NonEmptyString.parse('hello')).toBe('hello');
+  });
+  it('trims whitespace', () => {
+    expect(NonEmptyString.parse('  hello  ')).toBe('hello');
+  });
+  it('rejects empty string', () => {
+    expect(() => NonEmptyString.parse('')).toThrow();
+  });
+  it('rejects whitespace-only string', () => {
+    expect(() => NonEmptyString.parse('   ')).toThrow();
+  });
+});
+
+describe('SemVer', () => {
+  it('accepts valid semver', () => {
+    expect(SemVer.parse('1.2.3')).toBe('1.2.3');
+  });
+  it('accepts zero versions', () => {
+    expect(SemVer.parse('0.0.0')).toBe('0.0.0');
+  });
+  it('rejects two-part versions', () => {
+    expect(() => SemVer.parse('1.2')).toThrow();
+  });
+  it('rejects prerelease suffixes', () => {
+    expect(() => SemVer.parse('1.2.3-alpha')).toThrow();
+  });
+});
+
+describe('Tag', () => {
+  it('accepts lowercase tags', () => {
+    expect(Tag.parse('api-design')).toBe('api-design');
+  });
+  it('accepts numeric tags', () => {
+    expect(Tag.parse('v2')).toBe('v2');
+  });
+  it('rejects uppercase', () => {
+    expect(() => Tag.parse('API')).toThrow();
+  });
+  it('rejects starting with hyphen', () => {
+    expect(() => Tag.parse('-api')).toThrow();
+  });
+});
+
+describe('Author', () => {
+  it('accepts valid author', () => {
+    const result = Author.parse({ type: 'human', id: 'user-1', name: 'Test' });
+    expect(result.type).toBe('human');
+    expect(result.id).toBe('user-1');
+    expect(result.name).toBe('Test');
+  });
+  it('allows optional name', () => {
+    const result = Author.parse({ type: 'ai', id: 'claude' });
+    expect(result.name).toBeUndefined();
+  });
+  it('rejects missing id', () => {
+    expect(() => Author.parse({ type: 'human' })).toThrow();
+  });
+  it('rejects invalid author type', () => {
+    expect(() => Author.parse({ type: 'bot', id: 'x' })).toThrow();
+  });
+});
+
+describe('ContentMetadata', () => {
+  it('accepts full metadata', () => {
+    const meta = ContentMetadata.parse({
+      filePaths: ['src/index.ts'],
+      language: 'typescript',
+      projectContext: 'qmd-team-intent-kb',
+      sessionId: 'sess-123',
+      repoUrl: 'https://github.com/org/repo',
+      branch: 'main',
+      confidence: 'high',
+      sensitivity: 'internal',
+      tags: ['api-design', 'patterns'],
+    });
+    expect(meta.filePaths).toEqual(['src/index.ts']);
+    expect(meta.tags).toEqual(['api-design', 'patterns']);
+  });
+  it('defaults filePaths to empty array', () => {
+    const meta = ContentMetadata.parse({});
+    expect(meta.filePaths).toEqual([]);
+  });
+  it('defaults tags to empty array', () => {
+    const meta = ContentMetadata.parse({});
+    expect(meta.tags).toEqual([]);
+  });
+  it('rejects invalid confidence', () => {
+    expect(() => ContentMetadata.parse({ confidence: 'very_high' })).toThrow();
+  });
+});

--- a/packages/schema/src/__tests__/curated-memory.test.ts
+++ b/packages/schema/src/__tests__/curated-memory.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { CuratedMemory, PolicyEvaluation, SupersessionLink } from '../curated-memory.js';
+import { makeCuratedMemory } from './fixtures.js';
+
+const NOW = '2026-01-15T10:00:00.000Z';
+
+describe('PolicyEvaluation', () => {
+  it('parses valid evaluation', () => {
+    const result = PolicyEvaluation.parse({
+      policyId: randomUUID(),
+      ruleId: 'rule-1',
+      result: 'pass',
+      evaluatedAt: NOW,
+    });
+    expect(result.result).toBe('pass');
+  });
+
+  it('accepts optional reason', () => {
+    const result = PolicyEvaluation.parse({
+      policyId: randomUUID(),
+      ruleId: 'rule-1',
+      result: 'fail',
+      reason: 'Secret detected',
+      evaluatedAt: NOW,
+    });
+    expect(result.reason).toBe('Secret detected');
+  });
+
+  it('rejects invalid result', () => {
+    expect(() =>
+      PolicyEvaluation.parse({
+        policyId: randomUUID(),
+        ruleId: 'rule-1',
+        result: 'skip',
+        evaluatedAt: NOW,
+      }),
+    ).toThrow();
+  });
+});
+
+describe('SupersessionLink', () => {
+  it('parses valid link', () => {
+    const result = SupersessionLink.parse({
+      supersededBy: randomUUID(),
+      reason: 'Updated with new API pattern',
+      linkedAt: NOW,
+    });
+    expect(result.reason).toBe('Updated with new API pattern');
+  });
+
+  it('rejects empty reason', () => {
+    expect(() =>
+      SupersessionLink.parse({
+        supersededBy: randomUUID(),
+        reason: '',
+        linkedAt: NOW,
+      }),
+    ).toThrow();
+  });
+});
+
+describe('CuratedMemory', () => {
+  it('parses a valid active memory', () => {
+    const input = makeCuratedMemory();
+    const result = CuratedMemory.parse(input);
+    expect(result.lifecycle).toBe('active');
+    expect(result.version).toBe(1);
+  });
+
+  it('defaults sensitivity to internal', () => {
+    const input = makeCuratedMemory();
+    delete (input as Record<string, unknown>)['sensitivity'];
+    const result = CuratedMemory.parse(input);
+    expect(result.sensitivity).toBe('internal');
+  });
+
+  it('defaults version to 1', () => {
+    const input = makeCuratedMemory();
+    delete (input as Record<string, unknown>)['version'];
+    const result = CuratedMemory.parse(input);
+    expect(result.version).toBe(1);
+  });
+
+  it('defaults policyEvaluations to empty array', () => {
+    const input = makeCuratedMemory();
+    delete (input as Record<string, unknown>)['policyEvaluations'];
+    const result = CuratedMemory.parse(input);
+    expect(result.policyEvaluations).toEqual([]);
+  });
+
+  it('accepts superseded lifecycle with supersession link', () => {
+    const result = CuratedMemory.parse(
+      makeCuratedMemory({
+        lifecycle: 'superseded',
+        supersession: {
+          supersededBy: randomUUID(),
+          reason: 'Replaced by updated pattern',
+          linkedAt: NOW,
+        },
+      }),
+    );
+    expect(result.lifecycle).toBe('superseded');
+    expect(result.supersession).toBeDefined();
+  });
+
+  it('rejects superseded lifecycle without supersession link', () => {
+    expect(() =>
+      CuratedMemory.parse(
+        makeCuratedMemory({
+          lifecycle: 'superseded',
+          supersession: undefined,
+        }),
+      ),
+    ).toThrow('supersession must be defined');
+  });
+
+  it('accepts active lifecycle without supersession', () => {
+    const result = CuratedMemory.parse(makeCuratedMemory({ lifecycle: 'active' }));
+    expect(result.supersession).toBeUndefined();
+  });
+
+  it('accepts deprecated lifecycle without supersession', () => {
+    const result = CuratedMemory.parse(makeCuratedMemory({ lifecycle: 'deprecated' }));
+    expect(result.lifecycle).toBe('deprecated');
+  });
+
+  it('accepts archived lifecycle without supersession', () => {
+    const result = CuratedMemory.parse(makeCuratedMemory({ lifecycle: 'archived' }));
+    expect(result.lifecycle).toBe('archived');
+  });
+
+  it('rejects missing required fields', () => {
+    expect(() => CuratedMemory.parse({})).toThrow();
+  });
+
+  it('rejects empty content', () => {
+    expect(() => CuratedMemory.parse(makeCuratedMemory({ content: '' }))).toThrow();
+  });
+
+  it('rejects invalid contentHash', () => {
+    expect(() => CuratedMemory.parse(makeCuratedMemory({ contentHash: 'short' }))).toThrow();
+  });
+
+  it('rejects non-positive version', () => {
+    expect(() => CuratedMemory.parse(makeCuratedMemory({ version: 0 }))).toThrow();
+    expect(() => CuratedMemory.parse(makeCuratedMemory({ version: -1 }))).toThrow();
+  });
+
+  it('accepts version > 1', () => {
+    const result = CuratedMemory.parse(makeCuratedMemory({ version: 5 }));
+    expect(result.version).toBe(5);
+  });
+
+  it('preserves all policy evaluations', () => {
+    const evals = [
+      {
+        policyId: randomUUID(),
+        ruleId: 'rule-1',
+        result: 'pass' as const,
+        evaluatedAt: NOW,
+      },
+      {
+        policyId: randomUUID(),
+        ruleId: 'rule-2',
+        result: 'flag' as const,
+        reason: 'Low confidence',
+        evaluatedAt: NOW,
+      },
+    ];
+    const result = CuratedMemory.parse(makeCuratedMemory({ policyEvaluations: evals }));
+    expect(result.policyEvaluations).toHaveLength(2);
+  });
+
+  it('rejects invalid lifecycle state', () => {
+    expect(() =>
+      CuratedMemory.parse(makeCuratedMemory({ lifecycle: 'draft' as 'active' })),
+    ).toThrow();
+  });
+});

--- a/packages/schema/src/__tests__/enums.test.ts
+++ b/packages/schema/src/__tests__/enums.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MemorySource,
+  TrustLevel,
+  MemoryCategory,
+  MemoryLifecycleState,
+  CandidateStatus,
+  SearchScope,
+  PolicyRuleType,
+  PolicyRuleAction,
+  AuditAction,
+  Confidence,
+  Sensitivity,
+  AuthorType,
+} from '../enums.js';
+
+describe('MemorySource', () => {
+  it.each(['claude_session', 'manual', 'import', 'mcp'])('accepts "%s"', (val) => {
+    expect(MemorySource.parse(val)).toBe(val);
+  });
+  it('rejects invalid value', () => {
+    expect(() => MemorySource.parse('unknown')).toThrow();
+  });
+});
+
+describe('TrustLevel', () => {
+  it.each(['high', 'medium', 'low', 'untrusted'])('accepts "%s"', (val) => {
+    expect(TrustLevel.parse(val)).toBe(val);
+  });
+  it('rejects invalid value', () => {
+    expect(() => TrustLevel.parse('super_high')).toThrow();
+  });
+});
+
+describe('MemoryCategory', () => {
+  const categories = [
+    'decision',
+    'pattern',
+    'convention',
+    'architecture',
+    'troubleshooting',
+    'onboarding',
+    'reference',
+  ];
+  it.each(categories)('accepts "%s"', (val) => {
+    expect(MemoryCategory.parse(val)).toBe(val);
+  });
+  it('rejects invalid value', () => {
+    expect(() => MemoryCategory.parse('other')).toThrow();
+  });
+});
+
+describe('MemoryLifecycleState', () => {
+  it.each(['active', 'deprecated', 'superseded', 'archived'])('accepts "%s"', (val) => {
+    expect(MemoryLifecycleState.parse(val)).toBe(val);
+  });
+  it('rejects invalid value', () => {
+    expect(() => MemoryLifecycleState.parse('draft')).toThrow();
+  });
+});
+
+describe('CandidateStatus', () => {
+  it('accepts "inbox"', () => {
+    expect(CandidateStatus.parse('inbox')).toBe('inbox');
+  });
+  it('rejects anything else', () => {
+    expect(() => CandidateStatus.parse('review')).toThrow();
+  });
+});
+
+describe('SearchScope', () => {
+  it.each(['curated', 'all', 'inbox', 'archived'])('accepts "%s"', (val) => {
+    expect(SearchScope.parse(val)).toBe(val);
+  });
+  it('defaults to "curated"', () => {
+    expect(SearchScope.parse(undefined)).toBe('curated');
+  });
+  it('rejects invalid value', () => {
+    expect(() => SearchScope.parse('private')).toThrow();
+  });
+});
+
+describe('PolicyRuleType', () => {
+  const types = [
+    'secret_detection',
+    'dedup_check',
+    'relevance_score',
+    'content_length',
+    'source_trust',
+    'tenant_match',
+  ];
+  it.each(types)('accepts "%s"', (val) => {
+    expect(PolicyRuleType.parse(val)).toBe(val);
+  });
+  it('rejects invalid value', () => {
+    expect(() => PolicyRuleType.parse('custom')).toThrow();
+  });
+});
+
+describe('PolicyRuleAction', () => {
+  it.each(['reject', 'flag', 'approve', 'require_review'])('accepts "%s"', (val) => {
+    expect(PolicyRuleAction.parse(val)).toBe(val);
+  });
+  it('rejects invalid value', () => {
+    expect(() => PolicyRuleAction.parse('ignore')).toThrow();
+  });
+});
+
+describe('AuditAction', () => {
+  const actions = [
+    'promoted',
+    'demoted',
+    'superseded',
+    'archived',
+    'deleted',
+    'searched',
+    'exported',
+  ];
+  it.each(actions)('accepts "%s"', (val) => {
+    expect(AuditAction.parse(val)).toBe(val);
+  });
+  it('rejects invalid value', () => {
+    expect(() => AuditAction.parse('created')).toThrow();
+  });
+});
+
+describe('Confidence', () => {
+  it.each(['high', 'medium', 'low'])('accepts "%s"', (val) => {
+    expect(Confidence.parse(val)).toBe(val);
+  });
+  it('rejects invalid value', () => {
+    expect(() => Confidence.parse('very_high')).toThrow();
+  });
+});
+
+describe('Sensitivity', () => {
+  it.each(['public', 'internal', 'confidential', 'restricted'])('accepts "%s"', (val) => {
+    expect(Sensitivity.parse(val)).toBe(val);
+  });
+  it('rejects invalid value', () => {
+    expect(() => Sensitivity.parse('top_secret')).toThrow();
+  });
+});
+
+describe('AuthorType', () => {
+  it.each(['human', 'ai', 'system'])('accepts "%s"', (val) => {
+    expect(AuthorType.parse(val)).toBe(val);
+  });
+  it('rejects invalid value', () => {
+    expect(() => AuthorType.parse('bot')).toThrow();
+  });
+});

--- a/packages/schema/src/__tests__/fixtures.ts
+++ b/packages/schema/src/__tests__/fixtures.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from 'node:crypto';
+
+const NOW = '2026-01-15T10:00:00.000Z';
+const HASH = 'a'.repeat(64);
+
+export function makeAuthor(overrides?: Record<string, unknown>): {
+  type: string;
+  id: string;
+  name?: string;
+} {
+  return {
+    type: 'human',
+    id: 'user-1',
+    name: 'Test User',
+    ...overrides,
+  };
+}
+
+export function makeMemoryCandidate(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: randomUUID(),
+    status: 'inbox',
+    source: 'claude_session',
+    content: 'Use Result<T, E> for all fallible operations',
+    title: 'Error handling convention',
+    category: 'convention',
+    trustLevel: 'medium',
+    author: makeAuthor({ type: 'ai', id: 'claude-session-1' }),
+    tenantId: 'team-alpha',
+    metadata: {},
+    prePolicyFlags: {},
+    capturedAt: NOW,
+    ...overrides,
+  };
+}
+
+export function makeCuratedMemory(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: randomUUID(),
+    candidateId: randomUUID(),
+    source: 'claude_session',
+    content: 'All API endpoints must validate input with Zod schemas',
+    title: 'API input validation pattern',
+    category: 'pattern',
+    trustLevel: 'high',
+    sensitivity: 'internal',
+    author: makeAuthor({ type: 'ai', id: 'claude-session-2' }),
+    tenantId: 'team-alpha',
+    metadata: {},
+    lifecycle: 'active',
+    contentHash: HASH,
+    policyEvaluations: [],
+    promotedAt: NOW,
+    promotedBy: makeAuthor(),
+    updatedAt: NOW,
+    version: 1,
+    ...overrides,
+  };
+}
+
+export function makeGovernancePolicy(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: randomUUID(),
+    name: 'Default Security Policy',
+    tenantId: 'team-alpha',
+    rules: [
+      {
+        id: 'rule-secret-detect',
+        type: 'secret_detection',
+        action: 'reject',
+        enabled: true,
+        priority: 0,
+        parameters: {},
+      },
+    ],
+    enabled: true,
+    version: 1,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+export function makeSearchQuery(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    query: 'error handling',
+    ...overrides,
+  };
+}
+
+export function makeSearchHit(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    memoryId: randomUUID(),
+    title: 'Error handling convention',
+    snippet: 'Use Result<T, E> for all fallible operations',
+    score: 0.85,
+    category: 'convention',
+    matchedAt: NOW,
+    ...overrides,
+  };
+}
+
+export function makeSearchResult(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    hits: [makeSearchHit()],
+    totalCount: 1,
+    query: 'error handling',
+    scope: 'curated',
+    page: 1,
+    pageSize: 20,
+    hasMore: false,
+    ...overrides,
+  };
+}
+
+export function makeAuditEvent(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: randomUUID(),
+    action: 'promoted',
+    memoryId: randomUUID(),
+    tenantId: 'team-alpha',
+    actor: makeAuthor(),
+    reason: 'Passed all governance rules',
+    details: {},
+    timestamp: NOW,
+    ...overrides,
+  };
+}

--- a/packages/schema/src/__tests__/governance-policy.test.ts
+++ b/packages/schema/src/__tests__/governance-policy.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { GovernancePolicy, PolicyRule } from '../governance-policy.js';
+import { makeGovernancePolicy } from './fixtures.js';
+
+describe('PolicyRule', () => {
+  it('parses valid rule', () => {
+    const result = PolicyRule.parse({
+      id: 'rule-1',
+      type: 'secret_detection',
+      action: 'reject',
+    });
+    expect(result.enabled).toBe(true);
+    expect(result.priority).toBe(0);
+    expect(result.parameters).toEqual({});
+  });
+
+  it('accepts all rule types', () => {
+    const types = [
+      'secret_detection',
+      'dedup_check',
+      'relevance_score',
+      'content_length',
+      'source_trust',
+      'tenant_match',
+    ] as const;
+    for (const type of types) {
+      expect(PolicyRule.parse({ id: 'r', type, action: 'approve' }).type).toBe(type);
+    }
+  });
+
+  it('accepts all actions', () => {
+    const actions = ['reject', 'flag', 'approve', 'require_review'] as const;
+    for (const action of actions) {
+      expect(PolicyRule.parse({ id: 'r', type: 'dedup_check', action }).action).toBe(action);
+    }
+  });
+
+  it('accepts custom parameters', () => {
+    const result = PolicyRule.parse({
+      id: 'rule-dedup',
+      type: 'dedup_check',
+      action: 'flag',
+      parameters: { threshold: 0.8, algorithm: 'cosine' },
+    });
+    expect(result.parameters).toEqual({ threshold: 0.8, algorithm: 'cosine' });
+  });
+
+  it('rejects missing id', () => {
+    expect(() => PolicyRule.parse({ type: 'secret_detection', action: 'reject' })).toThrow();
+  });
+
+  it('rejects invalid type', () => {
+    expect(() => PolicyRule.parse({ id: 'r', type: 'custom_rule', action: 'reject' })).toThrow();
+  });
+
+  it('rejects negative priority', () => {
+    expect(() =>
+      PolicyRule.parse({ id: 'r', type: 'dedup_check', action: 'flag', priority: -1 }),
+    ).toThrow();
+  });
+});
+
+describe('GovernancePolicy', () => {
+  it('parses a valid policy', () => {
+    const input = makeGovernancePolicy();
+    const result = GovernancePolicy.parse(input);
+    expect(result.name).toBe('Default Security Policy');
+    expect(result.rules).toHaveLength(1);
+    expect(result.enabled).toBe(true);
+  });
+
+  it('requires at least one rule', () => {
+    expect(() => GovernancePolicy.parse(makeGovernancePolicy({ rules: [] }))).toThrow();
+  });
+
+  it('accepts multiple rules', () => {
+    const result = GovernancePolicy.parse(
+      makeGovernancePolicy({
+        rules: [
+          { id: 'r1', type: 'secret_detection', action: 'reject' },
+          { id: 'r2', type: 'dedup_check', action: 'flag', priority: 1 },
+          { id: 'r3', type: 'content_length', action: 'approve', priority: 2 },
+        ],
+      }),
+    );
+    expect(result.rules).toHaveLength(3);
+  });
+
+  it('defaults enabled to true', () => {
+    const input = makeGovernancePolicy();
+    delete (input as Record<string, unknown>)['enabled'];
+    const result = GovernancePolicy.parse(input);
+    expect(result.enabled).toBe(true);
+  });
+
+  it('defaults version to 1', () => {
+    const input = makeGovernancePolicy();
+    delete (input as Record<string, unknown>)['version'];
+    const result = GovernancePolicy.parse(input);
+    expect(result.version).toBe(1);
+  });
+
+  it('rejects missing name', () => {
+    const input = makeGovernancePolicy();
+    delete (input as Record<string, unknown>)['name'];
+    expect(() => GovernancePolicy.parse(input)).toThrow();
+  });
+
+  it('rejects missing tenantId', () => {
+    const input = makeGovernancePolicy();
+    delete (input as Record<string, unknown>)['tenantId'];
+    expect(() => GovernancePolicy.parse(input)).toThrow();
+  });
+
+  it('rejects non-positive version', () => {
+    expect(() => GovernancePolicy.parse(makeGovernancePolicy({ version: 0 }))).toThrow();
+  });
+});

--- a/packages/schema/src/__tests__/lifecycle.test.ts
+++ b/packages/schema/src/__tests__/lifecycle.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import {
+  ALLOWED_TRANSITIONS,
+  isTransitionAllowed,
+  validateTransition,
+  getAllowedTransitionsFrom,
+  TransitionRequest,
+} from '../lifecycle.js';
+import type { MemoryLifecycleState } from '../enums.js';
+import { makeAuthor } from './fixtures.js';
+
+const makeTransitionRequest = (
+  overrides?: Partial<{
+    reason: string;
+    actor: { type: string; id: string };
+    supersededBy: string;
+  }>,
+) =>
+  TransitionRequest.parse({
+    reason: 'No longer relevant',
+    actor: makeAuthor(),
+    ...overrides,
+  });
+
+describe('ALLOWED_TRANSITIONS', () => {
+  it('active can transition to deprecated, superseded, archived', () => {
+    expect(ALLOWED_TRANSITIONS.active).toEqual(['deprecated', 'superseded', 'archived']);
+  });
+
+  it('deprecated can transition to active, archived', () => {
+    expect(ALLOWED_TRANSITIONS.deprecated).toEqual(['active', 'archived']);
+  });
+
+  it('superseded can transition to archived', () => {
+    expect(ALLOWED_TRANSITIONS.superseded).toEqual(['archived']);
+  });
+
+  it('archived is terminal (no transitions)', () => {
+    expect(ALLOWED_TRANSITIONS.archived).toEqual([]);
+  });
+});
+
+describe('isTransitionAllowed', () => {
+  const allowed: [MemoryLifecycleState, MemoryLifecycleState][] = [
+    ['active', 'deprecated'],
+    ['active', 'superseded'],
+    ['active', 'archived'],
+    ['deprecated', 'active'],
+    ['deprecated', 'archived'],
+    ['superseded', 'archived'],
+  ];
+
+  it.each(allowed)('%s → %s is allowed', (from, to) => {
+    expect(isTransitionAllowed(from, to)).toBe(true);
+  });
+
+  const disallowed: [MemoryLifecycleState, MemoryLifecycleState][] = [
+    ['active', 'active'],
+    ['deprecated', 'deprecated'],
+    ['deprecated', 'superseded'],
+    ['superseded', 'active'],
+    ['superseded', 'deprecated'],
+    ['superseded', 'superseded'],
+    ['archived', 'active'],
+    ['archived', 'deprecated'],
+    ['archived', 'superseded'],
+    ['archived', 'archived'],
+  ];
+
+  it.each(disallowed)('%s → %s is NOT allowed', (from, to) => {
+    expect(isTransitionAllowed(from, to)).toBe(false);
+  });
+});
+
+describe('validateTransition', () => {
+  it('returns valid for allowed transition with required fields', () => {
+    const result = validateTransition('active', 'deprecated', makeTransitionRequest());
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('returns invalid for disallowed transition', () => {
+    const result = validateTransition('archived', 'active', makeTransitionRequest());
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain('not allowed');
+    }
+  });
+
+  it('requires supersededBy for transition to superseded', () => {
+    const result = validateTransition('active', 'superseded', makeTransitionRequest());
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain('supersededBy');
+    }
+  });
+
+  it('accepts transition to superseded with supersededBy', () => {
+    const result = validateTransition(
+      'active',
+      'superseded',
+      makeTransitionRequest({ supersededBy: randomUUID() }),
+    );
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('validates active → archived', () => {
+    const result = validateTransition('active', 'archived', makeTransitionRequest());
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('validates deprecated → active (un-deprecate)', () => {
+    const result = validateTransition('deprecated', 'active', makeTransitionRequest());
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('validates deprecated → archived', () => {
+    const result = validateTransition('deprecated', 'archived', makeTransitionRequest());
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('validates superseded → archived', () => {
+    const result = validateTransition('superseded', 'archived', makeTransitionRequest());
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('rejects all transitions from archived', () => {
+    const states: MemoryLifecycleState[] = ['active', 'deprecated', 'superseded', 'archived'];
+    for (const to of states) {
+      const result = validateTransition('archived', to, makeTransitionRequest());
+      expect(result.valid).toBe(false);
+    }
+  });
+});
+
+describe('getAllowedTransitionsFrom', () => {
+  it('returns correct transitions for active', () => {
+    expect(getAllowedTransitionsFrom('active')).toEqual(['deprecated', 'superseded', 'archived']);
+  });
+
+  it('returns correct transitions for deprecated', () => {
+    expect(getAllowedTransitionsFrom('deprecated')).toEqual(['active', 'archived']);
+  });
+
+  it('returns correct transitions for superseded', () => {
+    expect(getAllowedTransitionsFrom('superseded')).toEqual(['archived']);
+  });
+
+  it('returns empty array for archived', () => {
+    expect(getAllowedTransitionsFrom('archived')).toEqual([]);
+  });
+
+  it('returns a new array (not the original)', () => {
+    const result = getAllowedTransitionsFrom('active');
+    result.push('active');
+    expect(getAllowedTransitionsFrom('active')).toEqual(['deprecated', 'superseded', 'archived']);
+  });
+});
+
+describe('TransitionRequest', () => {
+  it('parses valid request', () => {
+    const result = TransitionRequest.parse({
+      reason: 'Outdated information',
+      actor: makeAuthor(),
+    });
+    expect(result.reason).toBe('Outdated information');
+    expect(result.supersededBy).toBeUndefined();
+  });
+
+  it('accepts optional supersededBy', () => {
+    const id = randomUUID();
+    const result = TransitionRequest.parse({
+      reason: 'Replaced',
+      actor: makeAuthor(),
+      supersededBy: id,
+    });
+    expect(result.supersededBy).toBe(id);
+  });
+
+  it('rejects empty reason', () => {
+    expect(() => TransitionRequest.parse({ reason: '', actor: makeAuthor() })).toThrow();
+  });
+
+  it('rejects missing actor', () => {
+    expect(() => TransitionRequest.parse({ reason: 'test' })).toThrow();
+  });
+});

--- a/packages/schema/src/__tests__/memory-candidate.test.ts
+++ b/packages/schema/src/__tests__/memory-candidate.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryCandidate, PrePolicyFlags } from '../memory-candidate.js';
+import { makeMemoryCandidate } from './fixtures.js';
+
+describe('PrePolicyFlags', () => {
+  it('defaults all flags to false', () => {
+    const flags = PrePolicyFlags.parse({});
+    expect(flags.potentialSecret).toBe(false);
+    expect(flags.lowConfidence).toBe(false);
+    expect(flags.duplicateSuspect).toBe(false);
+  });
+
+  it('accepts explicit flag values', () => {
+    const flags = PrePolicyFlags.parse({ potentialSecret: true, lowConfidence: true });
+    expect(flags.potentialSecret).toBe(true);
+    expect(flags.lowConfidence).toBe(true);
+    expect(flags.duplicateSuspect).toBe(false);
+  });
+});
+
+describe('MemoryCandidate', () => {
+  it('parses a valid candidate', () => {
+    const input = makeMemoryCandidate();
+    const result = MemoryCandidate.parse(input);
+    expect(result.status).toBe('inbox');
+    expect(result.source).toBe('claude_session');
+    expect(result.category).toBe('convention');
+  });
+
+  it('defaults trustLevel to medium', () => {
+    const input = makeMemoryCandidate();
+    delete (input as Record<string, unknown>)['trustLevel'];
+    const result = MemoryCandidate.parse(input);
+    expect(result.trustLevel).toBe('medium');
+  });
+
+  it('defaults metadata to empty', () => {
+    const input = makeMemoryCandidate();
+    delete (input as Record<string, unknown>)['metadata'];
+    const result = MemoryCandidate.parse(input);
+    expect(result.metadata.filePaths).toEqual([]);
+    expect(result.metadata.tags).toEqual([]);
+  });
+
+  it('defaults prePolicyFlags to all false', () => {
+    const input = makeMemoryCandidate();
+    delete (input as Record<string, unknown>)['prePolicyFlags'];
+    const result = MemoryCandidate.parse(input);
+    expect(result.prePolicyFlags.potentialSecret).toBe(false);
+  });
+
+  it('rejects missing required id', () => {
+    const input = makeMemoryCandidate();
+    delete (input as Record<string, unknown>)['id'];
+    expect(() => MemoryCandidate.parse(input)).toThrow();
+  });
+
+  it('rejects missing required content', () => {
+    const input = makeMemoryCandidate();
+    delete (input as Record<string, unknown>)['content'];
+    expect(() => MemoryCandidate.parse(input)).toThrow();
+  });
+
+  it('rejects empty content', () => {
+    expect(() => MemoryCandidate.parse(makeMemoryCandidate({ content: '' }))).toThrow();
+  });
+
+  it('rejects empty title', () => {
+    expect(() => MemoryCandidate.parse(makeMemoryCandidate({ title: '' }))).toThrow();
+  });
+
+  it('rejects invalid source', () => {
+    expect(() =>
+      MemoryCandidate.parse(makeMemoryCandidate({ source: 'email' as 'manual' })),
+    ).toThrow();
+  });
+
+  it('rejects invalid category', () => {
+    expect(() =>
+      MemoryCandidate.parse(makeMemoryCandidate({ category: 'other' as 'pattern' })),
+    ).toThrow();
+  });
+
+  it('rejects non-inbox status', () => {
+    expect(() =>
+      MemoryCandidate.parse(makeMemoryCandidate({ status: 'review' as 'inbox' })),
+    ).toThrow();
+  });
+
+  it('rejects invalid UUID for id', () => {
+    expect(() => MemoryCandidate.parse(makeMemoryCandidate({ id: 'not-a-uuid' }))).toThrow();
+  });
+
+  it('accepts all valid sources', () => {
+    for (const source of ['claude_session', 'manual', 'import', 'mcp'] as const) {
+      expect(MemoryCandidate.parse(makeMemoryCandidate({ source })).source).toBe(source);
+    }
+  });
+
+  it('accepts all valid categories', () => {
+    const categories = [
+      'decision',
+      'pattern',
+      'convention',
+      'architecture',
+      'troubleshooting',
+      'onboarding',
+      'reference',
+    ] as const;
+    for (const category of categories) {
+      expect(MemoryCandidate.parse(makeMemoryCandidate({ category })).category).toBe(category);
+    }
+  });
+
+  it('preserves metadata fields', () => {
+    const result = MemoryCandidate.parse(
+      makeMemoryCandidate({
+        metadata: {
+          filePaths: ['src/main.ts'],
+          language: 'typescript',
+          tags: ['api'],
+        },
+      }),
+    );
+    expect(result.metadata.filePaths).toEqual(['src/main.ts']);
+    expect(result.metadata.language).toBe('typescript');
+  });
+});

--- a/packages/schema/src/__tests__/search.test.ts
+++ b/packages/schema/src/__tests__/search.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { Pagination, SearchQuery, SearchHit, SearchResult } from '../search.js';
+import { makeSearchQuery, makeSearchHit, makeSearchResult } from './fixtures.js';
+
+describe('Pagination', () => {
+  it('defaults page to 1 and pageSize to 20', () => {
+    const result = Pagination.parse({});
+    expect(result.page).toBe(1);
+    expect(result.pageSize).toBe(20);
+  });
+
+  it('accepts custom values', () => {
+    const result = Pagination.parse({ page: 3, pageSize: 50 });
+    expect(result.page).toBe(3);
+    expect(result.pageSize).toBe(50);
+  });
+
+  it('rejects page < 1', () => {
+    expect(() => Pagination.parse({ page: 0 })).toThrow();
+  });
+
+  it('rejects pageSize > 100', () => {
+    expect(() => Pagination.parse({ pageSize: 101 })).toThrow();
+  });
+
+  it('rejects pageSize < 1', () => {
+    expect(() => Pagination.parse({ pageSize: 0 })).toThrow();
+  });
+});
+
+describe('SearchQuery', () => {
+  it('parses minimal query with defaults', () => {
+    const result = SearchQuery.parse(makeSearchQuery());
+    expect(result.query).toBe('error handling');
+    expect(result.scope).toBe('curated');
+    expect(result.pagination.page).toBe(1);
+    expect(result.pagination.pageSize).toBe(20);
+  });
+
+  it('defaults scope to curated', () => {
+    const result = SearchQuery.parse({ query: 'test' });
+    expect(result.scope).toBe('curated');
+  });
+
+  it('accepts explicit scope', () => {
+    const result = SearchQuery.parse(makeSearchQuery({ scope: 'all' }));
+    expect(result.scope).toBe('all');
+  });
+
+  it('accepts inbox scope', () => {
+    const result = SearchQuery.parse(makeSearchQuery({ scope: 'inbox' }));
+    expect(result.scope).toBe('inbox');
+  });
+
+  it('accepts archived scope', () => {
+    const result = SearchQuery.parse(makeSearchQuery({ scope: 'archived' }));
+    expect(result.scope).toBe('archived');
+  });
+
+  it('accepts optional filters', () => {
+    const result = SearchQuery.parse(
+      makeSearchQuery({
+        tenantId: 'team-alpha',
+        categories: ['decision', 'pattern'],
+        dateFrom: '2025-01-01T00:00:00Z',
+        dateTo: '2026-01-01T00:00:00Z',
+      }),
+    );
+    expect(result.tenantId).toBe('team-alpha');
+    expect(result.categories).toEqual(['decision', 'pattern']);
+  });
+
+  it('rejects empty query', () => {
+    expect(() => SearchQuery.parse({ query: '' })).toThrow();
+  });
+
+  it('rejects whitespace-only query', () => {
+    expect(() => SearchQuery.parse({ query: '   ' })).toThrow();
+  });
+
+  it('rejects invalid scope', () => {
+    expect(() => SearchQuery.parse(makeSearchQuery({ scope: 'private' as 'all' }))).toThrow();
+  });
+
+  it('rejects invalid category in categories array', () => {
+    expect(() =>
+      SearchQuery.parse(makeSearchQuery({ categories: ['invalid' as 'pattern'] })),
+    ).toThrow();
+  });
+});
+
+describe('SearchHit', () => {
+  it('parses valid hit', () => {
+    const result = SearchHit.parse(makeSearchHit());
+    expect(result.score).toBe(0.85);
+    expect(result.category).toBe('convention');
+  });
+
+  it('accepts score of 0', () => {
+    const result = SearchHit.parse(makeSearchHit({ score: 0 }));
+    expect(result.score).toBe(0);
+  });
+
+  it('accepts score of 1', () => {
+    const result = SearchHit.parse(makeSearchHit({ score: 1 }));
+    expect(result.score).toBe(1);
+  });
+
+  it('rejects score > 1', () => {
+    expect(() => SearchHit.parse(makeSearchHit({ score: 1.1 }))).toThrow();
+  });
+
+  it('rejects score < 0', () => {
+    expect(() => SearchHit.parse(makeSearchHit({ score: -0.1 }))).toThrow();
+  });
+
+  it('accepts optional highlightedContent', () => {
+    const result = SearchHit.parse(
+      makeSearchHit({ highlightedContent: 'Use <em>Result</em> type' }),
+    );
+    expect(result.highlightedContent).toBe('Use <em>Result</em> type');
+  });
+});
+
+describe('SearchResult', () => {
+  it('parses valid result', () => {
+    const result = SearchResult.parse(makeSearchResult());
+    expect(result.hits).toHaveLength(1);
+    expect(result.totalCount).toBe(1);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('accepts empty hits', () => {
+    const result = SearchResult.parse(makeSearchResult({ hits: [], totalCount: 0 }));
+    expect(result.hits).toHaveLength(0);
+  });
+
+  it('rejects negative totalCount', () => {
+    expect(() => SearchResult.parse(makeSearchResult({ totalCount: -1 }))).toThrow();
+  });
+
+  it('rejects missing query', () => {
+    const input = makeSearchResult();
+    delete (input as Record<string, unknown>)['query'];
+    expect(() => SearchResult.parse(input)).toThrow();
+  });
+});

--- a/packages/schema/src/audit-event.ts
+++ b/packages/schema/src/audit-event.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+import { AuditAction } from './enums.js';
+import { Author, IsoDatetime, NonEmptyString, TenantId, Uuid } from './common.js';
+
+/** An immutable audit trail event recording a memory operation */
+export const AuditEvent = z.object({
+  id: Uuid,
+  action: AuditAction,
+  memoryId: Uuid,
+  tenantId: TenantId,
+  actor: Author,
+  reason: NonEmptyString.optional(),
+  details: z.record(z.unknown()).default({}),
+  timestamp: IsoDatetime,
+});
+export type AuditEvent = z.infer<typeof AuditEvent>;

--- a/packages/schema/src/common.ts
+++ b/packages/schema/src/common.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import { AuthorType, Confidence, Sensitivity } from './enums.js';
+
+/** UUID v4 string */
+export const Uuid = z.string().uuid();
+export type Uuid = z.infer<typeof Uuid>;
+
+/** SHA-256 hex hash (64 lowercase hex characters) */
+export const Sha256Hash = z.string().regex(/^[a-f0-9]{64}$/, 'Must be a valid SHA-256 hex hash');
+export type Sha256Hash = z.infer<typeof Sha256Hash>;
+
+/** ISO 8601 datetime string */
+export const IsoDatetime = z.string().datetime();
+export type IsoDatetime = z.infer<typeof IsoDatetime>;
+
+/** Non-empty trimmed string */
+export const NonEmptyString = z.string().trim().min(1);
+export type NonEmptyString = z.infer<typeof NonEmptyString>;
+
+/** Semantic version string (e.g., 1.2.3) */
+export const SemVer = z.string().regex(/^\d+\.\d+\.\d+$/, 'Must be a valid semver string');
+export type SemVer = z.infer<typeof SemVer>;
+
+/** Tag — lowercase alphanumeric with hyphens */
+export const Tag = z.string().regex(/^[a-z0-9][a-z0-9-]*$/, 'Must be a lowercase tag');
+export type Tag = z.infer<typeof Tag>;
+
+/** Author metadata */
+export const Author = z.object({
+  type: AuthorType,
+  id: NonEmptyString,
+  name: NonEmptyString.optional(),
+});
+export type Author = z.infer<typeof Author>;
+
+/** Tenant identifier — scoped project or team boundary */
+export const TenantId = NonEmptyString;
+export type TenantId = z.infer<typeof TenantId>;
+
+/** Metadata about the content's origin and context */
+export const ContentMetadata = z.object({
+  filePaths: z.array(z.string()).default([]),
+  language: z.string().optional(),
+  projectContext: z.string().optional(),
+  sessionId: z.string().optional(),
+  repoUrl: z.string().optional(),
+  branch: z.string().optional(),
+  confidence: Confidence.optional(),
+  sensitivity: Sensitivity.optional(),
+  tags: z.array(Tag).default([]),
+});
+export type ContentMetadata = z.infer<typeof ContentMetadata>;

--- a/packages/schema/src/common.ts
+++ b/packages/schema/src/common.ts
@@ -17,8 +17,13 @@ export type IsoDatetime = z.infer<typeof IsoDatetime>;
 export const NonEmptyString = z.string().trim().min(1);
 export type NonEmptyString = z.infer<typeof NonEmptyString>;
 
-/** Semantic version string (e.g., 1.2.3) */
-export const SemVer = z.string().regex(/^\d+\.\d+\.\d+$/, 'Must be a valid semver string');
+/** Semantic version string — full SemVer 2.0.0 (e.g., 1.2.3, 1.0.0-alpha.1, 1.0.0+build.123) */
+export const SemVer = z
+  .string()
+  .regex(
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/,
+    'Must be a valid semver string',
+  );
 export type SemVer = z.infer<typeof SemVer>;
 
 /** Tag — lowercase alphanumeric with hyphens */

--- a/packages/schema/src/curated-memory.ts
+++ b/packages/schema/src/curated-memory.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod';
+import {
+  MemoryCategory,
+  MemoryLifecycleState,
+  MemorySource,
+  Sensitivity,
+  TrustLevel,
+} from './enums.js';
+import {
+  Author,
+  ContentMetadata,
+  IsoDatetime,
+  NonEmptyString,
+  Sha256Hash,
+  TenantId,
+  Uuid,
+} from './common.js';
+
+/** Record of a policy evaluation result for this memory */
+export const PolicyEvaluation = z.object({
+  policyId: Uuid,
+  ruleId: NonEmptyString,
+  result: z.enum(['pass', 'fail', 'flag']),
+  reason: z.string().optional(),
+  evaluatedAt: IsoDatetime,
+});
+export type PolicyEvaluation = z.infer<typeof PolicyEvaluation>;
+
+/** Supersession link — points to the memory that replaced this one */
+export const SupersessionLink = z.object({
+  supersededBy: Uuid,
+  reason: NonEmptyString,
+  linkedAt: IsoDatetime,
+});
+export type SupersessionLink = z.infer<typeof SupersessionLink>;
+
+/** A memory that has passed governance and entered the curated lifecycle */
+export const CuratedMemory = z
+  .object({
+    id: Uuid,
+    candidateId: Uuid,
+    source: MemorySource,
+    content: NonEmptyString,
+    title: NonEmptyString,
+    category: MemoryCategory,
+    trustLevel: TrustLevel,
+    sensitivity: Sensitivity.default('internal'),
+    author: Author,
+    tenantId: TenantId,
+    metadata: ContentMetadata.default({}),
+    lifecycle: MemoryLifecycleState,
+    contentHash: Sha256Hash,
+    policyEvaluations: z.array(PolicyEvaluation).default([]),
+    supersession: SupersessionLink.optional(),
+    promotedAt: IsoDatetime,
+    promotedBy: Author,
+    updatedAt: IsoDatetime,
+    version: z.number().int().positive().default(1),
+  })
+  .refine(
+    (data) => {
+      if (data.lifecycle === 'superseded') {
+        return data.supersession !== undefined;
+      }
+      return true;
+    },
+    {
+      message: 'supersession must be defined when lifecycle is "superseded"',
+      path: ['supersession'],
+    },
+  );
+
+export type CuratedMemory = z.infer<typeof CuratedMemory>;
+
+/** Narrowed type: an active curated memory */
+export type ActiveMemory = CuratedMemory & { lifecycle: 'active' };
+
+/** Narrowed type: a superseded curated memory with required supersession link */
+export type SupersededMemory = CuratedMemory & {
+  lifecycle: 'superseded';
+  supersession: z.infer<typeof SupersessionLink>;
+};

--- a/packages/schema/src/enums.ts
+++ b/packages/schema/src/enums.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+
+export const MemorySource = z.enum(['claude_session', 'manual', 'import', 'mcp']);
+export type MemorySource = z.infer<typeof MemorySource>;
+
+export const TrustLevel = z.enum(['high', 'medium', 'low', 'untrusted']);
+export type TrustLevel = z.infer<typeof TrustLevel>;
+
+export const MemoryCategory = z.enum([
+  'decision',
+  'pattern',
+  'convention',
+  'architecture',
+  'troubleshooting',
+  'onboarding',
+  'reference',
+]);
+export type MemoryCategory = z.infer<typeof MemoryCategory>;
+
+export const MemoryLifecycleState = z.enum(['active', 'deprecated', 'superseded', 'archived']);
+export type MemoryLifecycleState = z.infer<typeof MemoryLifecycleState>;
+
+export const CandidateStatus = z.literal('inbox');
+export type CandidateStatus = z.infer<typeof CandidateStatus>;
+
+export const SearchScope = z.enum(['curated', 'all', 'inbox', 'archived']).default('curated');
+export type SearchScope = z.infer<typeof SearchScope>;
+
+export const PolicyRuleType = z.enum([
+  'secret_detection',
+  'dedup_check',
+  'relevance_score',
+  'content_length',
+  'source_trust',
+  'tenant_match',
+]);
+export type PolicyRuleType = z.infer<typeof PolicyRuleType>;
+
+export const PolicyRuleAction = z.enum(['reject', 'flag', 'approve', 'require_review']);
+export type PolicyRuleAction = z.infer<typeof PolicyRuleAction>;
+
+export const AuditAction = z.enum([
+  'promoted',
+  'demoted',
+  'superseded',
+  'archived',
+  'deleted',
+  'searched',
+  'exported',
+]);
+export type AuditAction = z.infer<typeof AuditAction>;
+
+export const Confidence = z.enum(['high', 'medium', 'low']);
+export type Confidence = z.infer<typeof Confidence>;
+
+export const Sensitivity = z.enum(['public', 'internal', 'confidential', 'restricted']);
+export type Sensitivity = z.infer<typeof Sensitivity>;
+
+export const AuthorType = z.enum(['human', 'ai', 'system']);
+export type AuthorType = z.infer<typeof AuthorType>;

--- a/packages/schema/src/governance-policy.ts
+++ b/packages/schema/src/governance-policy.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { PolicyRuleAction, PolicyRuleType } from './enums.js';
+import { IsoDatetime, NonEmptyString, TenantId, Uuid } from './common.js';
+
+/** A single governance rule within a policy */
+export const PolicyRule = z.object({
+  id: NonEmptyString,
+  type: PolicyRuleType,
+  action: PolicyRuleAction,
+  enabled: z.boolean().default(true),
+  priority: z.number().int().min(0).default(0),
+  parameters: z.record(z.unknown()).default({}),
+  description: z.string().optional(),
+});
+export type PolicyRule = z.infer<typeof PolicyRule>;
+
+/** A governance policy containing ordered rules */
+export const GovernancePolicy = z.object({
+  id: Uuid,
+  name: NonEmptyString,
+  tenantId: TenantId,
+  rules: z.array(PolicyRule).min(1),
+  enabled: z.boolean().default(true),
+  version: z.number().int().positive().default(1),
+  createdAt: IsoDatetime,
+  updatedAt: IsoDatetime,
+});
+export type GovernancePolicy = z.infer<typeof GovernancePolicy>;

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,3 +1,46 @@
-// TODO: Zod schemas for MemoryCandidate, CuratedMemory, GovernancePolicy, SearchQuery, etc. (Phase 1)
+// Enums
+export {
+  MemorySource,
+  TrustLevel,
+  MemoryCategory,
+  MemoryLifecycleState,
+  CandidateStatus,
+  SearchScope,
+  PolicyRuleType,
+  PolicyRuleAction,
+  AuditAction,
+  Confidence,
+  Sensitivity,
+  AuthorType,
+} from './enums.js';
 
-export const name = '@qmd-team-intent-kb/schema';
+// Common primitives
+export {
+  Uuid,
+  Sha256Hash,
+  IsoDatetime,
+  NonEmptyString,
+  SemVer,
+  Tag,
+  Author,
+  TenantId,
+  ContentMetadata,
+} from './common.js';
+
+// Domain schemas
+export { PrePolicyFlags, MemoryCandidate } from './memory-candidate.js';
+export { PolicyEvaluation, SupersessionLink, CuratedMemory } from './curated-memory.js';
+export type { ActiveMemory, SupersededMemory } from './curated-memory.js';
+export { PolicyRule, GovernancePolicy } from './governance-policy.js';
+export { Pagination, SearchQuery, SearchHit, SearchResult } from './search.js';
+export { AuditEvent } from './audit-event.js';
+
+// Lifecycle
+export {
+  TransitionRequest,
+  ALLOWED_TRANSITIONS,
+  isTransitionAllowed,
+  validateTransition,
+  getAllowedTransitionsFrom,
+} from './lifecycle.js';
+export type { TransitionValidationResult } from './lifecycle.js';

--- a/packages/schema/src/lifecycle.ts
+++ b/packages/schema/src/lifecycle.ts
@@ -1,0 +1,55 @@
+import type { MemoryLifecycleState } from './enums.js';
+import { Author, NonEmptyString, Uuid } from './common.js';
+import { z } from 'zod';
+
+/** Metadata required for a lifecycle transition */
+export const TransitionRequest = z.object({
+  reason: NonEmptyString,
+  actor: Author,
+  supersededBy: Uuid.optional(),
+});
+export type TransitionRequest = z.infer<typeof TransitionRequest>;
+
+/** All allowed transitions from each state */
+export const ALLOWED_TRANSITIONS: Record<MemoryLifecycleState, MemoryLifecycleState[]> = {
+  active: ['deprecated', 'superseded', 'archived'],
+  deprecated: ['active', 'archived'],
+  superseded: ['archived'],
+  archived: [],
+};
+
+/** Check if a transition between two states is allowed */
+export function isTransitionAllowed(from: MemoryLifecycleState, to: MemoryLifecycleState): boolean {
+  return ALLOWED_TRANSITIONS[from].includes(to);
+}
+
+/** Result of a transition validation */
+export type TransitionValidationResult = { valid: true } | { valid: false; error: string };
+
+/** Validate a lifecycle transition with full context */
+export function validateTransition(
+  from: MemoryLifecycleState,
+  to: MemoryLifecycleState,
+  request: TransitionRequest,
+): TransitionValidationResult {
+  if (!isTransitionAllowed(from, to)) {
+    return {
+      valid: false,
+      error: `Transition from "${from}" to "${to}" is not allowed`,
+    };
+  }
+
+  if (to === 'superseded' && !request.supersededBy) {
+    return {
+      valid: false,
+      error: 'Transition to "superseded" requires supersededBy UUID',
+    };
+  }
+
+  return { valid: true };
+}
+
+/** Get all states that can be transitioned to from the given state */
+export function getAllowedTransitionsFrom(state: MemoryLifecycleState): MemoryLifecycleState[] {
+  return [...ALLOWED_TRANSITIONS[state]];
+}

--- a/packages/schema/src/memory-candidate.ts
+++ b/packages/schema/src/memory-candidate.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { CandidateStatus, MemoryCategory, MemorySource, TrustLevel } from './enums.js';
+import { Author, ContentMetadata, IsoDatetime, NonEmptyString, TenantId, Uuid } from './common.js';
+
+/** Pre-policy flags raised during capture */
+export const PrePolicyFlags = z.object({
+  potentialSecret: z.boolean().default(false),
+  lowConfidence: z.boolean().default(false),
+  duplicateSuspect: z.boolean().default(false),
+});
+export type PrePolicyFlags = z.infer<typeof PrePolicyFlags>;
+
+/** A raw memory proposal captured from a Claude Code session, before governance */
+export const MemoryCandidate = z.object({
+  id: Uuid,
+  status: CandidateStatus,
+  source: MemorySource,
+  content: NonEmptyString,
+  title: NonEmptyString,
+  category: MemoryCategory,
+  trustLevel: TrustLevel.default('medium'),
+  author: Author,
+  tenantId: TenantId,
+  metadata: ContentMetadata.default({}),
+  prePolicyFlags: PrePolicyFlags.default({}),
+  capturedAt: IsoDatetime,
+});
+export type MemoryCandidate = z.infer<typeof MemoryCandidate>;

--- a/packages/schema/src/search.ts
+++ b/packages/schema/src/search.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import { MemoryCategory, SearchScope } from './enums.js';
+import { IsoDatetime, NonEmptyString, TenantId, Uuid } from './common.js';
+
+/** Pagination parameters */
+export const Pagination = z.object({
+  page: z.number().int().min(1).default(1),
+  pageSize: z.number().int().min(1).max(100).default(20),
+});
+export type Pagination = z.infer<typeof Pagination>;
+
+/** A structured search request */
+export const SearchQuery = z.object({
+  query: NonEmptyString,
+  scope: SearchScope,
+  tenantId: TenantId.optional(),
+  categories: z.array(MemoryCategory).optional(),
+  dateFrom: IsoDatetime.optional(),
+  dateTo: IsoDatetime.optional(),
+  pagination: Pagination.default({}),
+});
+export type SearchQuery = z.infer<typeof SearchQuery>;
+
+/** A single search result hit */
+export const SearchHit = z.object({
+  memoryId: Uuid,
+  title: NonEmptyString,
+  snippet: z.string(),
+  score: z.number().min(0).max(1),
+  category: MemoryCategory,
+  highlightedContent: z.string().optional(),
+  matchedAt: IsoDatetime,
+});
+export type SearchHit = z.infer<typeof SearchHit>;
+
+/** Search response with results and pagination metadata */
+export const SearchResult = z.object({
+  hits: z.array(SearchHit),
+  totalCount: z.number().int().min(0),
+  query: NonEmptyString,
+  scope: SearchScope,
+  page: z.number().int().min(1),
+  pageSize: z.number().int().min(1),
+  hasMore: z.boolean(),
+});
+export type SearchResult = z.infer<typeof SearchResult>;


### PR DESCRIPTION
## Summary

- Implements complete domain model in `packages/schema` with Zod v3 schemas and derived TypeScript types
- 12 enum definitions, shared primitive types, and 6 domain schemas (MemoryCandidate, CuratedMemory, GovernancePolicy, SearchQuery/Result, AuditEvent)
- Lifecycle state machine with transition validation: active → deprecated/superseded/archived, deprecated → active/archived, superseded → archived, archived (terminal)
- CuratedMemory refinement enforces supersession link when lifecycle is superseded
- SearchScope defaults to curated-only at the schema level
- 225 tests across 8 test files, all passing

## What's Implemented vs Scaffolded

**Implemented (this PR):** `packages/schema` — all source modules, barrel export, test fixtures, comprehensive tests

**Still scaffolded:** All other packages and apps remain TODO placeholders

## Test plan

- [x] `pnpm validate` passes (format, lint, typecheck, test)
- [x] 225 tests covering valid/invalid inputs, defaults, enum validation, lifecycle transitions
- [x] CuratedMemory supersession refinement tested
- [x] Lifecycle state machine: all allowed/disallowed transitions tested
- [x] SearchScope curated default tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)