### PR TITLE
feat: Phase 3 — qmd adapter with curated-only search and index isolation

### DIFF
--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -40,6 +40,7 @@
 - `012-AA-AACR-initial-aar.md` — Phase 0 after action review
 - `013-AA-AACR-phase1-schema.md` — Phase 1 core schema after action review
 - `014-AA-AACR-phase2-runtime.md` — Phase 2 claude runtime after action review
+- `015-AA-AACR-phase3-adapter.md` — Phase 3 qmd adapter after action review
 
 ## Chronological Listing
 
@@ -60,5 +61,6 @@
 | 012 | AA-AACR | initial-aar                | Phase 0 AAR                 |
 | 013 | AA-AACR | phase1-schema              | Phase 1 AAR                 |
 | 014 | AA-AACR | phase2-runtime             | Phase 2 AAR                 |
+| 015 | AA-AACR | phase3-adapter             | Phase 3 AAR                 |
 
-## Next Available Sequence: 015
+## Next Available Sequence: 016

--- a/000-docs/004-PP-RMAP-phase-plan.md
+++ b/000-docs/004-PP-RMAP-phase-plan.md
@@ -75,7 +75,7 @@ The project is implemented in sequential phases, each building on the previous. 
 
 ## Phase 3 — qmd Adapter and Local Edge Index
 
-**Status**: NOT STARTED
+**Status**: COMPLETE
 
 **Scope**: Wrap qmd CLI for programmatic TypeScript access. Establish the search interface with curated-only default semantics.
 

--- a/000-docs/015-AA-AACR-phase3-adapter.md
+++ b/000-docs/015-AA-AACR-phase3-adapter.md
@@ -1,0 +1,46 @@
+# After Action Review — Phase 3: qmd Adapter
+
+## Summary
+
+Implemented the qmd integration layer as the local retrieval/index edge foundation. Curated-only default search enforced at the adapter level.
+
+## What Was Delivered
+
+- **Types**: QmdError, CommandResult, QmdHealthStatus, QmdSearchResult
+- **Config**: Dedicated index paths (~/.teamkb/qmd-index/{tenantId}/{collection}/)
+- **QmdExecutor interface**: Strategy pattern with RealQmdExecutor and MockQmdExecutor
+- **CollectionRegistry**: 5 known collections with default search inclusion flags
+  - kb-curated (default search: yes)
+  - kb-decisions (default search: yes)
+  - kb-guides (default search: yes)
+  - kb-inbox (default search: no)
+  - kb-archive (default search: no)
+- **CollectionManager**: Add, remove, list, ensure collections via qmd CLI
+- **SearchClient**: Query with curated-only default scope enforcement via post-filtering
+- **IndexLifecycleManager**: Update, embed, cleanup, status via qmd CLI
+- **QmdAdapter facade**: Composes all managers, delegates operations
+- **Health check**: Never throws, returns structured QmdHealthStatus
+
+## Test Coverage
+
+- 367 total tests (303 from Phases 1-2 + 64 new)
+- Real integration tests with actual qmd CLI (version, availability)
+- Unit tests using MockQmdExecutor for deterministic behavior
+- Curated-only default scope enforcement tested across all scope options
+
+## Key Design Decisions
+
+1. QmdExecutor interface for strategy pattern — real CLI + test double
+2. qmd IS installed locally — real integration tests run by default
+3. Result<T, QmdError> return type on all adapter methods (never throws)
+4. Curated-only enforced at adapter level (defense in depth)
+5. Dedicated index path isolated from personal qmd usage
+6. Health check always returns structured status, never throws
+7. Post-query collection filtering for scope enforcement
+
+## What Is NOT Implemented
+
+- No actual qmd index population (no data indexed yet)
+- No persistence layer (Phase 5)
+- No edge daemon sync (Phase 8)
+- No authentication/authorization (Phase 5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- qmd adapter with curated-only default search, 5 collection types, and index isolation per tenant
+- Real qmd CLI integration with RealQmdExecutor and health check
 - Claude runtime capture layer with local JSONL spool, secret detection (11 patterns), and content redaction
 - Shared utilities: Result<T, E> type, SHA-256 content hashing, TeamKB path resolution
 - Shell hook templates and CLAUDE.md guidance block generators

--- a/packages/qmd-adapter/package.json
+++ b/packages/qmd-adapter/package.json
@@ -17,5 +17,9 @@
     "test": "vitest run",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@qmd-team-intent-kb/schema": "workspace:*",
+    "@qmd-team-intent-kb/common": "workspace:*"
   }
 }

--- a/packages/qmd-adapter/src/__tests__/adapter.test.ts
+++ b/packages/qmd-adapter/src/__tests__/adapter.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MockQmdExecutor } from '../executor/mock-executor.js';
+import { QmdAdapter } from '../adapter.js';
+
+describe('QmdAdapter', () => {
+  let mock: MockQmdExecutor;
+  let adapter: QmdAdapter;
+
+  beforeEach(() => {
+    mock = new MockQmdExecutor();
+    adapter = new QmdAdapter({ tenantId: 'test-tenant' }, mock);
+  });
+
+  it('delegates query to search client', async () => {
+    mock.queueSuccess('0.9\t/kb-curated/doc.md\tResult snippet');
+    const result = await adapter.query('test query');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1);
+    }
+  });
+
+  it('delegates health to checkHealth', async () => {
+    mock.queueSuccess('qmd 2.0.1');
+    mock.queueSuccess('kb-curated');
+    const status = await adapter.health();
+    expect(status.available).toBe(true);
+  });
+
+  it('delegates update to index lifecycle', async () => {
+    mock.queueSuccess('Updated');
+    const result = await adapter.update();
+    expect(result.ok).toBe(true);
+  });
+
+  it('delegates ensureCollections to collection manager', async () => {
+    mock.queueSuccess(''); // list
+    for (let i = 0; i < 5; i++) mock.queueSuccess(''); // adds
+    const result = await adapter.ensureCollections();
+    expect(result.ok).toBe(true);
+  });
+
+  it('enforces curated-only default on query', async () => {
+    mock.queueSuccess('0.9\t/kb-curated/a.md\tA\n0.8\t/kb-inbox/b.md\tB');
+    const result = await adapter.query('test');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Should not include inbox results
+      expect(result.value.some((r) => r.collection === 'kb-inbox')).toBe(false);
+    }
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/collection-manager.test.ts
+++ b/packages/qmd-adapter/src/__tests__/collection-manager.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MockQmdExecutor } from '../executor/mock-executor.js';
+import { CollectionManager } from '../collections/collection-manager.js';
+
+describe('CollectionManager', () => {
+  let mock: MockQmdExecutor;
+  let manager: CollectionManager;
+
+  beforeEach(() => {
+    mock = new MockQmdExecutor();
+    manager = new CollectionManager(mock, '/tmp/test-data');
+  });
+
+  describe('addCollection', () => {
+    it('adds a collection successfully', async () => {
+      mock.queueSuccess('');
+      const result = await manager.addCollection('kb-curated', '/path/to/docs');
+      expect(result.ok).toBe(true);
+      expect(mock.lastCommand).toEqual([
+        'collection',
+        'add',
+        '/path/to/docs',
+        '--name',
+        'kb-curated',
+      ]);
+    });
+
+    it('returns error on failure', async () => {
+      mock.queueFailure('already exists');
+      const result = await manager.addCollection('kb-curated', '/path');
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('command_failed');
+      }
+    });
+  });
+
+  describe('removeCollection', () => {
+    it('removes a collection', async () => {
+      mock.queueSuccess('');
+      const result = await manager.removeCollection('kb-inbox');
+      expect(result.ok).toBe(true);
+      expect(mock.lastCommand).toEqual(['collection', 'remove', 'kb-inbox']);
+    });
+  });
+
+  describe('listCollections', () => {
+    it('lists collections', async () => {
+      mock.queueSuccess('kb-curated\nkb-guides\nkb-inbox');
+      const result = await manager.listCollections();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toEqual(['kb-curated', 'kb-guides', 'kb-inbox']);
+      }
+    });
+
+    it('handles empty list', async () => {
+      mock.queueSuccess('');
+      const result = await manager.listCollections();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toEqual([]);
+      }
+    });
+  });
+
+  describe('ensureCollections', () => {
+    it('creates missing collections', async () => {
+      // listCollections returns empty
+      mock.queueSuccess('');
+      // 5 addCollection calls
+      for (let i = 0; i < 5; i++) {
+        mock.queueSuccess('');
+      }
+      const result = await manager.ensureCollections('/base/path');
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toHaveLength(5);
+      }
+    });
+
+    it('skips existing collections', async () => {
+      // listCollections returns all 5
+      mock.queueSuccess('kb-curated\nkb-decisions\nkb-guides\nkb-inbox\nkb-archive');
+      const result = await manager.ensureCollections('/base/path');
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toHaveLength(0);
+      }
+    });
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/collection-registry.test.ts
+++ b/packages/qmd-adapter/src/__tests__/collection-registry.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  KNOWN_COLLECTIONS,
+  getDefaultSearchCollections,
+  getAllCollectionNames,
+  isKnownCollection,
+  isDefaultSearchCollection,
+} from '../collections/collection-registry.js';
+
+describe('KNOWN_COLLECTIONS', () => {
+  it('has 5 collections', () => {
+    expect(KNOWN_COLLECTIONS).toHaveLength(5);
+  });
+
+  it('all have required fields', () => {
+    for (const c of KNOWN_COLLECTIONS) {
+      expect(c.name).toBeTruthy();
+      expect(c.description).toBeTruthy();
+      expect(typeof c.includeInDefaultSearch).toBe('boolean');
+    }
+  });
+});
+
+describe('getDefaultSearchCollections', () => {
+  it('includes kb-curated, kb-decisions, kb-guides', () => {
+    const defaults = getDefaultSearchCollections();
+    expect(defaults).toContain('kb-curated');
+    expect(defaults).toContain('kb-decisions');
+    expect(defaults).toContain('kb-guides');
+  });
+
+  it('excludes kb-inbox and kb-archive', () => {
+    const defaults = getDefaultSearchCollections();
+    expect(defaults).not.toContain('kb-inbox');
+    expect(defaults).not.toContain('kb-archive');
+  });
+
+  it('returns 3 collections', () => {
+    expect(getDefaultSearchCollections()).toHaveLength(3);
+  });
+});
+
+describe('getAllCollectionNames', () => {
+  it('returns all 5 names', () => {
+    const names = getAllCollectionNames();
+    expect(names).toHaveLength(5);
+    expect(names).toContain('kb-inbox');
+    expect(names).toContain('kb-archive');
+  });
+});
+
+describe('isKnownCollection', () => {
+  it('returns true for known collections', () => {
+    expect(isKnownCollection('kb-curated')).toBe(true);
+    expect(isKnownCollection('kb-inbox')).toBe(true);
+  });
+
+  it('returns false for unknown collections', () => {
+    expect(isKnownCollection('kb-unknown')).toBe(false);
+    expect(isKnownCollection('')).toBe(false);
+  });
+});
+
+describe('isDefaultSearchCollection', () => {
+  it('returns true for default search collections', () => {
+    expect(isDefaultSearchCollection('kb-curated')).toBe(true);
+    expect(isDefaultSearchCollection('kb-guides')).toBe(true);
+  });
+
+  it('returns false for non-default collections', () => {
+    expect(isDefaultSearchCollection('kb-inbox')).toBe(false);
+    expect(isDefaultSearchCollection('kb-archive')).toBe(false);
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/config.test.ts
+++ b/packages/qmd-adapter/src/__tests__/config.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import {
+  QMD_INDEX_DIR,
+  getQmdIndexBasePath,
+  getQmdTenantIndexPath,
+  getQmdCollectionIndexPath,
+} from '../config.js';
+
+describe('qmd-adapter config', () => {
+  const originalEnv = process.env['TEAMKB_BASE_PATH'];
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env['TEAMKB_BASE_PATH'];
+    } else {
+      process.env['TEAMKB_BASE_PATH'] = originalEnv;
+    }
+  });
+
+  it('exports QMD_INDEX_DIR', () => {
+    expect(QMD_INDEX_DIR).toBe('qmd-index');
+  });
+
+  it('getQmdIndexBasePath uses default base', () => {
+    delete process.env['TEAMKB_BASE_PATH'];
+    expect(getQmdIndexBasePath()).toBe(join(homedir(), '.teamkb', 'qmd-index'));
+  });
+
+  it('getQmdTenantIndexPath includes tenant', () => {
+    delete process.env['TEAMKB_BASE_PATH'];
+    expect(getQmdTenantIndexPath('my-team')).toBe(
+      join(homedir(), '.teamkb', 'qmd-index', 'my-team'),
+    );
+  });
+
+  it('getQmdCollectionIndexPath includes tenant and collection', () => {
+    delete process.env['TEAMKB_BASE_PATH'];
+    expect(getQmdCollectionIndexPath('my-team', 'kb-curated')).toBe(
+      join(homedir(), '.teamkb', 'qmd-index', 'my-team', 'kb-curated'),
+    );
+  });
+
+  it('respects TEAMKB_BASE_PATH override', () => {
+    process.env['TEAMKB_BASE_PATH'] = '/custom';
+    expect(getQmdTenantIndexPath('t1')).toBe('/custom/qmd-index/t1');
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/health-check.test.ts
+++ b/packages/qmd-adapter/src/__tests__/health-check.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MockQmdExecutor } from '../executor/mock-executor.js';
+import { checkHealth } from '../health/health-check.js';
+
+describe('checkHealth', () => {
+  let mock: MockQmdExecutor;
+
+  beforeEach(() => {
+    mock = new MockQmdExecutor();
+  });
+
+  it('reports not available when qmd is missing', async () => {
+    mock.setAvailable(false);
+    const status = await checkHealth(mock);
+    expect(status.available).toBe(false);
+    expect(status.version).toBeNull();
+    expect(status.initialized).toBe(false);
+    expect(status.collections).toEqual([]);
+  });
+
+  it('reports available and initialized with collections', async () => {
+    mock.queueSuccess('qmd 2.0.1'); // --version
+    mock.queueSuccess('kb-curated\nkb-guides'); // collection list
+    const status = await checkHealth(mock);
+    expect(status.available).toBe(true);
+    expect(status.version).toBe('qmd 2.0.1');
+    expect(status.initialized).toBe(true);
+    expect(status.collections).toEqual(['kb-curated', 'kb-guides']);
+  });
+
+  it('reports available but not initialized (no collections)', async () => {
+    mock.queueSuccess('qmd 2.0.1'); // --version
+    mock.queueSuccess(''); // collection list (empty)
+    const status = await checkHealth(mock);
+    expect(status.available).toBe(true);
+    expect(status.initialized).toBe(false);
+    expect(status.collections).toEqual([]);
+  });
+
+  it('never throws', async () => {
+    // Even with weird state, should not throw
+    mock.setAvailable(true);
+    // No responses queued — both --version and collection list will "fail"
+    const status = await checkHealth(mock);
+    expect(status.available).toBe(true);
+    // version and collections may be null/empty but no throw
+    expect(typeof status.initialized).toBe('boolean');
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/index-lifecycle.test.ts
+++ b/packages/qmd-adapter/src/__tests__/index-lifecycle.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MockQmdExecutor } from '../executor/mock-executor.js';
+import { IndexLifecycleManager } from '../index-manager/index-lifecycle.js';
+
+describe('IndexLifecycleManager', () => {
+  let mock: MockQmdExecutor;
+  let manager: IndexLifecycleManager;
+
+  beforeEach(() => {
+    mock = new MockQmdExecutor();
+    manager = new IndexLifecycleManager(mock);
+  });
+
+  describe('update', () => {
+    it('runs qmd update', async () => {
+      mock.queueSuccess('Updated 5 files');
+      const result = await manager.update();
+      expect(result.ok).toBe(true);
+      expect(mock.lastCommand).toEqual(['update']);
+    });
+
+    it('returns error on failure', async () => {
+      mock.queueFailure('No collections found');
+      const result = await manager.update();
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('embed', () => {
+    it('runs qmd embed', async () => {
+      mock.queueSuccess('Embedded 10 documents');
+      const result = await manager.embed();
+      expect(result.ok).toBe(true);
+      expect(mock.lastCommand).toEqual(['embed']);
+    });
+
+    it('runs qmd embed -f when forced', async () => {
+      mock.queueSuccess('');
+      const result = await manager.embed(true);
+      expect(result.ok).toBe(true);
+      expect(mock.lastCommand).toEqual(['embed', '-f']);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('runs qmd cleanup', async () => {
+      mock.queueSuccess('Cleaned up');
+      const result = await manager.cleanup();
+      expect(result.ok).toBe(true);
+      expect(mock.lastCommand).toEqual(['cleanup']);
+    });
+  });
+
+  describe('status', () => {
+    it('returns status output', async () => {
+      mock.queueSuccess('Index: 42 documents, 3 collections');
+      const result = await manager.status();
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toContain('42 documents');
+      }
+    });
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/index-paths.test.ts
+++ b/packages/qmd-adapter/src/__tests__/index-paths.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { getTenantDataDir, getCollectionDataDir } from '../index-manager/index-paths.js';
+
+describe('index-paths', () => {
+  const originalEnv = process.env['TEAMKB_BASE_PATH'];
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env['TEAMKB_BASE_PATH'];
+    } else {
+      process.env['TEAMKB_BASE_PATH'] = originalEnv;
+    }
+  });
+
+  it('getTenantDataDir returns tenant-scoped path', () => {
+    process.env['TEAMKB_BASE_PATH'] = '/test';
+    expect(getTenantDataDir('my-tenant')).toBe('/test/qmd-index/my-tenant');
+  });
+
+  it('getCollectionDataDir returns collection-scoped path', () => {
+    process.env['TEAMKB_BASE_PATH'] = '/test';
+    expect(getCollectionDataDir('my-tenant', 'kb-curated')).toBe(
+      '/test/qmd-index/my-tenant/kb-curated',
+    );
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/mock-executor.test.ts
+++ b/packages/qmd-adapter/src/__tests__/mock-executor.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MockQmdExecutor } from '../executor/mock-executor.js';
+
+describe('MockQmdExecutor', () => {
+  let mock: MockQmdExecutor;
+
+  beforeEach(() => {
+    mock = new MockQmdExecutor();
+  });
+
+  it('records executed commands', async () => {
+    mock.queueSuccess('ok');
+    await mock.execute(['search', 'test']);
+    expect(mock.commands).toHaveLength(1);
+    expect(mock.commands[0]).toEqual(['search', 'test']);
+  });
+
+  it('returns queued responses in order', async () => {
+    mock.queueSuccess('first');
+    mock.queueSuccess('second');
+
+    const r1 = await mock.execute(['cmd1']);
+    const r2 = await mock.execute(['cmd2']);
+    expect(r1.stdout).toBe('first');
+    expect(r2.stdout).toBe('second');
+  });
+
+  it('returns failure when no response queued', async () => {
+    const result = await mock.execute(['anything']);
+    expect(result.exitCode).toBe(1);
+  });
+
+  it('queueFailure sets stderr and exitCode', async () => {
+    mock.queueFailure('bad command', 2);
+    const result = await mock.execute(['bad']);
+    expect(result.stderr).toBe('bad command');
+    expect(result.exitCode).toBe(2);
+  });
+
+  it('isAvailable reflects setAvailable', async () => {
+    expect(await mock.isAvailable()).toBe(true);
+    mock.setAvailable(false);
+    expect(await mock.isAvailable()).toBe(false);
+  });
+
+  it('lastCommand returns most recent command', async () => {
+    mock.queueSuccess('a');
+    mock.queueSuccess('b');
+    await mock.execute(['first']);
+    await mock.execute(['second', 'arg']);
+    expect(mock.lastCommand).toEqual(['second', 'arg']);
+  });
+
+  it('reset clears all state', async () => {
+    mock.queueSuccess('ok');
+    await mock.execute(['test']);
+    mock.setAvailable(false);
+    mock.reset();
+
+    expect(mock.commands).toHaveLength(0);
+    expect(await mock.isAvailable()).toBe(true);
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/real-executor.test.ts
+++ b/packages/qmd-adapter/src/__tests__/real-executor.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { RealQmdExecutor } from '../executor/real-executor.js';
+
+describe('RealQmdExecutor', () => {
+  const executor = new RealQmdExecutor();
+
+  it('detects qmd availability', async () => {
+    const available = await executor.isAvailable();
+    expect(available).toBe(true);
+  });
+
+  it('gets qmd version', async () => {
+    const result = await executor.execute(['--version']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('qmd');
+  });
+
+  it('handles invalid commands gracefully', async () => {
+    const result = await executor.execute(['invalid-command-that-does-not-exist']);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('respects dataDir option', () => {
+    const exec = new RealQmdExecutor({ dataDir: '/tmp/test-qmd' });
+    // Just verify it constructs without error
+    expect(exec).toBeDefined();
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/result-parser.test.ts
+++ b/packages/qmd-adapter/src/__tests__/result-parser.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { parseQueryOutput, deriveCollectionFromPath } from '../search/result-parser.js';
+
+describe('parseQueryOutput', () => {
+  it('parses tab-separated output', () => {
+    const output = '0.95\t/data/kb-curated/doc.md\tSome relevant snippet';
+    const results = parseQueryOutput(output);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.score).toBe(0.95);
+    expect(results[0]!.file).toBe('/data/kb-curated/doc.md');
+    expect(results[0]!.snippet).toBe('Some relevant snippet');
+    expect(results[0]!.collection).toBe('kb-curated');
+  });
+
+  it('parses multiple lines', () => {
+    const output = '0.9\t/kb-curated/a.md\tA\n0.8\t/kb-guides/b.md\tB\n0.7\t/kb-inbox/c.md\tC';
+    const results = parseQueryOutput(output);
+    expect(results).toHaveLength(3);
+  });
+
+  it('handles empty output', () => {
+    expect(parseQueryOutput('')).toHaveLength(0);
+    expect(parseQueryOutput('\n')).toHaveLength(0);
+  });
+
+  it('handles non-numeric scores', () => {
+    const output = 'NaN\t/kb-curated/doc.md\tSnippet';
+    const results = parseQueryOutput(output);
+    expect(results[0]!.score).toBe(0);
+  });
+});
+
+describe('deriveCollectionFromPath', () => {
+  it('derives kb-curated', () => {
+    expect(deriveCollectionFromPath('/data/kb-curated/doc.md')).toBe('kb-curated');
+  });
+
+  it('derives kb-inbox', () => {
+    expect(deriveCollectionFromPath('/data/kb-inbox/doc.md')).toBe('kb-inbox');
+  });
+
+  it('returns unknown for unrecognized paths', () => {
+    expect(deriveCollectionFromPath('/data/random/doc.md')).toBe('unknown');
+  });
+});

--- a/packages/qmd-adapter/src/__tests__/search-client.test.ts
+++ b/packages/qmd-adapter/src/__tests__/search-client.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MockQmdExecutor } from '../executor/mock-executor.js';
+import { SearchClient } from '../search/search-client.js';
+
+describe('SearchClient', () => {
+  let mock: MockQmdExecutor;
+  let client: SearchClient;
+
+  beforeEach(() => {
+    mock = new MockQmdExecutor();
+    client = new SearchClient(mock);
+  });
+
+  it('executes a search and returns results', async () => {
+    mock.queueSuccess('0.95\t/path/kb-curated/doc.md\tSome snippet');
+    const result = await client.search('test query');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]!.score).toBe(0.95);
+      expect(result.value[0]!.collection).toBe('kb-curated');
+    }
+  });
+
+  it('defaults scope to curated', async () => {
+    // Return results from mixed collections
+    mock.queueSuccess('0.9\t/kb-curated/a.md\tA\n0.8\t/kb-inbox/b.md\tB\n0.7\t/kb-guides/c.md\tC');
+    const result = await client.search('test');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // Should filter out kb-inbox
+      const collections = result.value.map((r) => r.collection);
+      expect(collections).not.toContain('kb-inbox');
+      expect(collections).toContain('kb-curated');
+      expect(collections).toContain('kb-guides');
+    }
+  });
+
+  it('scope "all" returns everything', async () => {
+    mock.queueSuccess('0.9\t/kb-curated/a.md\tA\n0.8\t/kb-inbox/b.md\tB\n0.7\t/kb-archive/c.md\tC');
+    const result = await client.search('test', 'all');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(3);
+    }
+  });
+
+  it('scope "inbox" only returns inbox results', async () => {
+    mock.queueSuccess('0.9\t/kb-curated/a.md\tA\n0.8\t/kb-inbox/b.md\tB');
+    const result = await client.search('test', 'inbox');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]!.collection).toBe('kb-inbox');
+    }
+  });
+
+  it('scope "archived" only returns archive results', async () => {
+    mock.queueSuccess('0.9\t/kb-curated/a.md\tA\n0.8\t/kb-archive/b.md\tB');
+    const result = await client.search('test', 'archived');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]!.collection).toBe('kb-archive');
+    }
+  });
+
+  it('returns error on command failure', async () => {
+    mock.queueFailure('search error', 1);
+    const result = await client.search('test');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('command_failed');
+    }
+  });
+
+  it('handles empty search results', async () => {
+    mock.queueSuccess('');
+    const result = await client.search('nonexistent');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(0);
+    }
+  });
+});

--- a/packages/qmd-adapter/src/adapter.ts
+++ b/packages/qmd-adapter/src/adapter.ts
@@ -1,0 +1,57 @@
+import type { Result } from '@qmd-team-intent-kb/common';
+import type { SearchScope } from '@qmd-team-intent-kb/schema';
+import type { QmdError, QmdHealthStatus, QmdSearchResult } from './types.js';
+import type { QmdExecutor } from './executor/executor.js';
+import type { QmdAdapterConfig } from './config.js';
+import { RealQmdExecutor } from './executor/real-executor.js';
+import { CollectionManager } from './collections/collection-manager.js';
+import { SearchClient } from './search/search-client.js';
+import { IndexLifecycleManager } from './index-manager/index-lifecycle.js';
+import { checkHealth } from './health/health-check.js';
+import { getQmdTenantIndexPath } from './config.js';
+
+/** Facade class composing all qmd adapter managers */
+export class QmdAdapter {
+  readonly executor: QmdExecutor;
+  readonly collections: CollectionManager;
+  readonly search: SearchClient;
+  readonly indexLifecycle: IndexLifecycleManager;
+  private readonly dataPath: string;
+
+  constructor(config: QmdAdapterConfig, executor?: QmdExecutor) {
+    this.dataPath = getQmdTenantIndexPath(config.tenantId);
+    this.executor =
+      executor ??
+      new RealQmdExecutor({
+        binary: config.qmdBinary,
+        timeout: config.timeout,
+        dataDir: this.dataPath,
+      });
+    this.collections = new CollectionManager(this.executor, this.dataPath);
+    this.search = new SearchClient(this.executor);
+    this.indexLifecycle = new IndexLifecycleManager(this.executor);
+  }
+
+  /** Run a search with curated-only default scope */
+  async query(
+    queryText: string,
+    scope?: SearchScope,
+  ): Promise<Result<QmdSearchResult[], QmdError>> {
+    return this.search.search(queryText, scope);
+  }
+
+  /** Check health of qmd and index state */
+  async health(): Promise<QmdHealthStatus> {
+    return checkHealth(this.executor);
+  }
+
+  /** Update the index */
+  async update(): Promise<Result<void, QmdError>> {
+    return this.indexLifecycle.update();
+  }
+
+  /** Ensure all known collections are set up */
+  async ensureCollections(): Promise<Result<string[], QmdError>> {
+    return this.collections.ensureCollections(this.dataPath);
+  }
+}

--- a/packages/qmd-adapter/src/collections/collection-manager.ts
+++ b/packages/qmd-adapter/src/collections/collection-manager.ts
@@ -1,0 +1,85 @@
+import type { Result } from '@qmd-team-intent-kb/common';
+import type { QmdError } from '../types.js';
+import type { QmdExecutor } from '../executor/executor.js';
+import { getAllCollectionNames } from './collection-registry.js';
+
+/** Manage qmd collections (add, remove, list) */
+export class CollectionManager {
+  constructor(
+    private readonly executor: QmdExecutor,
+    readonly dataPath: string,
+  ) {}
+
+  /** Add a collection pointing to a directory */
+  async addCollection(name: string, path: string): Promise<Result<void, QmdError>> {
+    const result = await this.executor.execute(['collection', 'add', path, '--name', name]);
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        error: {
+          code: 'command_failed',
+          message: `Failed to add collection "${name}"`,
+          command: `qmd collection add ${path} --name ${name}`,
+          stderr: result.stderr,
+        },
+      };
+    }
+    return { ok: true, value: undefined };
+  }
+
+  /** Remove a collection */
+  async removeCollection(name: string): Promise<Result<void, QmdError>> {
+    const result = await this.executor.execute(['collection', 'remove', name]);
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        error: {
+          code: 'command_failed',
+          message: `Failed to remove collection "${name}"`,
+          command: `qmd collection remove ${name}`,
+          stderr: result.stderr,
+        },
+      };
+    }
+    return { ok: true, value: undefined };
+  }
+
+  /** List existing collections */
+  async listCollections(): Promise<Result<string[], QmdError>> {
+    const result = await this.executor.execute(['collection', 'list']);
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        error: {
+          code: 'command_failed',
+          message: 'Failed to list collections',
+          command: 'qmd collection list',
+          stderr: result.stderr,
+        },
+      };
+    }
+    const collections = result.stdout
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => line.trim());
+    return { ok: true, value: collections };
+  }
+
+  /** Ensure all known collections exist, creating missing ones */
+  async ensureCollections(basePath: string): Promise<Result<string[], QmdError>> {
+    const listResult = await this.listCollections();
+    const existing = listResult.ok ? listResult.value : [];
+
+    const created: string[] = [];
+    for (const name of getAllCollectionNames()) {
+      if (!existing.some((e) => e.includes(name))) {
+        const path = `${basePath}/${name}`;
+        const addResult = await this.addCollection(name, path);
+        if (!addResult.ok) return addResult as Result<string[], QmdError>;
+        created.push(name);
+      }
+    }
+    return { ok: true, value: created };
+  }
+}

--- a/packages/qmd-adapter/src/collections/collection-registry.ts
+++ b/packages/qmd-adapter/src/collections/collection-registry.ts
@@ -1,0 +1,55 @@
+/** Definition of a known collection */
+export interface CollectionDef {
+  name: string;
+  description: string;
+  includeInDefaultSearch: boolean;
+}
+
+/** The 5 known collections with their default search inclusion */
+export const KNOWN_COLLECTIONS: CollectionDef[] = [
+  {
+    name: 'kb-curated',
+    description: 'Curated, governance-approved team knowledge',
+    includeInDefaultSearch: true,
+  },
+  {
+    name: 'kb-decisions',
+    description: 'Architectural and design decisions',
+    includeInDefaultSearch: true,
+  },
+  {
+    name: 'kb-guides',
+    description: 'How-to guides and onboarding documentation',
+    includeInDefaultSearch: true,
+  },
+  {
+    name: 'kb-inbox',
+    description: 'Unreviewed memory candidates awaiting governance',
+    includeInDefaultSearch: false,
+  },
+  {
+    name: 'kb-archive',
+    description: 'Deprecated, superseded, or archived memories',
+    includeInDefaultSearch: false,
+  },
+];
+
+/** Get collection names included in default (curated) search */
+export function getDefaultSearchCollections(): string[] {
+  return KNOWN_COLLECTIONS.filter((c) => c.includeInDefaultSearch).map((c) => c.name);
+}
+
+/** Get all known collection names */
+export function getAllCollectionNames(): string[] {
+  return KNOWN_COLLECTIONS.map((c) => c.name);
+}
+
+/** Check if a collection name is known */
+export function isKnownCollection(name: string): boolean {
+  return KNOWN_COLLECTIONS.some((c) => c.name === name);
+}
+
+/** Check if a collection is included in default search */
+export function isDefaultSearchCollection(name: string): boolean {
+  return KNOWN_COLLECTIONS.some((c) => c.name === name && c.includeInDefaultSearch);
+}

--- a/packages/qmd-adapter/src/config.ts
+++ b/packages/qmd-adapter/src/config.ts
@@ -1,0 +1,30 @@
+import { resolveTeamKbPath } from '@qmd-team-intent-kb/common';
+
+/** Base directory for qmd indexes, isolated from personal qmd usage */
+export const QMD_INDEX_DIR = 'qmd-index';
+
+/** Get the dedicated qmd index base path */
+export function getQmdIndexBasePath(): string {
+  return resolveTeamKbPath(QMD_INDEX_DIR);
+}
+
+/** Get the index path for a specific tenant */
+export function getQmdTenantIndexPath(tenantId: string): string {
+  return resolveTeamKbPath(`${QMD_INDEX_DIR}/${tenantId}`);
+}
+
+/** Get the index path for a specific tenant + collection */
+export function getQmdCollectionIndexPath(tenantId: string, collection: string): string {
+  return resolveTeamKbPath(`${QMD_INDEX_DIR}/${tenantId}/${collection}`);
+}
+
+/** Adapter configuration */
+export interface QmdAdapterConfig {
+  tenantId: string;
+  qmdBinary?: string;
+  timeout?: number;
+}
+
+/** Default configuration values */
+export const DEFAULT_QMD_BINARY = 'qmd';
+export const DEFAULT_TIMEOUT = 30_000;

--- a/packages/qmd-adapter/src/executor/executor.ts
+++ b/packages/qmd-adapter/src/executor/executor.ts
@@ -1,0 +1,7 @@
+import type { CommandResult } from '../types.js';
+
+/** Interface for executing qmd CLI commands */
+export interface QmdExecutor {
+  execute(args: string[]): Promise<CommandResult>;
+  isAvailable(): Promise<boolean>;
+}

--- a/packages/qmd-adapter/src/executor/mock-executor.ts
+++ b/packages/qmd-adapter/src/executor/mock-executor.ts
@@ -1,0 +1,54 @@
+import type { QmdExecutor } from './executor.js';
+import type { CommandResult } from '../types.js';
+
+/** Mock executor for testing — queues responses and records commands */
+export class MockQmdExecutor implements QmdExecutor {
+  readonly commands: string[][] = [];
+  private responses: CommandResult[] = [];
+  private _available = true;
+
+  /** Queue a response for the next execute() call */
+  queueResponse(response: CommandResult): void {
+    this.responses.push(response);
+  }
+
+  /** Queue a success response */
+  queueSuccess(stdout: string): void {
+    this.responses.push({ stdout, stderr: '', exitCode: 0 });
+  }
+
+  /** Queue a failure response */
+  queueFailure(stderr: string, exitCode = 1): void {
+    this.responses.push({ stdout: '', stderr, exitCode });
+  }
+
+  /** Set whether qmd appears available */
+  setAvailable(available: boolean): void {
+    this._available = available;
+  }
+
+  async execute(args: string[]): Promise<CommandResult> {
+    this.commands.push(args);
+    const response = this.responses.shift();
+    if (!response) {
+      return { stdout: '', stderr: 'No mock response queued', exitCode: 1 };
+    }
+    return response;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return this._available;
+  }
+
+  /** Get the last command that was executed */
+  get lastCommand(): string[] | undefined {
+    return this.commands[this.commands.length - 1];
+  }
+
+  /** Reset all state */
+  reset(): void {
+    this.commands.length = 0;
+    this.responses.length = 0;
+    this._available = true;
+  }
+}

--- a/packages/qmd-adapter/src/executor/real-executor.ts
+++ b/packages/qmd-adapter/src/executor/real-executor.ts
@@ -1,0 +1,51 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { QmdExecutor } from './executor.js';
+import type { CommandResult } from '../types.js';
+import { DEFAULT_QMD_BINARY, DEFAULT_TIMEOUT } from '../config.js';
+
+const execFileAsync = promisify(execFile);
+
+/** Real qmd CLI executor using child_process */
+export class RealQmdExecutor implements QmdExecutor {
+  private readonly binary: string;
+  private readonly timeout: number;
+  private readonly dataDir: string | null;
+
+  constructor(options?: { binary?: string; timeout?: number; dataDir?: string }) {
+    this.binary = options?.binary ?? DEFAULT_QMD_BINARY;
+    this.timeout = options?.timeout ?? DEFAULT_TIMEOUT;
+    this.dataDir = options?.dataDir ?? null;
+  }
+
+  async execute(args: string[]): Promise<CommandResult> {
+    const fullArgs = this.dataDir ? ['--data-dir', this.dataDir, ...args] : args;
+
+    try {
+      const { stdout, stderr } = await execFileAsync(this.binary, fullArgs, {
+        timeout: this.timeout,
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      return { stdout, stderr, exitCode: 0 };
+    } catch (e: unknown) {
+      if (e && typeof e === 'object' && 'stdout' in e && 'stderr' in e && 'code' in e) {
+        const err = e as { stdout: string; stderr: string; code: number | string };
+        return {
+          stdout: err.stdout ?? '',
+          stderr: err.stderr ?? '',
+          exitCode: typeof err.code === 'number' ? err.code : 1,
+        };
+      }
+      return { stdout: '', stderr: String(e), exitCode: 1 };
+    }
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      const result = await this.execute(['--version']);
+      return result.exitCode === 0;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/qmd-adapter/src/health/health-check.ts
+++ b/packages/qmd-adapter/src/health/health-check.ts
@@ -1,0 +1,40 @@
+import type { QmdHealthStatus } from '../types.js';
+import type { QmdExecutor } from '../executor/executor.js';
+
+/** Check qmd health — never throws, always returns structured status */
+export async function checkHealth(executor: QmdExecutor): Promise<QmdHealthStatus> {
+  const available = await executor.isAvailable();
+  if (!available) {
+    return { available: false, version: null, initialized: false, collections: [] };
+  }
+
+  // Get version
+  let version: string | null = null;
+  try {
+    const vResult = await executor.execute(['--version']);
+    if (vResult.exitCode === 0) {
+      version = vResult.stdout.trim();
+    }
+  } catch {
+    // Non-fatal
+  }
+
+  // Get collections (proxy for "initialized")
+  let collections: string[] = [];
+  let initialized = false;
+  try {
+    const cResult = await executor.execute(['collection', 'list']);
+    if (cResult.exitCode === 0) {
+      collections = cResult.stdout
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((l) => l.trim());
+      initialized = collections.length > 0;
+    }
+  } catch {
+    // Non-fatal
+  }
+
+  return { available, version, initialized, collections };
+}

--- a/packages/qmd-adapter/src/index-manager/index-lifecycle.ts
+++ b/packages/qmd-adapter/src/index-manager/index-lifecycle.ts
@@ -1,0 +1,77 @@
+import type { Result } from '@qmd-team-intent-kb/common';
+import type { QmdError } from '../types.js';
+import type { QmdExecutor } from '../executor/executor.js';
+
+/** Manage qmd index lifecycle operations */
+export class IndexLifecycleManager {
+  constructor(private readonly executor: QmdExecutor) {}
+
+  /** Update the qmd index (re-index all collections) */
+  async update(): Promise<Result<void, QmdError>> {
+    const result = await this.executor.execute(['update']);
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        error: {
+          code: 'command_failed',
+          message: 'Failed to update index',
+          command: 'qmd update',
+          stderr: result.stderr,
+        },
+      };
+    }
+    return { ok: true, value: undefined };
+  }
+
+  /** Generate/refresh vector embeddings */
+  async embed(force = false): Promise<Result<void, QmdError>> {
+    const args = force ? ['embed', '-f'] : ['embed'];
+    const result = await this.executor.execute(args);
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        error: {
+          code: 'command_failed',
+          message: 'Failed to generate embeddings',
+          command: `qmd embed${force ? ' -f' : ''}`,
+          stderr: result.stderr,
+        },
+      };
+    }
+    return { ok: true, value: undefined };
+  }
+
+  /** Clean up caches and vacuum the database */
+  async cleanup(): Promise<Result<void, QmdError>> {
+    const result = await this.executor.execute(['cleanup']);
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        error: {
+          code: 'command_failed',
+          message: 'Failed to cleanup index',
+          command: 'qmd cleanup',
+          stderr: result.stderr,
+        },
+      };
+    }
+    return { ok: true, value: undefined };
+  }
+
+  /** Get index status */
+  async status(): Promise<Result<string, QmdError>> {
+    const result = await this.executor.execute(['status']);
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        error: {
+          code: 'command_failed',
+          message: 'Failed to get index status',
+          command: 'qmd status',
+          stderr: result.stderr,
+        },
+      };
+    }
+    return { ok: true, value: result.stdout };
+  }
+}

--- a/packages/qmd-adapter/src/index-manager/index-paths.ts
+++ b/packages/qmd-adapter/src/index-manager/index-paths.ts
@@ -1,0 +1,11 @@
+import { getQmdTenantIndexPath, getQmdCollectionIndexPath } from '../config.js';
+
+/** Get the data directory for a tenant's qmd index */
+export function getTenantDataDir(tenantId: string): string {
+  return getQmdTenantIndexPath(tenantId);
+}
+
+/** Get the data directory for a specific collection within a tenant */
+export function getCollectionDataDir(tenantId: string, collection: string): string {
+  return getQmdCollectionIndexPath(tenantId, collection);
+}

--- a/packages/qmd-adapter/src/index.ts
+++ b/packages/qmd-adapter/src/index.ts
@@ -1,3 +1,43 @@
-// TODO: qmd CLI/API integration adapter for local indexing and retrieval (Phase 3)
+// Types
+export type { QmdError, CommandResult, QmdHealthStatus, QmdSearchResult } from './types.js';
 
-export const name = '@qmd-team-intent-kb/qmd-adapter';
+// Config
+export type { QmdAdapterConfig } from './config.js';
+export {
+  QMD_INDEX_DIR,
+  getQmdIndexBasePath,
+  getQmdTenantIndexPath,
+  getQmdCollectionIndexPath,
+  DEFAULT_QMD_BINARY,
+  DEFAULT_TIMEOUT,
+} from './config.js';
+
+// Executor
+export type { QmdExecutor } from './executor/executor.js';
+export { RealQmdExecutor } from './executor/real-executor.js';
+export { MockQmdExecutor } from './executor/mock-executor.js';
+
+// Collections
+export type { CollectionDef } from './collections/collection-registry.js';
+export {
+  KNOWN_COLLECTIONS,
+  getDefaultSearchCollections,
+  getAllCollectionNames,
+  isKnownCollection,
+  isDefaultSearchCollection,
+} from './collections/collection-registry.js';
+export { CollectionManager } from './collections/collection-manager.js';
+
+// Index management
+export { getTenantDataDir, getCollectionDataDir } from './index-manager/index-paths.js';
+export { IndexLifecycleManager } from './index-manager/index-lifecycle.js';
+
+// Search
+export { SearchClient } from './search/search-client.js';
+export { parseQueryOutput, deriveCollectionFromPath } from './search/result-parser.js';
+
+// Health
+export { checkHealth } from './health/health-check.js';
+
+// Facade
+export { QmdAdapter } from './adapter.js';

--- a/packages/qmd-adapter/src/search/result-parser.ts
+++ b/packages/qmd-adapter/src/search/result-parser.ts
@@ -1,0 +1,35 @@
+import type { QmdSearchResult } from '../types.js';
+
+/** Parse qmd query output (which may include scores and metadata) */
+export function parseQueryOutput(stdout: string): QmdSearchResult[] {
+  const results: QmdSearchResult[] = [];
+  const lines = stdout.trim().split('\n').filter(Boolean);
+
+  for (const line of lines) {
+    // qmd query output: various formats, try tab-separated first
+    const tabParts = line.split('\t');
+    if (tabParts.length >= 2) {
+      const score = parseFloat(tabParts[0] ?? '0');
+      const file = tabParts[1] ?? '';
+      const snippet = tabParts.slice(2).join('\t');
+      const collection = deriveCollectionFromPath(file);
+      results.push({
+        file,
+        score: isNaN(score) ? 0 : score,
+        snippet,
+        collection,
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Derive collection name from a file path */
+export function deriveCollectionFromPath(filePath: string): string {
+  const knownCollections = ['kb-curated', 'kb-decisions', 'kb-guides', 'kb-inbox', 'kb-archive'];
+  for (const name of knownCollections) {
+    if (filePath.includes(name)) return name;
+  }
+  return 'unknown';
+}

--- a/packages/qmd-adapter/src/search/search-client.ts
+++ b/packages/qmd-adapter/src/search/search-client.ts
@@ -1,0 +1,89 @@
+import type { Result } from '@qmd-team-intent-kb/common';
+import type { SearchScope } from '@qmd-team-intent-kb/schema';
+import type { QmdError, QmdSearchResult } from '../types.js';
+import type { QmdExecutor } from '../executor/executor.js';
+import { getDefaultSearchCollections } from '../collections/collection-registry.js';
+
+/** Search client with curated-only default scope enforcement */
+export class SearchClient {
+  constructor(private readonly executor: QmdExecutor) {}
+
+  /** Execute a search query, enforcing curated-only scope by default */
+  async search(
+    query: string,
+    scope: SearchScope = 'curated',
+  ): Promise<Result<QmdSearchResult[], QmdError>> {
+    const collections = this.resolveCollections(scope);
+
+    const args = ['search', query];
+    // qmd search doesn't have a --collection flag per se,
+    // but we filter results by collection post-query for scope enforcement
+    const result = await this.executor.execute(args);
+
+    if (result.exitCode !== 0) {
+      return {
+        ok: false,
+        error: {
+          code: 'command_failed',
+          message: `Search failed for query "${query}"`,
+          command: `qmd search ${query}`,
+          stderr: result.stderr,
+        },
+      };
+    }
+
+    const parsed = this.parseSearchResults(result.stdout);
+    // Filter to only allowed collections based on scope
+    const filtered =
+      scope === 'all' ? parsed : parsed.filter((r) => collections.includes(r.collection));
+
+    return { ok: true, value: filtered };
+  }
+
+  /** Resolve which collections to include based on scope */
+  private resolveCollections(scope: SearchScope): string[] {
+    switch (scope) {
+      case 'curated':
+        return getDefaultSearchCollections();
+      case 'inbox':
+        return ['kb-inbox'];
+      case 'archived':
+        return ['kb-archive'];
+      case 'all':
+        return []; // No filtering
+      default:
+        return getDefaultSearchCollections();
+    }
+  }
+
+  /** Parse qmd search output into typed results */
+  private parseSearchResults(stdout: string): QmdSearchResult[] {
+    const results: QmdSearchResult[] = [];
+    const lines = stdout.trim().split('\n').filter(Boolean);
+
+    for (const line of lines) {
+      // qmd search output format: score\tfile\tsnippet
+      const parts = line.split('\t');
+      if (parts.length >= 2) {
+        const score = parseFloat(parts[0] ?? '0');
+        const file = parts[1] ?? '';
+        const snippet = parts.slice(2).join('\t');
+
+        // Derive collection from file path
+        const collection = this.deriveCollection(file);
+
+        results.push({ file, score: isNaN(score) ? 0 : score, snippet, collection });
+      }
+    }
+
+    return results;
+  }
+
+  /** Derive collection name from file path */
+  private deriveCollection(filePath: string): string {
+    for (const name of ['kb-curated', 'kb-decisions', 'kb-guides', 'kb-inbox', 'kb-archive']) {
+      if (filePath.includes(name)) return name;
+    }
+    return 'unknown';
+  }
+}

--- a/packages/qmd-adapter/src/types.ts
+++ b/packages/qmd-adapter/src/types.ts
@@ -1,0 +1,30 @@
+/** Error from a qmd operation */
+export interface QmdError {
+  code: 'not_available' | 'not_initialized' | 'command_failed' | 'parse_error' | 'timeout';
+  message: string;
+  command?: string;
+  stderr?: string;
+}
+
+/** Result of executing a qmd CLI command */
+export interface CommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/** Health status of the qmd installation and index */
+export interface QmdHealthStatus {
+  available: boolean;
+  version: string | null;
+  initialized: boolean;
+  collections: string[];
+}
+
+/** A single search result from qmd */
+export interface QmdSearchResult {
+  file: string;
+  score: number;
+  snippet: string;
+  collection: string;
+}

--- a/packages/qmd-adapter/tsconfig.json
+++ b/packages/qmd-adapter/tsconfig.json
@@ -7,5 +7,6 @@
     "declaration": true,
     "declarationMap": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [{ "path": "../schema" }, { "path": "../common" }]
 }


### PR DESCRIPTION
## Summary

- Implements qmd CLI integration in `packages/qmd-adapter` with real executor using installed qmd v2.0.1
- QmdExecutor interface (strategy pattern) with RealQmdExecutor and MockQmdExecutor
- 5 known collections: kb-curated, kb-decisions, kb-guides (default search), kb-inbox, kb-archive (excluded)
- Curated-only default search enforced at adapter level via post-query collection filtering
- Dedicated index paths: ~/.teamkb/qmd-index/{tenantId}/ — isolated from personal qmd usage
- Health check never throws, always returns structured QmdHealthStatus
- QmdAdapter facade composing CollectionManager, SearchClient, IndexLifecycleManager

## Real qmd Integration

qmd v2.0.1 is installed and all integration tests execute real qmd CLI commands:
- Version detection
- Availability check
- Error handling for invalid commands

## Test plan

- [x] `pnpm validate` passes (format, lint, typecheck, test)
- [x] 367 tests passing (303 Phases 1-2 + 64 new)
- [x] Real qmd executor tests confirmed working
- [x] Curated-only default scope enforcement tested for all 4 scopes
- [x] Collection registry tested for default inclusion/exclusion
- [x] Health check tested for all 3 scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)