### PR TITLE
feat: Phases 4-6 — policy engine, store, API, curator, git exporter

### DIFF
--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -45,6 +45,9 @@
 - `013-AA-AACR-phase1-schema.md` — Phase 1 core schema after action review
 - `014-AA-AACR-phase2-runtime.md` — Phase 2 claude runtime after action review
 - `015-AA-AACR-phase3-adapter.md` — Phase 3 qmd adapter after action review
+- `017-AA-AACR-phase4-api.md` — Phase 4 policy engine, store, and API after action review
+- `018-AA-AACR-phase5-curator.md` — Phase 5 curator engine after action review
+- `019-AA-AACR-phase6-exporter.md` — Phase 6 git exporter after action review
 
 ## Chronological Listing
 
@@ -67,5 +70,8 @@
 | 014 | AA-AACR | phase2-runtime              | Phase 2 AAR                 |
 | 015 | AA-AACR | phase3-adapter              | Phase 3 AAR                 |
 | 016 | OD-OPSM | branch-protection-checklist | Branch protection setup     |
+| 017 | AA-AACR | phase4-api                  | Phase 4 AAR                 |
+| 018 | AA-AACR | phase5-curator              | Phase 5 AAR                 |
+| 019 | AA-AACR | phase6-exporter             | Phase 6 AAR                 |
 
-## Next Available Sequence: 017
+## Next Available Sequence: 020

--- a/000-docs/004-PP-RMAP-phase-plan.md
+++ b/000-docs/004-PP-RMAP-phase-plan.md
@@ -94,9 +94,9 @@ The project is implemented in sequential phases, each building on the previous. 
 
 ---
 
-## Phase 4 — Policy Engine
+## Phase 4 — Policy Engine + Store + Control Plane API
 
-**Status**: NOT STARTED
+**Status**: COMPLETE
 
 **Scope**: Implement the deterministic governance rule evaluation pipeline. No LLM involvement — all decisions are code.
 
@@ -117,9 +117,9 @@ The project is implemented in sequential phases, each building on the previous. 
 
 ---
 
-## Phase 5 — Control Plane API
+## Phase 5 — Curator Engine
 
-**Status**: NOT STARTED
+**Status**: COMPLETE
 
 **Scope**: Fastify REST API serving as the central authority for memory operations, search delegation, and governance administration.
 
@@ -139,9 +139,9 @@ The project is implemented in sequential phases, each building on the previous. 
 
 ---
 
-## Phase 6 — Curator Engine
+## Phase 6 — Git Export Mirror
 
-**Status**: NOT STARTED
+**Status**: COMPLETE
 
 **Scope**: The promotion pipeline that moves memory candidates from inbox through governance to curated status.
 
@@ -161,7 +161,7 @@ The project is implemented in sequential phases, each building on the previous. 
 
 ---
 
-## Phase 7 — Git Export Mirror
+## Phase 7 — (Reserved)
 
 **Status**: NOT STARTED
 

--- a/000-docs/017-AA-AACR-phase4-api.md
+++ b/000-docs/017-AA-AACR-phase4-api.md
@@ -1,0 +1,61 @@
+# Phase 4 After Action Review — Policy Engine, Store, Control Plane API
+
+## Date
+
+2026-03-18
+
+## Scope
+
+Phase 4 implemented three sub-phases: the policy engine (4A), SQLite persistence layer (4B), and the control plane REST API (4C). Together these establish the canonical system of record and deterministic governance evaluation.
+
+## What Was Delivered
+
+### Phase 4A — Policy Engine (`packages/policy-engine`)
+
+- 6 deterministic rule evaluators: secret detection, content length, source trust, relevance score, dedup check, tenant match
+- `PolicyPipeline` class with priority-sorted, short-circuiting evaluation
+- Rule registry and `createRule()` factory mapping `PolicyRuleType` to evaluators
+- 54 tests
+
+### Phase 4B — Store (`packages/store`) — New Package
+
+- SQLite persistence via `better-sqlite3` with WAL mode and foreign keys
+- 5 repositories: candidate, memory, policy, audit (append-only), export-state
+- Idempotent DDL schema creation, in-memory option for tests (`:memory:`)
+- 38 tests
+
+### Phase 4C — Control Plane API (`apps/api`)
+
+- Fastify REST API with service layer pattern
+- Routes: POST/GET candidates, GET/transition memories, CRUD policies, GET audit, GET health
+- Zod validation on all inputs, lifecycle transition validation with audit trail
+- 62 tests via Fastify `inject()`
+
+## Architectural Decisions
+
+### Persistence: SQLite via better-sqlite3
+
+Single-file, zero-config, embedded database. Fast enough for team-scale data. Easy backup (copy file). WAL mode for read concurrency. DB path defaults to `~/.teamkb/data/teamkb.db`.
+
+### `packages/store` Extraction
+
+Both `apps/api`, `apps/curator`, and `apps/git-exporter` need repository access. Having `apps/api` own the repos would create app-to-app dependencies. A shared `packages/store` is cleaner.
+
+### Auth Posture: Deferred
+
+No authentication implemented. Current assumption: single-user or trusted-network deployment. Future hardening: API key auth, then role-based (admin/curator/reader) with tenant scoping.
+
+### Repository Pattern
+
+Prepared statements compiled once in constructor. Synchronous API matching better-sqlite3's design. JSON serialization for complex fields (author, metadata, policyEvaluations).
+
+## Test Count
+
+154 new tests (54 + 38 + 62). Cumulative: 523.
+
+## Lessons Learned
+
+- better-sqlite3's synchronous API simplifies repository code vs async alternatives
+- Fastify `inject()` is excellent for API testing without HTTP overhead
+- Policy engine's pure-function rule evaluators are highly testable
+- `noUncheckedIndexedAccess` catches real bugs in index access patterns

--- a/000-docs/018-AA-AACR-phase5-curator.md
+++ b/000-docs/018-AA-AACR-phase5-curator.md
@@ -1,0 +1,49 @@
+# Phase 5 After Action Review — Curator Engine
+
+## Date
+
+2026-03-18
+
+## Scope
+
+Phase 5 implemented the memory promotion and governance pipeline: spool intake, deduplication, policy evaluation, supersession detection, and promotion/rejection.
+
+## What Was Delivered
+
+### Curator (`apps/curator`)
+
+- **Spool Intake**: Reads JSONL spool files from claude-runtime, inserts new candidates into store. Idempotent — skips already-ingested candidates by ID.
+- **Dedup Checker**: Exact content hash match against curated memories. Returns `DedupResult` with match details.
+- **Supersession Detector**: Jaccard word-token similarity on titles, filtered by same category + tenant. Configurable threshold (default 0.6).
+- **Promoter**: Creates `CuratedMemory` from candidate + evaluations. Handles supersession (marks old memory as superseded with link). Records audit events.
+- **Rejector**: Records audit events for rejected/flagged candidates. Returns rejection reason string.
+- **Curator Orchestrator**: Per-candidate pipeline: hash → dedup → policy → supersession → promote/reject. Batch processing and dry-run mode.
+- 79 tests
+
+## Pipeline Flow
+
+1. Compute content hash
+2. Exact dedup check (hash lookup in store)
+3. Load tenant governance policy
+4. Run `PolicyPipeline.evaluate()` — returns approved/rejected/flagged
+5. If rejected/flagged → `Rejector` (audit + failure reason)
+6. Run supersession detection (title similarity, same category+tenant)
+7. If supersedes → `Promoter` with supersession (old memory → 'superseded', new → 'active')
+8. Else → `Promoter` without supersession
+
+## Key Design Decisions
+
+- **No policy = auto-approve**: If no enabled governance policy exists for a tenant, candidates pass through to promotion. This prevents blocking in unconfigured environments.
+- **Dry-run mode**: Full pipeline executes but nothing persists. Useful for preview/testing.
+- **Supersession link direction**: The OLD memory gets the `supersession.supersededBy` field pointing to the NEW memory. The new memory has no supersession link.
+- **Audit action for rejection**: Uses `deleted` action (closest available AuditAction enum value).
+
+## Test Count
+
+79 new tests. Cumulative: 602.
+
+## Lessons Learned
+
+- Jaccard similarity works well for title matching but may false-positive on very short titles (2-3 words). Threshold of 0.6 is a reasonable default.
+- Dry-run mode was trivial to implement since all persistence is concentrated in the promote/reject functions.
+- Spool re-ingestion guard (check by candidate ID) prevents duplicates without needing file tracking.

--- a/000-docs/019-AA-AACR-phase6-exporter.md
+++ b/000-docs/019-AA-AACR-phase6-exporter.md
@@ -1,0 +1,53 @@
+# Phase 6 After Action Review — Git Export Mirror
+
+## Date
+
+2026-03-18
+
+## Scope
+
+Phase 6 implemented the git export mirror: formatting curated memories as Markdown with YAML frontmatter, mapping to directory structure, detecting incremental changes, and writing files idempotently.
+
+## What Was Delivered
+
+### Git Exporter (`apps/git-exporter`)
+
+- **Frontmatter Formatter**: String-templated YAML (no yaml library). Deterministic key order, quoted strings, handles escaping for colons/quotes in titles.
+- **Markdown Formatter**: Full document: `---frontmatter---\n\n# Title\n\nContent\n`. Filename: `{id}.md`.
+- **Directory Mapper**: Category-based routing: decision→`decisions/`, pattern/convention/architecture→`curated/`, troubleshooting/reference/onboarding→`guides/`. Archived/superseded→`archive/` regardless of category.
+- **Change Detector**: Queries memories updated since last export. First run = all active memories. Uses `ExportStateRepository` for incremental tracking.
+- **File Writer**: Sync filesystem operations. Creates directories as needed. Archive removes old location, writes new.
+- **Exporter Orchestrator**: Detect changes → write/archive → update export state. Idempotent — re-running with no changes produces no writes.
+- 76 tests
+
+## Export Directory Structure
+
+```
+kb-export/
+  curated/     <- pattern, convention, architecture
+  decisions/   <- decision
+  guides/      <- troubleshooting, reference, onboarding
+  archive/     <- any lifecycle=archived or superseded
+```
+
+## What Phase 6 Does NOT Do
+
+- No `git commit` / `git push` — just generates files on disk
+- No sync daemon — that's Phase 8
+- No git conflict resolution — future concern
+
+## Key Design Decisions
+
+- **`nowFn` injection**: `runExport` accepts optional `nowFn: () => string` parameter (defaults to `() => new Date().toISOString()`). Makes temporal assertions in tests deterministic without mocking `Date`.
+- **String-templated YAML**: No yaml library dependency. All strings quoted. Deterministic key order. Escapes backslashes and double quotes. Trade-off: cannot handle deeply nested YAML, but frontmatter is flat by design.
+- **Idempotency via content comparison**: Before writing, reads existing file and compares content. If identical, skips write. This means re-export is safe to run repeatedly.
+
+## Test Count
+
+76 new tests. Cumulative: 678.
+
+## Lessons Learned
+
+- String-templated YAML is sufficient for flat frontmatter and avoids a dependency, but the escape logic needs careful handling for edge cases (colons in titles, quotes in content).
+- Idempotency check via `readFileSync` comparison is simple and effective for file-level change detection.
+- `mkdtempSync` + `rmSync` in test fixtures provides clean isolation for filesystem tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Git exporter with incremental Markdown export, YAML frontmatter, category-based directory mapping, and idempotent writes (Phase 6, 76 tests)
+- Curator engine with full promotion pipeline: spool intake, exact-hash dedup, policy evaluation, Jaccard supersession detection, dry-run mode (Phase 5, 79 tests)
+- Control plane REST API with Fastify: candidate intake, memory lifecycle transitions, policy CRUD, audit trail, health check (Phase 4C, 62 tests)
+- SQLite persistence layer (`packages/store`) with better-sqlite3, WAL mode, 5 repositories, in-memory testing (Phase 4B, 38 tests)
+- Policy engine with 6 deterministic rule evaluators and short-circuit pipeline: secret detection, content length, source trust, relevance score, dedup check, tenant match (Phase 4A, 54 tests)
 - Release workflow with dispatch trigger, tag trigger, changelog validation, and placeholder detection
 - Security workflow with weekly npm audit, lockfile integrity check, and secret scanning
 - Nightly workflow with full validation, dependency audit, and outdated dependency check

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@qmd-team-intent-kb/api",
-  "version": "0.0.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsx watch src/index.ts",
@@ -11,6 +20,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "fastify": "^5.0.0"
+    "fastify": "^5.0.0",
+    "@qmd-team-intent-kb/schema": "workspace:*",
+    "@qmd-team-intent-kb/common": "workspace:*",
+    "@qmd-team-intent-kb/store": "workspace:*",
+    "@qmd-team-intent-kb/policy-engine": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0"
   }
 }

--- a/apps/api/src/__tests__/audit.test.ts
+++ b/apps/api/src/__tests__/audit.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+import type Database from 'better-sqlite3';
+import { createTestDatabase, AuditRepository } from '@qmd-team-intent-kb/store';
+import type { AuditEvent } from '@qmd-team-intent-kb/schema';
+import { buildApp } from '../app.js';
+import { NOW } from './fixtures.js';
+
+describe('GET /api/audit', () => {
+  let db: Database.Database;
+  let app: FastifyInstance;
+  let auditRepo: AuditRepository;
+
+  function makeEvent(overrides?: Partial<AuditEvent>): AuditEvent {
+    return {
+      id: randomUUID(),
+      action: 'promoted',
+      memoryId: randomUUID(),
+      tenantId: 'team-alpha',
+      actor: { type: 'human', id: 'user-1', name: 'Test User' },
+      reason: 'Passed all governance rules',
+      details: {},
+      timestamp: NOW,
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    auditRepo = new AuditRepository(db);
+    app = buildApp({ db });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.close();
+  });
+
+  it('returns empty array when no events match', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/audit?tenantId=nobody',
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([]);
+  });
+
+  it('returns events filtered by tenantId', async () => {
+    auditRepo.insert(makeEvent({ tenantId: 'team-alpha', action: 'promoted' }));
+    auditRepo.insert(makeEvent({ tenantId: 'team-beta', action: 'archived' }));
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/audit?tenantId=team-alpha',
+    });
+    expect(res.statusCode).toBe(200);
+    const events = res.json<Array<{ tenantId: string }>>();
+    expect(events.every((e) => e.tenantId === 'team-alpha')).toBe(true);
+    expect(events.length).toBe(1);
+  });
+
+  it('returns events filtered by memoryId', async () => {
+    const memoryId = randomUUID();
+    auditRepo.insert(makeEvent({ memoryId, action: 'promoted' }));
+    auditRepo.insert(makeEvent({ memoryId, action: 'demoted' }));
+    auditRepo.insert(makeEvent({ memoryId: randomUUID(), action: 'archived' }));
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/audit?memoryId=${memoryId}`,
+    });
+    expect(res.statusCode).toBe(200);
+    const events = res.json<Array<{ memoryId: string }>>();
+    expect(events.every((e) => e.memoryId === memoryId)).toBe(true);
+    expect(events.length).toBe(2);
+  });
+
+  it('returns events filtered by action', async () => {
+    auditRepo.insert(makeEvent({ action: 'promoted' }));
+    auditRepo.insert(makeEvent({ action: 'archived' }));
+    auditRepo.insert(makeEvent({ action: 'promoted', memoryId: randomUUID() }));
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/audit?action=promoted',
+    });
+    expect(res.statusCode).toBe(200);
+    const events = res.json<Array<{ action: string }>>();
+    expect(events.every((e) => e.action === 'promoted')).toBe(true);
+    expect(events.length).toBe(2);
+  });
+
+  it('multiple events for the same memory are all returned', async () => {
+    const memoryId = randomUUID();
+    auditRepo.insert(makeEvent({ memoryId, action: 'promoted' }));
+    auditRepo.insert(makeEvent({ memoryId, action: 'demoted' }));
+    auditRepo.insert(makeEvent({ memoryId, action: 'archived' }));
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/audit?memoryId=${memoryId}`,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<unknown[]>().length).toBe(3);
+  });
+
+  it('memoryId filter takes precedence over tenantId when both provided', async () => {
+    const memoryId = randomUUID();
+    // This event has a different tenant but the memoryId matches
+    auditRepo.insert(makeEvent({ memoryId, tenantId: 'team-other', action: 'archived' }));
+    auditRepo.insert(makeEvent({ tenantId: 'team-alpha', action: 'promoted' }));
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/audit?memoryId=${memoryId}&tenantId=team-alpha`,
+    });
+    const events = res.json<Array<{ memoryId: string }>>();
+    // memoryId wins — only the event with that memoryId is returned
+    expect(events.every((e) => e.memoryId === memoryId)).toBe(true);
+    expect(events.length).toBe(1);
+  });
+});

--- a/apps/api/src/__tests__/candidates.test.ts
+++ b/apps/api/src/__tests__/candidates.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '@qmd-team-intent-kb/store';
+import { buildApp } from '../app.js';
+import { makeCandidate, NOW } from './fixtures.js';
+
+describe('/api/candidates', () => {
+  let db: Database.Database;
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    app = buildApp({ db });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.close();
+  });
+
+  // ---- POST /api/candidates ------------------------------------------------
+
+  it('POST creates a candidate and returns 201', async () => {
+    const body = makeCandidate();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/candidates',
+      payload: body,
+    });
+    expect(res.statusCode).toBe(201);
+    const created = res.json<{ id: string; status: string }>();
+    expect(created.id).toBe(body['id']);
+    expect(created.status).toBe('inbox');
+  });
+
+  it('POST with invalid data returns 400', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/candidates',
+      payload: { title: 'Missing required fields' },
+    });
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ error: string }>();
+    expect(body.error).toMatch(/Invalid candidate/);
+  });
+
+  it('POST with missing required fields returns 400', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/candidates',
+      payload: { id: randomUUID(), status: 'inbox' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('POST computes and stores a content hash', async () => {
+    const content = 'Unique content for hash test';
+    const body = makeCandidate({ content });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/candidates',
+      payload: body,
+    });
+    expect(res.statusCode).toBe(201);
+    // Verify the candidate is retrievable (hash stored internally)
+    const candidate = res.json<{ id: string }>();
+    const getRes = await app.inject({
+      method: 'GET',
+      url: `/api/candidates/${candidate.id}`,
+    });
+    expect(getRes.statusCode).toBe(200);
+    expect(getRes.json<{ content: string }>().content).toBe(content);
+  });
+
+  it('POST accepts duplicate candidates with different IDs', async () => {
+    const content = 'Shared content between two candidates';
+    const first = makeCandidate({ content });
+    const second = makeCandidate({ content, id: randomUUID() });
+
+    const r1 = await app.inject({ method: 'POST', url: '/api/candidates', payload: first });
+    const r2 = await app.inject({ method: 'POST', url: '/api/candidates', payload: second });
+
+    expect(r1.statusCode).toBe(201);
+    expect(r2.statusCode).toBe(201);
+  });
+
+  it('POST with full metadata fields succeeds', async () => {
+    const body = makeCandidate({
+      metadata: {
+        filePaths: ['src/api.ts', 'src/auth.ts'],
+        language: 'typescript',
+        projectContext: 'backend api',
+        sessionId: 'session-abc',
+        tags: ['api', 'auth'],
+      },
+      prePolicyFlags: {
+        potentialSecret: true,
+        lowConfidence: false,
+        duplicateSuspect: true,
+      },
+    });
+    const res = await app.inject({ method: 'POST', url: '/api/candidates', payload: body });
+    expect(res.statusCode).toBe(201);
+    const created = res.json<{ metadata: { filePaths: string[] } }>();
+    expect(created.metadata.filePaths).toEqual(['src/api.ts', 'src/auth.ts']);
+  });
+
+  // ---- GET /api/candidates/:id ---------------------------------------------
+
+  it('GET /:id returns the stored candidate', async () => {
+    const body = makeCandidate();
+    await app.inject({ method: 'POST', url: '/api/candidates', payload: body });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/candidates/${body['id'] as string}`,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ id: string }>().id).toBe(body['id']);
+  });
+
+  it('GET /:id for non-existent returns 404', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/candidates/${randomUUID()}`,
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: string }>().error).toMatch(/not found/i);
+  });
+
+  // ---- GET /api/candidates -------------------------------------------------
+
+  it('GET list with tenantId filter returns matching candidates', async () => {
+    const alpha = makeCandidate({ tenantId: 'team-alpha' });
+    const beta = makeCandidate({ tenantId: 'team-beta', content: 'Beta-specific content' });
+    await app.inject({ method: 'POST', url: '/api/candidates', payload: alpha });
+    await app.inject({ method: 'POST', url: '/api/candidates', payload: beta });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/candidates?tenantId=team-alpha',
+    });
+    expect(res.statusCode).toBe(200);
+    const list = res.json<Array<{ tenantId: string }>>();
+    expect(list.every((c) => c.tenantId === 'team-alpha')).toBe(true);
+    expect(list.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('GET list without tenantId returns 400', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/candidates' });
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toMatch(/tenantId/);
+  });
+
+  it('POST preserves capturedAt timestamp exactly', async () => {
+    const body = makeCandidate({ capturedAt: NOW });
+    const res = await app.inject({ method: 'POST', url: '/api/candidates', payload: body });
+    expect(res.statusCode).toBe(201);
+    expect(res.json<{ capturedAt: string }>().capturedAt).toBe(NOW);
+  });
+});

--- a/apps/api/src/__tests__/fixtures.ts
+++ b/apps/api/src/__tests__/fixtures.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from 'node:crypto';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type { CuratedMemory, GovernancePolicy, MemoryCandidate } from '@qmd-team-intent-kb/schema';
+
+export const NOW = '2026-01-15T10:00:00.000Z';
+export const HASH_A = 'a'.repeat(64);
+
+/**
+ * Build a valid MemoryCandidate request body.
+ * All fields are valid by default; pass overrides to test edge cases.
+ */
+export function makeCandidate(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: randomUUID(),
+    status: 'inbox',
+    source: 'claude_session',
+    content: 'Use Result<T, E> for all fallible operations in the codebase',
+    title: 'Error handling convention',
+    category: 'convention',
+    trustLevel: 'medium',
+    author: { type: 'ai', id: 'claude-1' },
+    tenantId: 'team-alpha',
+    metadata: { filePaths: [], tags: [] },
+    prePolicyFlags: {},
+    capturedAt: NOW,
+    ...overrides,
+  };
+}
+
+/**
+ * Build a valid CuratedMemory for direct repository insertion in tests.
+ * Use this when you need a memory to already exist (e.g. transition tests).
+ */
+export function makeMemory(overrides?: Partial<CuratedMemory>): CuratedMemory {
+  const content = 'All API endpoints must validate input with Zod schemas';
+  return {
+    id: randomUUID(),
+    candidateId: randomUUID(),
+    source: 'claude_session',
+    content,
+    title: 'API input validation pattern',
+    category: 'pattern',
+    trustLevel: 'high',
+    sensitivity: 'internal',
+    author: { type: 'ai', id: 'claude-session-2', name: 'Claude' },
+    tenantId: 'team-alpha',
+    metadata: { filePaths: [], tags: [] },
+    lifecycle: 'active',
+    contentHash: computeContentHash(content),
+    policyEvaluations: [],
+    promotedAt: NOW,
+    promotedBy: { type: 'human', id: 'user-1', name: 'Test User' },
+    updatedAt: NOW,
+    version: 1,
+    ...overrides,
+  } as CuratedMemory;
+}
+
+/**
+ * Build a valid GovernancePolicy request body.
+ */
+export function makePolicy(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: randomUUID(),
+    name: 'Default Security Policy',
+    tenantId: 'team-alpha',
+    rules: [
+      {
+        id: 'rule-secret-detect',
+        type: 'secret_detection',
+        action: 'reject',
+        enabled: true,
+        priority: 0,
+        parameters: {},
+      },
+    ],
+    enabled: true,
+    version: 1,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+/**
+ * Valid TransitionRequest body (without the `to` field, which is handled separately).
+ */
+export function makeTransitionBody(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    reason: 'No longer needed',
+    actor: { type: 'human', id: 'user-1', name: 'Test User' },
+    ...overrides,
+  };
+}
+
+// Re-export for use in tests that need a typed GovernancePolicy
+export type { GovernancePolicy, MemoryCandidate };

--- a/apps/api/src/__tests__/health.test.ts
+++ b/apps/api/src/__tests__/health.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '@qmd-team-intent-kb/store';
+import { buildApp } from '../app.js';
+
+describe('GET /api/health', () => {
+  let db: Database.Database;
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    app = buildApp({ db });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.close();
+  });
+
+  it('returns status healthy when the database is reachable', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/health' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ status: string }>();
+    expect(body.status).toBe('healthy');
+  });
+
+  it('returns a non-negative uptime in seconds', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/health' });
+    const body = res.json<{ uptime: number }>();
+    expect(typeof body.uptime).toBe('number');
+    expect(body.uptime).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns the current API version', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/health' });
+    const body = res.json<{ version: string }>();
+    expect(body.version).toBe('0.4.0');
+  });
+});

--- a/apps/api/src/__tests__/memories.test.ts
+++ b/apps/api/src/__tests__/memories.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+import type Database from 'better-sqlite3';
+import { createTestDatabase, MemoryRepository, AuditRepository } from '@qmd-team-intent-kb/store';
+import { buildApp } from '../app.js';
+import { makeMemory, makeTransitionBody, NOW } from './fixtures.js';
+
+describe('/api/memories', () => {
+  let db: Database.Database;
+  let app: FastifyInstance;
+  let memoryRepo: MemoryRepository;
+  let auditRepo: AuditRepository;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    // Repositories for direct seeding
+    memoryRepo = new MemoryRepository(db);
+    auditRepo = new AuditRepository(db);
+    app = buildApp({ db });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.close();
+  });
+
+  // ---- GET /api/memories/:id -----------------------------------------------
+
+  it('GET /:id returns the stored memory', () => {
+    const memory = makeMemory();
+    memoryRepo.insert(memory);
+
+    return app.inject({ method: 'GET', url: `/api/memories/${memory.id}` }).then((res) => {
+      expect(res.statusCode).toBe(200);
+      expect(res.json<{ id: string }>().id).toBe(memory.id);
+    });
+  });
+
+  it('GET /:id for non-existent returns 404', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/memories/${randomUUID()}`,
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: string }>().error).toMatch(/not found/i);
+  });
+
+  // ---- GET /api/memories ---------------------------------------------------
+
+  it('GET list with tenantId returns memories for that tenant', async () => {
+    const alpha = makeMemory({ tenantId: 'team-alpha' });
+    const beta = makeMemory({
+      tenantId: 'team-beta',
+      contentHash: 'b'.repeat(64),
+      content: 'Beta-specific memory',
+    });
+    memoryRepo.insert(alpha);
+    memoryRepo.insert(beta);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/memories?tenantId=team-alpha',
+    });
+    expect(res.statusCode).toBe(200);
+    const list = res.json<Array<{ tenantId: string }>>();
+    expect(list.every((m) => m.tenantId === 'team-alpha')).toBe(true);
+    expect(list.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('GET list without tenantId returns empty array', async () => {
+    const memory = makeMemory();
+    memoryRepo.insert(memory);
+
+    const res = await app.inject({ method: 'GET', url: '/api/memories' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([]);
+  });
+
+  // ---- GET /api/memories/by-hash/:hash ------------------------------------
+
+  it('GET /by-hash/:hash returns the matching memory', async () => {
+    const memory = makeMemory();
+    memoryRepo.insert(memory);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/memories/by-hash/${memory.contentHash}`,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ id: string }>().id).toBe(memory.id);
+  });
+
+  it('GET /by-hash/:hash for unknown hash returns 404', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/memories/by-hash/${'c'.repeat(64)}`,
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  // ---- POST /api/memories/:id/transition ----------------------------------
+
+  it('POST /:id/transition performs a valid active→deprecated transition', async () => {
+    const memory = makeMemory({ lifecycle: 'active' });
+    memoryRepo.insert(memory);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/memories/${memory.id}/transition`,
+      payload: { to: 'deprecated', ...makeTransitionBody() },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ lifecycle: string }>().lifecycle).toBe('deprecated');
+  });
+
+  it('POST /:id/transition with invalid target state returns 400', async () => {
+    const memory = makeMemory({ lifecycle: 'active' });
+    memoryRepo.insert(memory);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/memories/${memory.id}/transition`,
+      payload: { to: 'not-a-real-state', ...makeTransitionBody() },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('POST /:id/transition with disallowed transition returns 400', async () => {
+    // archived → active is not allowed
+    const memory = makeMemory({ lifecycle: 'archived' });
+    memoryRepo.insert(memory);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/memories/${memory.id}/transition`,
+      payload: { to: 'active', ...makeTransitionBody() },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toMatch(/not allowed/i);
+  });
+
+  it('POST /:id/transition creates an audit event', async () => {
+    const memory = makeMemory({ lifecycle: 'active', tenantId: 'team-audit' });
+    memoryRepo.insert(memory);
+
+    await app.inject({
+      method: 'POST',
+      url: `/api/memories/${memory.id}/transition`,
+      payload: { to: 'deprecated', ...makeTransitionBody() },
+    });
+
+    const events = auditRepo.findByMemory(memory.id);
+    expect(events.length).toBe(1);
+    expect(events[0]?.action).toBe('demoted');
+    expect(events[0]?.memoryId).toBe(memory.id);
+  });
+
+  it('POST /:id/transition to superseded requires supersededBy', async () => {
+    const memory = makeMemory({ lifecycle: 'active' });
+    memoryRepo.insert(memory);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/memories/${memory.id}/transition`,
+      payload: { to: 'superseded', ...makeTransitionBody() },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toMatch(/supersededBy/i);
+  });
+
+  it('POST /:id/transition for non-existent memory returns 404', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/memories/${randomUUID()}/transition`,
+      payload: { to: 'archived', ...makeTransitionBody() },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('POST /:id/transition active→archived records correct audit action', async () => {
+    const memory = makeMemory({
+      lifecycle: 'active',
+      tenantId: 'team-archive-test',
+    });
+    memoryRepo.insert(memory);
+
+    await app.inject({
+      method: 'POST',
+      url: `/api/memories/${memory.id}/transition`,
+      payload: {
+        to: 'archived',
+        reason: 'Archiving old content',
+        actor: { type: 'human', id: 'user-1', name: 'Test User' },
+      },
+    });
+
+    const events = auditRepo.findByMemory(memory.id);
+    expect(events[0]?.action).toBe('archived');
+  });
+
+  it('POST /:id/transition with missing actor returns 400', async () => {
+    const memory = makeMemory({ lifecycle: 'active' });
+    memoryRepo.insert(memory);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/memories/${memory.id}/transition`,
+      payload: { to: 'deprecated', reason: 'Reason without actor' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('transition to superseded with supersededBy succeeds', async () => {
+    const replacementId = randomUUID();
+    const memory = makeMemory({ lifecycle: 'active' });
+    memoryRepo.insert(memory);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/memories/${memory.id}/transition`,
+      payload: {
+        to: 'superseded',
+        reason: 'Replaced by newer approach',
+        actor: { type: 'human', id: 'user-1', name: 'Test User' },
+        supersededBy: replacementId,
+      },
+    });
+    // Note: the lifecycle update succeeds but the supersession field
+    // on the record is not set here (that is the curator's job).
+    // The transition itself is valid per validateTransition.
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ lifecycle: string }>().lifecycle).toBe('superseded');
+  });
+
+  it('transition preserves updatedAt after state change', async () => {
+    const memory = makeMemory({ lifecycle: 'active', updatedAt: NOW });
+    memoryRepo.insert(memory);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/memories/${memory.id}/transition`,
+      payload: { to: 'archived', ...makeTransitionBody() },
+    });
+    expect(res.statusCode).toBe(200);
+    const updated = res.json<{ updatedAt: string }>();
+    // updatedAt should have changed from the seed value
+    expect(updated.updatedAt).not.toBe(NOW);
+  });
+});

--- a/apps/api/src/__tests__/policies.test.ts
+++ b/apps/api/src/__tests__/policies.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '@qmd-team-intent-kb/store';
+import { buildApp } from '../app.js';
+import { makePolicy, NOW } from './fixtures.js';
+
+describe('/api/policies', () => {
+  let db: Database.Database;
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    app = buildApp({ db });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.close();
+  });
+
+  async function createPolicy(overrides?: Record<string, unknown>) {
+    const body = makePolicy(overrides);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/policies',
+      payload: body,
+    });
+    return { res, body };
+  }
+
+  // ---- POST /api/policies --------------------------------------------------
+
+  it('POST creates a policy and returns 201', async () => {
+    const { res, body } = await createPolicy();
+    expect(res.statusCode).toBe(201);
+    expect(res.json<{ id: string }>().id).toBe(body['id']);
+  });
+
+  it('POST with invalid data returns 400', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/policies',
+      payload: { name: 'Missing required fields' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toMatch(/Invalid policy/);
+  });
+
+  it('POST with missing rules returns 400', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/policies',
+      payload: makePolicy({ rules: [] }), // min(1) — empty rules invalid
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  // ---- GET /api/policies/:id -----------------------------------------------
+
+  it('GET /:id returns the stored policy', async () => {
+    const { body } = await createPolicy();
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/policies/${body['id'] as string}`,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ id: string }>().id).toBe(body['id']);
+  });
+
+  it('GET /:id for non-existent returns 404', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/policies/${randomUUID()}`,
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: string }>().error).toMatch(/not found/i);
+  });
+
+  // ---- GET /api/policies ---------------------------------------------------
+
+  it('GET list by tenantId returns matching policies', async () => {
+    await createPolicy({ tenantId: 'team-alpha' });
+    await createPolicy({ tenantId: 'team-beta', id: randomUUID(), name: 'Beta Policy' });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/policies?tenantId=team-alpha',
+    });
+    expect(res.statusCode).toBe(200);
+    const list = res.json<Array<{ tenantId: string }>>();
+    expect(list.every((p) => p.tenantId === 'team-alpha')).toBe(true);
+    expect(list.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('GET list without tenantId returns 400', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/policies' });
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toMatch(/tenantId/);
+  });
+
+  it('multiple policies for the same tenant are all returned', async () => {
+    const tenant = 'team-multi';
+    await createPolicy({ tenantId: tenant, id: randomUUID(), name: 'Policy One' });
+    await createPolicy({ tenantId: tenant, id: randomUUID(), name: 'Policy Two' });
+    await createPolicy({ tenantId: tenant, id: randomUUID(), name: 'Policy Three' });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/policies?tenantId=${tenant}`,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<unknown[]>().length).toBe(3);
+  });
+
+  // ---- PUT /api/policies/:id -----------------------------------------------
+
+  it('PUT /:id updates the policy and returns the updated record', async () => {
+    const { body } = await createPolicy();
+    const updated = makePolicy({
+      ...body,
+      name: 'Updated Policy Name',
+      updatedAt: '2026-06-01T00:00:00.000Z',
+    });
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/policies/${body['id'] as string}`,
+      payload: updated,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ name: string }>().name).toBe('Updated Policy Name');
+  });
+
+  it('PUT /:id with invalid data returns 400', async () => {
+    const { body } = await createPolicy();
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/policies/${body['id'] as string}`,
+      payload: { name: 'No rules provided' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('PUT /:id for non-existent returns 404', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/policies/${randomUUID()}`,
+      payload: makePolicy(),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  // ---- DELETE /api/policies/:id --------------------------------------------
+
+  it('DELETE /:id removes the policy and returns 204', async () => {
+    const { body } = await createPolicy();
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/policies/${body['id'] as string}`,
+    });
+    expect(res.statusCode).toBe(204);
+
+    // Confirm it no longer exists
+    const getRes = await app.inject({
+      method: 'GET',
+      url: `/api/policies/${body['id'] as string}`,
+    });
+    expect(getRes.statusCode).toBe(404);
+  });
+
+  it('DELETE /:id for non-existent returns 404', async () => {
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/api/policies/${randomUUID()}`,
+    });
+    expect(res.statusCode).toBe(404);
+    expect(res.json<{ error: string }>().error).toMatch(/not found/i);
+  });
+
+  it('policy createdAt timestamp is preserved on update', async () => {
+    const { body } = await createPolicy({ createdAt: NOW });
+    const updated = makePolicy({
+      ...body,
+      name: 'Updated Name',
+      createdAt: NOW,
+      updatedAt: '2026-07-01T00:00:00.000Z',
+    });
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/policies/${body['id'] as string}`,
+      payload: updated,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ createdAt: string }>().createdAt).toBe(NOW);
+  });
+});

--- a/apps/api/src/__tests__/services.test.ts
+++ b/apps/api/src/__tests__/services.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import {
+  createTestDatabase,
+  CandidateRepository,
+  MemoryRepository,
+  PolicyRepository,
+  AuditRepository,
+} from '@qmd-team-intent-kb/store';
+import { CandidateService } from '../services/candidate-service.js';
+import { MemoryService } from '../services/memory-service.js';
+import { PolicyService } from '../services/policy-service.js';
+import { HealthService } from '../services/health-service.js';
+import { ApiError } from '../errors.js';
+import { makeCandidate, makeMemory, makePolicy, NOW } from './fixtures.js';
+
+describe('CandidateService', () => {
+  let db: Database.Database;
+  let repo: CandidateRepository;
+  let service: CandidateService;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new CandidateRepository(db);
+    service = new CandidateService(repo);
+  });
+
+  it('intake validates and inserts a candidate', () => {
+    const data = makeCandidate();
+    const candidate = service.intake(data);
+    expect(candidate.id).toBe(data['id']);
+    expect(candidate.status).toBe('inbox');
+    // Verify persistence
+    const fromRepo = repo.findById(candidate.id);
+    expect(fromRepo).not.toBeNull();
+  });
+
+  it('intake rejects invalid data with a 400 ApiError', () => {
+    expect(() => service.intake({ title: 'No required fields' })).toThrow(ApiError);
+    expect(() => service.intake({ title: 'No required fields' })).toThrow(/Invalid candidate/);
+  });
+
+  it('getById throws 404 ApiError for unknown id', () => {
+    expect(() => service.getById('00000000-0000-0000-0000-000000000000')).toThrow(ApiError);
+    try {
+      service.getById('00000000-0000-0000-0000-000000000000');
+    } catch (err) {
+      expect(err instanceof ApiError).toBe(true);
+      expect((err as ApiError).statusCode).toBe(404);
+    }
+  });
+});
+
+describe('MemoryService', () => {
+  let db: Database.Database;
+  let memoryRepo: MemoryRepository;
+  let auditRepo: AuditRepository;
+  let service: MemoryService;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    memoryRepo = new MemoryRepository(db);
+    auditRepo = new AuditRepository(db);
+    service = new MemoryService(memoryRepo, auditRepo);
+  });
+
+  it('transition validates allowed lifecycle transitions', () => {
+    const memory = makeMemory({ lifecycle: 'active' });
+    memoryRepo.insert(memory);
+
+    const result = service.transition(memory.id, 'deprecated', {
+      reason: 'No longer maintained',
+      actor: { type: 'human', id: 'user-1', name: 'Test User' },
+    });
+    expect(result.lifecycle).toBe('deprecated');
+  });
+
+  it('transition rejects disallowed lifecycle transitions with 400', () => {
+    const memory = makeMemory({ lifecycle: 'archived' });
+    memoryRepo.insert(memory);
+
+    expect(() =>
+      service.transition(memory.id, 'active', {
+        reason: 'Attempt to reactivate',
+        actor: { type: 'human', id: 'user-1' },
+      }),
+    ).toThrow(ApiError);
+  });
+
+  it('transition creates a corresponding audit trail entry', () => {
+    const memory = makeMemory({ lifecycle: 'active', tenantId: 'team-audit' });
+    memoryRepo.insert(memory);
+
+    service.transition(memory.id, 'archived', {
+      reason: 'Archiving',
+      actor: { type: 'human', id: 'user-1', name: 'Test User' },
+    });
+
+    const events = auditRepo.findByMemory(memory.id);
+    expect(events.length).toBe(1);
+    expect(events[0]?.action).toBe('archived');
+    expect(events[0]?.tenantId).toBe('team-audit');
+  });
+});
+
+describe('PolicyService', () => {
+  let db: Database.Database;
+  let repo: PolicyRepository;
+  let service: PolicyService;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new PolicyRepository(db);
+    service = new PolicyService(repo);
+  });
+
+  it('create validates data with Zod and inserts', () => {
+    const data = makePolicy();
+    const policy = service.create(data);
+    expect(policy.id).toBe(data['id']);
+    expect(repo.findById(policy.id)).not.toBeNull();
+  });
+
+  it('create rejects invalid data with a 400 ApiError', () => {
+    expect(() => service.create({ name: 'Missing everything' })).toThrow(ApiError);
+    try {
+      service.create({ name: 'Missing everything' });
+    } catch (err) {
+      expect((err as ApiError).statusCode).toBe(400);
+    }
+  });
+});
+
+describe('HealthService', () => {
+  let db: Database.Database;
+  let service: HealthService;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    service = new HealthService(db);
+  });
+
+  it('check returns healthy status when database is connected', () => {
+    const status = service.check();
+    expect(status.status).toBe('healthy');
+    expect(status.dbConnected).toBe(true);
+  });
+
+  it('check returns version string', () => {
+    const status = service.check();
+    expect(status.version).toBe('0.4.0');
+  });
+
+  it('check returns a non-negative uptime', () => {
+    const status = service.check();
+    expect(status.uptime).toBeGreaterThanOrEqual(0);
+  });
+
+  it('check returns degraded when database is closed', () => {
+    db.close();
+    const status = service.check();
+    expect(status.status).toBe('degraded');
+    expect(status.dbConnected).toBe(false);
+  });
+});
+
+// Keep a reference to NOW to avoid unused import warning
+const _now: string = NOW;
+void _now;

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,58 @@
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
+import type Database from 'better-sqlite3';
+import {
+  CandidateRepository,
+  MemoryRepository,
+  PolicyRepository,
+  AuditRepository,
+} from '@qmd-team-intent-kb/store';
+import { CandidateService } from './services/candidate-service.js';
+import { MemoryService } from './services/memory-service.js';
+import { PolicyService } from './services/policy-service.js';
+import { HealthService } from './services/health-service.js';
+import { registerCandidateRoutes } from './routes/candidates.js';
+import { registerMemoryRoutes } from './routes/memories.js';
+import { registerPolicyRoutes } from './routes/policies.js';
+import { registerHealthRoutes } from './routes/health.js';
+import { registerAuditRoutes } from './routes/audit.js';
+
+/** External dependencies injected into the application factory. */
+export interface AppDependencies {
+  /** An open better-sqlite3 database connection (real or in-memory). */
+  db: Database.Database;
+  /** Suppress Fastify's built-in logger — useful in tests. Default: false. */
+  silent?: boolean;
+}
+
+/**
+ * Build and configure the Fastify application.
+ *
+ * Repositories and services are constructed here and wired into route
+ * handlers. No `.listen()` is called — callers are responsible for
+ * starting the server or using `inject()` for testing.
+ */
+export function buildApp(deps: AppDependencies): FastifyInstance {
+  const app = Fastify({ logger: deps.silent !== false ? false : true });
+
+  // Repositories
+  const candidateRepo = new CandidateRepository(deps.db);
+  const memoryRepo = new MemoryRepository(deps.db);
+  const policyRepo = new PolicyRepository(deps.db);
+  const auditRepo = new AuditRepository(deps.db);
+
+  // Services
+  const candidateService = new CandidateService(candidateRepo);
+  const memoryService = new MemoryService(memoryRepo, auditRepo);
+  const policyService = new PolicyService(policyRepo);
+  const healthService = new HealthService(deps.db);
+
+  // Routes
+  registerHealthRoutes(app, healthService);
+  registerCandidateRoutes(app, candidateService);
+  registerMemoryRoutes(app, memoryService);
+  registerPolicyRoutes(app, policyService);
+  registerAuditRoutes(app, auditRepo);
+
+  return app;
+}

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,0 +1,24 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/** Runtime configuration for the control plane API */
+export interface AppConfig {
+  port: number;
+  host: string;
+  dbPath: string;
+  logLevel: string;
+}
+
+/**
+ * Load configuration from environment variables with sensible defaults.
+ * The API port defaults to 3847, host to loopback, and database path
+ * to ~/.teamkb/data/teamkb.db.
+ */
+export function loadConfig(): AppConfig {
+  return {
+    port: parseInt(process.env['TEAMKB_API_PORT'] ?? '3847', 10),
+    host: process.env['TEAMKB_API_HOST'] ?? '127.0.0.1',
+    dbPath: process.env['TEAMKB_DB_PATH'] ?? join(homedir(), '.teamkb', 'data', 'teamkb.db'),
+    logLevel: process.env['TEAMKB_LOG_LEVEL'] ?? 'info',
+  };
+}

--- a/apps/api/src/errors.ts
+++ b/apps/api/src/errors.ts
@@ -1,0 +1,28 @@
+/**
+ * Typed API error carrying an HTTP status code.
+ * Routes catch these and convert them to JSON responses.
+ */
+export class ApiError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+/** Produce a 404 Not Found error. */
+export function notFound(message: string): ApiError {
+  return new ApiError(404, message);
+}
+
+/** Produce a 400 Bad Request error. */
+export function badRequest(message: string): ApiError {
+  return new ApiError(400, message);
+}
+
+/** Produce a 500 Internal Server Error. */
+export function internalError(message: string): ApiError {
+  return new ApiError(500, message);
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,3 +1,9 @@
-// TODO: Control plane REST API — memory CRUD, search, governance (Phase 5)
-
-export const name = '@qmd-team-intent-kb/api';
+export { buildApp } from './app.js';
+export type { AppDependencies } from './app.js';
+export { loadConfig } from './config.js';
+export type { AppConfig } from './config.js';
+export { ApiError, notFound, badRequest, internalError } from './errors.js';
+export { CandidateService } from './services/candidate-service.js';
+export { MemoryService } from './services/memory-service.js';
+export { PolicyService } from './services/policy-service.js';
+export { HealthService } from './services/health-service.js';

--- a/apps/api/src/routes/audit.ts
+++ b/apps/api/src/routes/audit.ts
@@ -1,0 +1,36 @@
+import type { FastifyInstance } from 'fastify';
+import type { AuditRepository } from '@qmd-team-intent-kb/store';
+
+/**
+ * Register audit event query routes.
+ * The audit log is append-only; this endpoint only supports reads.
+ *
+ * GET /api/audit — query by tenantId, memoryId, or action (query params)
+ *
+ * When multiple filters are supplied the most specific wins:
+ * memoryId > action > tenantId. If none are supplied an empty array
+ * is returned — a tenant scope is recommended for production use.
+ */
+export function registerAuditRoutes(app: FastifyInstance, repo: AuditRepository): void {
+  app.get('/api/audit', async (request, reply) => {
+    const { tenantId, memoryId, action } = request.query as {
+      tenantId?: string;
+      memoryId?: string;
+      action?: string;
+    };
+
+    if (memoryId !== undefined && memoryId.length > 0) {
+      return reply.send(repo.findByMemory(memoryId));
+    }
+
+    if (action !== undefined && action.length > 0) {
+      return reply.send(repo.findByAction(action));
+    }
+
+    if (tenantId !== undefined && tenantId.length > 0) {
+      return reply.send(repo.findByTenant(tenantId));
+    }
+
+    return reply.send([]);
+  });
+}

--- a/apps/api/src/routes/candidates.ts
+++ b/apps/api/src/routes/candidates.ts
@@ -1,0 +1,50 @@
+import type { FastifyInstance } from 'fastify';
+import { ApiError } from '../errors.js';
+import type { CandidateService } from '../services/candidate-service.js';
+
+/**
+ * Register candidate intake and retrieval routes.
+ *
+ * POST   /api/candidates          — intake a new candidate (201)
+ * GET    /api/candidates/:id      — retrieve by UUID (200 | 404)
+ * GET    /api/candidates          — list by tenantId query param (200 | 400)
+ */
+export function registerCandidateRoutes(app: FastifyInstance, service: CandidateService): void {
+  app.post('/api/candidates', async (request, reply) => {
+    try {
+      const candidate = service.intake(request.body);
+      return reply.status(201).send(candidate);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return reply.status(err.statusCode).send({ error: err.message });
+      }
+      throw err;
+    }
+  });
+
+  app.get('/api/candidates/:id', async (request, reply) => {
+    try {
+      const { id } = request.params as { id: string };
+      const candidate = service.getById(id);
+      return reply.send(candidate);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return reply.status(err.statusCode).send({ error: err.message });
+      }
+      throw err;
+    }
+  });
+
+  app.get('/api/candidates', async (request, reply) => {
+    try {
+      const { tenantId } = request.query as { tenantId?: string };
+      const candidates = service.list(tenantId);
+      return reply.send(candidates);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return reply.status(err.statusCode).send({ error: err.message });
+      }
+      throw err;
+    }
+  });
+}

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,0 +1,14 @@
+import type { FastifyInstance } from 'fastify';
+import type { HealthService } from '../services/health-service.js';
+
+/**
+ * Register the health check route.
+ * GET /api/health — returns liveness and database connectivity.
+ */
+export function registerHealthRoutes(app: FastifyInstance, service: HealthService): void {
+  app.get('/api/health', async (_request, reply) => {
+    const status = service.check();
+    const httpStatus = status.status === 'healthy' ? 200 : 503;
+    return reply.status(httpStatus).send(status);
+  });
+}

--- a/apps/api/src/routes/memories.ts
+++ b/apps/api/src/routes/memories.ts
@@ -1,0 +1,78 @@
+import type { FastifyInstance } from 'fastify';
+import { MemoryLifecycleState } from '@qmd-team-intent-kb/schema';
+import { ApiError } from '../errors.js';
+import type { MemoryService } from '../services/memory-service.js';
+
+/**
+ * Register curated memory retrieval and lifecycle routes.
+ *
+ * GET  /api/memories                      — list by tenantId query (200)
+ * GET  /api/memories/by-hash/:hash        — find by content hash (200 | 404)
+ * GET  /api/memories/:id                  — retrieve by UUID (200 | 404)
+ * POST /api/memories/:id/transition       — lifecycle transition (200 | 400 | 404)
+ *
+ * Note: by-hash must be registered before :id so Fastify does not treat
+ * "by-hash" as a UUID parameter value.
+ */
+export function registerMemoryRoutes(app: FastifyInstance, service: MemoryService): void {
+  app.get('/api/memories', async (request, reply) => {
+    const { tenantId } = request.query as { tenantId?: string };
+    const memories = service.list(tenantId);
+    return reply.send(memories);
+  });
+
+  // Static segment — must come before the /:id wildcard
+  app.get('/api/memories/by-hash/:hash', async (request, reply) => {
+    try {
+      const { hash } = request.params as { hash: string };
+      const memory = service.findByHash(hash);
+      if (memory === null) {
+        return reply.status(404).send({ error: `No memory found with hash ${hash}` });
+      }
+      return reply.send(memory);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return reply.status(err.statusCode).send({ error: err.message });
+      }
+      throw err;
+    }
+  });
+
+  app.get('/api/memories/:id', async (request, reply) => {
+    try {
+      const { id } = request.params as { id: string };
+      const memory = service.getById(id);
+      return reply.send(memory);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return reply.status(err.statusCode).send({ error: err.message });
+      }
+      throw err;
+    }
+  });
+
+  app.post('/api/memories/:id/transition', async (request, reply) => {
+    try {
+      const { id } = request.params as { id: string };
+      const body = request.body as { to?: unknown } & Record<string, unknown>;
+      const toRaw = body['to'];
+
+      const toParsed = MemoryLifecycleState.safeParse(toRaw);
+      if (!toParsed.success) {
+        return reply
+          .status(400)
+          .send({ error: `Invalid lifecycle state: ${String(toRaw ?? 'undefined')}` });
+      }
+
+      // Forward the rest of the body as the TransitionRequest
+      const { to: _to, ...transitionBody } = body;
+      const memory = service.transition(id, toParsed.data, transitionBody);
+      return reply.send(memory);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return reply.status(err.statusCode).send({ error: err.message });
+      }
+      throw err;
+    }
+  });
+}

--- a/apps/api/src/routes/policies.ts
+++ b/apps/api/src/routes/policies.ts
@@ -1,0 +1,78 @@
+import type { FastifyInstance } from 'fastify';
+import { ApiError } from '../errors.js';
+import type { PolicyService } from '../services/policy-service.js';
+
+/**
+ * Register governance policy CRUD routes.
+ *
+ * POST   /api/policies            — create policy (201)
+ * GET    /api/policies            — list by tenantId (200 | 400)
+ * GET    /api/policies/:id        — get by UUID (200 | 404)
+ * PUT    /api/policies/:id        — full replace update (200 | 400 | 404)
+ * DELETE /api/policies/:id        — delete (204 | 404)
+ */
+export function registerPolicyRoutes(app: FastifyInstance, service: PolicyService): void {
+  app.post('/api/policies', async (request, reply) => {
+    try {
+      const policy = service.create(request.body);
+      return reply.status(201).send(policy);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return reply.status(err.statusCode).send({ error: err.message });
+      }
+      throw err;
+    }
+  });
+
+  app.get('/api/policies', async (request, reply) => {
+    try {
+      const { tenantId } = request.query as { tenantId?: string };
+      const policies = service.list(tenantId);
+      return reply.send(policies);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return reply.status(err.statusCode).send({ error: err.message });
+      }
+      throw err;
+    }
+  });
+
+  app.get('/api/policies/:id', async (request, reply) => {
+    try {
+      const { id } = request.params as { id: string };
+      const policy = service.getById(id);
+      return reply.send(policy);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return reply.status(err.statusCode).send({ error: err.message });
+      }
+      throw err;
+    }
+  });
+
+  app.put('/api/policies/:id', async (request, reply) => {
+    try {
+      const { id } = request.params as { id: string };
+      const policy = service.update(id, request.body);
+      return reply.send(policy);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return reply.status(err.statusCode).send({ error: err.message });
+      }
+      throw err;
+    }
+  });
+
+  app.delete('/api/policies/:id', async (request, reply) => {
+    try {
+      const { id } = request.params as { id: string };
+      service.delete(id);
+      return reply.status(204).send();
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return reply.status(err.statusCode).send({ error: err.message });
+      }
+      throw err;
+    }
+  });
+}

--- a/apps/api/src/services/candidate-service.ts
+++ b/apps/api/src/services/candidate-service.ts
@@ -1,0 +1,61 @@
+import type { CandidateRepository } from '@qmd-team-intent-kb/store';
+import { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import { ApiError, badRequest, notFound } from '../errors.js';
+
+/**
+ * Service layer for memory candidate intake and retrieval.
+ * Validates all inputs with Zod before writing to the repository.
+ */
+export class CandidateService {
+  constructor(private readonly repo: CandidateRepository) {}
+
+  /**
+   * Validate and intake a new memory candidate.
+   * Computes the content hash and inserts the record.
+   * Throws a 400 ApiError on invalid input.
+   */
+  intake(data: unknown): MemoryCandidate {
+    const parsed = MemoryCandidate.safeParse(data);
+    if (!parsed.success) {
+      throw badRequest(`Invalid candidate: ${parsed.error.message}`);
+    }
+    const candidate = parsed.data;
+    const contentHash = computeContentHash(candidate.content);
+    this.repo.insert(candidate, contentHash);
+    return candidate;
+  }
+
+  /**
+   * Retrieve a candidate by its UUID.
+   * Throws a 404 ApiError if not found.
+   */
+  getById(id: string): MemoryCandidate {
+    const candidate = this.repo.findById(id);
+    if (candidate === null) throw notFound(`Candidate ${id} not found`);
+    return candidate;
+  }
+
+  /**
+   * List candidates, optionally filtered by tenant.
+   * When no tenantId is provided, a 400 ApiError is thrown — the API
+   * always requires a tenant scope for list operations.
+   */
+  list(tenantId: string | undefined): MemoryCandidate[] {
+    if (tenantId !== undefined && tenantId.length > 0) {
+      return this.repo.findByTenant(tenantId);
+    }
+    throw badRequest('tenantId query parameter is required');
+  }
+
+  /**
+   * Internal helper — check whether a content hash is already stored.
+   * Returns null when no match exists.
+   */
+  findByHash(hash: string): MemoryCandidate | null {
+    return this.repo.findByContentHash(hash);
+  }
+}
+
+// Re-export for route-layer instanceof checks
+export { ApiError };

--- a/apps/api/src/services/health-service.ts
+++ b/apps/api/src/services/health-service.ts
@@ -1,0 +1,37 @@
+import type Database from 'better-sqlite3';
+
+/** Payload returned by the health endpoint. */
+export interface HealthStatus {
+  status: 'healthy' | 'degraded';
+  uptime: number;
+  dbConnected: boolean;
+  version: string;
+}
+
+/**
+ * Reports the operational health of the API process.
+ * Checks database connectivity with a lightweight probe query.
+ */
+export class HealthService {
+  private readonly startTime = Date.now();
+
+  constructor(private readonly db: Database.Database) {}
+
+  /** Perform a health check and return the current status. */
+  check(): HealthStatus {
+    let dbConnected = false;
+    try {
+      this.db.prepare('SELECT 1').get();
+      dbConnected = true;
+    } catch {
+      // DB unavailable — status will be reported as degraded
+    }
+
+    return {
+      status: dbConnected ? 'healthy' : 'degraded',
+      uptime: Math.floor((Date.now() - this.startTime) / 1000),
+      dbConnected,
+      version: '0.4.0',
+    };
+  }
+}

--- a/apps/api/src/services/memory-service.ts
+++ b/apps/api/src/services/memory-service.ts
@@ -89,6 +89,7 @@ export class MemoryService {
     });
     this.auditRepo.insert(auditEvent);
 
-    return this.getById(id);
+    // Return the updated memory without a second DB fetch
+    return { ...memory, lifecycle: to, updatedAt: now } as CuratedMemory;
   }
 }

--- a/apps/api/src/services/memory-service.ts
+++ b/apps/api/src/services/memory-service.ts
@@ -1,0 +1,94 @@
+import { randomUUID } from 'node:crypto';
+import type { MemoryRepository, AuditRepository } from '@qmd-team-intent-kb/store';
+import { AuditEvent, TransitionRequest, validateTransition } from '@qmd-team-intent-kb/schema';
+import type { CuratedMemory, MemoryLifecycleState } from '@qmd-team-intent-kb/schema';
+import { badRequest, notFound } from '../errors.js';
+
+/** Map a target lifecycle state to an audit action verb. */
+function lifecycleToAction(to: MemoryLifecycleState): AuditEvent['action'] {
+  switch (to) {
+    case 'archived':
+      return 'archived';
+    case 'superseded':
+      return 'superseded';
+    case 'deprecated':
+      return 'demoted';
+    case 'active':
+      return 'promoted';
+  }
+}
+
+/**
+ * Service layer for curated memory lifecycle management.
+ * Validates all transitions and writes a corresponding audit event.
+ */
+export class MemoryService {
+  constructor(
+    private readonly memoryRepo: MemoryRepository,
+    private readonly auditRepo: AuditRepository,
+  ) {}
+
+  /**
+   * Retrieve a curated memory by its UUID.
+   * Throws a 404 ApiError if not found.
+   */
+  getById(id: string): CuratedMemory {
+    const memory = this.memoryRepo.findById(id);
+    if (memory === null) throw notFound(`Memory ${id} not found`);
+    return memory;
+  }
+
+  /**
+   * List curated memories, optionally filtered by tenant.
+   * When no tenantId is provided the list is empty — tenant scope is
+   * always required. Returns an empty array rather than throwing so
+   * callers can decide how to surface this constraint.
+   */
+  list(tenantId: string | undefined): CuratedMemory[] {
+    if (tenantId !== undefined && tenantId.length > 0) {
+      return this.memoryRepo.findByTenant(tenantId);
+    }
+    return [];
+  }
+
+  /** Find a curated memory by its content hash, or null if not found. */
+  findByHash(hash: string): CuratedMemory | null {
+    return this.memoryRepo.findByContentHash(hash);
+  }
+
+  /**
+   * Transition a memory to a new lifecycle state.
+   * Validates the transition is allowed, updates the row, and appends
+   * an audit event. Throws 400 on invalid transition or bad request body.
+   * Throws 404 when the memory does not exist.
+   */
+  transition(id: string, to: MemoryLifecycleState, requestBody: unknown): CuratedMemory {
+    const parsed = TransitionRequest.safeParse(requestBody);
+    if (!parsed.success) {
+      throw badRequest(`Invalid transition request: ${parsed.error.message}`);
+    }
+
+    const memory = this.getById(id); // throws 404 if missing
+    const validation = validateTransition(memory.lifecycle, to, parsed.data);
+    if (!validation.valid) {
+      throw badRequest(validation.error);
+    }
+
+    const now = new Date().toISOString();
+    this.memoryRepo.updateLifecycle(id, to, now);
+
+    const auditEvent = AuditEvent.parse({
+      id: randomUUID(),
+      action: lifecycleToAction(to),
+      memoryId: id,
+      tenantId: memory.tenantId,
+      actor: parsed.data.actor,
+      reason: parsed.data.reason,
+      details: { from: memory.lifecycle, to },
+      timestamp: now,
+    });
+    this.auditRepo.insert(auditEvent);
+
+    return this.getById(id);
+  }
+}

--- a/apps/api/src/services/policy-service.ts
+++ b/apps/api/src/services/policy-service.ts
@@ -1,0 +1,73 @@
+import type { PolicyRepository } from '@qmd-team-intent-kb/store';
+import { GovernancePolicy } from '@qmd-team-intent-kb/schema';
+import { badRequest, notFound } from '../errors.js';
+
+/**
+ * Service layer for governance policy CRUD.
+ * All inputs are validated with Zod before reaching the repository.
+ */
+export class PolicyService {
+  constructor(private readonly repo: PolicyRepository) {}
+
+  /**
+   * Validate and create a new governance policy.
+   * Throws 400 on invalid input.
+   */
+  create(data: unknown): GovernancePolicy {
+    const parsed = GovernancePolicy.safeParse(data);
+    if (!parsed.success) {
+      throw badRequest(`Invalid policy: ${parsed.error.message}`);
+    }
+    this.repo.insert(parsed.data);
+    return parsed.data;
+  }
+
+  /**
+   * Retrieve a governance policy by its UUID.
+   * Throws 404 if not found.
+   */
+  getById(id: string): GovernancePolicy {
+    const policy = this.repo.findById(id);
+    if (policy === null) throw notFound(`Policy ${id} not found`);
+    return policy;
+  }
+
+  /**
+   * List governance policies for a tenant.
+   * tenantId is required; throws 400 if omitted.
+   */
+  list(tenantId: string | undefined): GovernancePolicy[] {
+    if (tenantId !== undefined && tenantId.length > 0) {
+      return this.repo.findByTenant(tenantId);
+    }
+    throw badRequest('tenantId query parameter is required');
+  }
+
+  /**
+   * Full-replace update of an existing policy.
+   * The body must pass Zod validation and the id must exist.
+   * Throws 400 on invalid input or 404 if the policy does not exist.
+   */
+  update(id: string, data: unknown): GovernancePolicy {
+    const parsed = GovernancePolicy.safeParse(data);
+    if (!parsed.success) {
+      throw badRequest(`Invalid policy update: ${parsed.error.message}`);
+    }
+    // Ensure the record exists first
+    this.getById(id);
+    // Enforce URL id wins over body id
+    const updated: GovernancePolicy = { ...parsed.data, id };
+    const changed = this.repo.update(updated);
+    if (!changed) throw notFound(`Policy ${id} not found`);
+    return updated;
+  }
+
+  /**
+   * Delete a policy by its UUID.
+   * Throws 404 if not found.
+   */
+  delete(id: string): void {
+    const deleted = this.repo.delete(id);
+    if (!deleted) throw notFound(`Policy ${id} not found`);
+  }
+}

--- a/apps/api/src/services/policy-service.ts
+++ b/apps/api/src/services/policy-service.ts
@@ -53,8 +53,6 @@ export class PolicyService {
     if (!parsed.success) {
       throw badRequest(`Invalid policy update: ${parsed.error.message}`);
     }
-    // Ensure the record exists first
-    this.getById(id);
     // Enforce URL id wins over body id
     const updated: GovernancePolicy = { ...parsed.data, id };
     const changed = this.repo.update(updated);

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,7 +2,16 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [
+    { "path": "../../packages/schema" },
+    { "path": "../../packages/common" },
+    { "path": "../../packages/store" },
+    { "path": "../../packages/policy-engine" }
+  ]
 }

--- a/apps/curator/package.json
+++ b/apps/curator/package.json
@@ -9,5 +9,15 @@
     "test": "vitest run",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@qmd-team-intent-kb/schema": "workspace:*",
+    "@qmd-team-intent-kb/common": "workspace:*",
+    "@qmd-team-intent-kb/store": "workspace:*",
+    "@qmd-team-intent-kb/policy-engine": "workspace:*",
+    "@qmd-team-intent-kb/claude-runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0"
   }
 }

--- a/apps/curator/src/__tests__/curator.test.ts
+++ b/apps/curator/src/__tests__/curator.test.ts
@@ -1,0 +1,424 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createTestDatabase,
+  CandidateRepository,
+  MemoryRepository,
+  PolicyRepository,
+  AuditRepository,
+} from '@qmd-team-intent-kb/store';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type Database from 'better-sqlite3';
+import { Curator } from '../curator.js';
+import type { CuratorDependencies } from '../curator.js';
+import { makeCandidate, makeCuratedMemory, makePolicy, TENANT } from './fixtures.js';
+
+function makeDeps(db: Database.Database): CuratorDependencies {
+  return {
+    candidateRepo: new CandidateRepository(db),
+    memoryRepo: new MemoryRepository(db),
+    policyRepo: new PolicyRepository(db),
+    auditRepo: new AuditRepository(db),
+  };
+}
+
+describe('Curator.processSingle', () => {
+  let deps: CuratorDependencies;
+
+  beforeEach(() => {
+    const db = createTestDatabase();
+    deps = makeDeps(db);
+  });
+
+  it('promotes a clean candidate when no governance policy exists', () => {
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const candidate = makeCandidate();
+    const result = curator.processSingle(candidate);
+    expect(result.outcome).toBe('promoted');
+    expect(result.memoryId).toBeDefined();
+    expect(result.candidateId).toBe(candidate.id);
+  });
+
+  it('promotes a clean candidate that passes all policy rules', () => {
+    const policy = makePolicy();
+    deps.policyRepo.insert(policy);
+    const curator = new Curator(deps, { tenantId: TENANT });
+
+    const candidate = makeCandidate({
+      content:
+        'Always use strict TypeScript settings in tsconfig including noUncheckedIndexedAccess and noUnusedLocals.',
+    });
+    const result = curator.processSingle(candidate);
+    expect(result.outcome).toBe('promoted');
+    expect(result.memoryId).toBeDefined();
+  });
+
+  it('rejects a candidate that contains secrets', () => {
+    const policy = makePolicy();
+    deps.policyRepo.insert(policy);
+    const curator = new Curator(deps, { tenantId: TENANT });
+
+    const candidate = makeCandidate({
+      content: 'API key is AKIAIOSFODNN7EXAMPLE — keep safe',
+    });
+    const result = curator.processSingle(candidate);
+    expect(result.outcome).toBe('rejected');
+    expect(result.reason).toContain('rule-secret');
+  });
+
+  it('detects exact duplicate and returns duplicate outcome', () => {
+    const content = 'Use Result<T, E> for all fallible operations in the codebase';
+    const existing = makeCuratedMemory({ content });
+    deps.memoryRepo.insert(existing);
+
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const candidate = makeCandidate({ content });
+    const result = curator.processSingle(candidate);
+    expect(result.outcome).toBe('duplicate');
+    expect(result.reason).toContain(existing.id);
+  });
+
+  it('detects supersession and links memories', () => {
+    const existingContent = 'Existing error handling guide for the team at work';
+    const existing = makeCuratedMemory({
+      title: 'Error handling guide',
+      category: 'convention',
+      content: existingContent,
+    });
+    deps.memoryRepo.insert(existing);
+
+    const curator = new Curator(deps, { tenantId: TENANT, supersessionThreshold: 0.5 });
+    const candidate = makeCandidate({
+      title: 'Error handling guide',
+      category: 'convention',
+      content: 'Updated error handling guide with new patterns for the team here today.',
+    });
+    const result = curator.processSingle(candidate);
+    expect(result.outcome).toBe('promoted');
+    expect(result.supersedes).toBe(existing.id);
+
+    const oldMemory = deps.memoryRepo.findById(existing.id);
+    expect(oldMemory?.lifecycle).toBe('superseded');
+    expect(oldMemory?.supersession?.supersededBy).toBe(result.memoryId);
+  });
+
+  it('auto-approves when policy is disabled', () => {
+    const policy = makePolicy({ enabled: false });
+    deps.policyRepo.insert(policy);
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const candidate = makeCandidate();
+    const result = curator.processSingle(candidate);
+    expect(result.outcome).toBe('promoted');
+  });
+
+  it('returns correct CurationResult fields on promotion', () => {
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const candidate = makeCandidate();
+    const result = curator.processSingle(candidate);
+    expect(result.candidateId).toBe(candidate.id);
+    expect(result.outcome).toBe('promoted');
+    expect(result.memoryId).toBeDefined();
+    expect(result.reason).toBeTruthy();
+  });
+
+  it('records policy evaluations on the promoted memory', () => {
+    const policy = makePolicy();
+    deps.policyRepo.insert(policy);
+    const curator = new Curator(deps, { tenantId: TENANT });
+
+    const candidate = makeCandidate({
+      content: 'Repository pattern for all data access operations across the application layer.',
+    });
+    const result = curator.processSingle(candidate);
+    expect(result.outcome).toBe('promoted');
+
+    const memory = deps.memoryRepo.findById(result.memoryId!);
+    expect(memory).not.toBeNull();
+    expect(memory!.policyEvaluations.length).toBeGreaterThan(0);
+  });
+
+  it('content hash is computed correctly on the promoted memory', () => {
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const content = 'Specific content for hash verification in curator test suite.';
+    const candidate = makeCandidate({ content });
+    const result = curator.processSingle(candidate);
+
+    const memory = deps.memoryRepo.findById(result.memoryId!);
+    expect(memory?.contentHash).toBe(computeContentHash(content));
+  });
+
+  it('superseded memory lifecycle changes to superseded', () => {
+    const existingContent = 'Architecture decision record for REST versus GraphQL approach used';
+    const existing = makeCuratedMemory({
+      title: 'API architecture decision',
+      category: 'decision',
+      content: existingContent,
+    });
+    deps.memoryRepo.insert(existing);
+
+    const curator = new Curator(deps, { tenantId: TENANT, supersessionThreshold: 0.5 });
+    const candidate = makeCandidate({
+      title: 'API architecture decision',
+      category: 'decision',
+      content: 'Updated architecture decision for REST versus GraphQL with new details.',
+    });
+    curator.processSingle(candidate);
+
+    const old = deps.memoryRepo.findById(existing.id);
+    expect(old?.lifecycle).toBe('superseded');
+  });
+
+  it('does not supersede memories in a different category', () => {
+    const existing = makeCuratedMemory({
+      title: 'Error handling convention',
+      category: 'pattern',
+    });
+    deps.memoryRepo.insert(existing);
+
+    const curator = new Curator(deps, { tenantId: TENANT, supersessionThreshold: 0.5 });
+    const candidate = makeCandidate({
+      title: 'Error handling convention',
+      category: 'convention',
+      content: 'Different content for the new convention entry not a duplicate.',
+    });
+    const result = curator.processSingle(candidate);
+    expect(result.supersedes).toBeUndefined();
+  });
+
+  it('supersession threshold is configurable', () => {
+    const existingContent = 'Error convention established for team use and coding standards';
+    const existing = makeCuratedMemory({
+      title: 'Error handling pattern guide',
+      category: 'convention',
+      content: existingContent,
+    });
+    deps.memoryRepo.insert(existing);
+
+    // High threshold — "Error handling convention" vs "Error handling pattern guide"
+    // A: {error, handling, convention}, B: {error, handling, pattern, guide}
+    // intersection=2, union=5, similarity=0.4
+    const curatorHigh = new Curator(deps, { tenantId: TENANT, supersessionThreshold: 0.9 });
+    const candidate = makeCandidate({
+      title: 'Error handling convention',
+      category: 'convention',
+      content: 'New convention content for error handling that is different from existing.',
+    });
+    const resultHigh = curatorHigh.processSingle(candidate);
+    expect(resultHigh.supersedes).toBeUndefined();
+  });
+
+  it('flagged candidate is not promoted', () => {
+    const policy = makePolicy({
+      rules: [
+        {
+          id: 'rule-relevance',
+          type: 'relevance_score',
+          action: 'flag',
+          enabled: true,
+          priority: 0,
+          parameters: { minimumScore: 0.99 },
+        },
+      ],
+    });
+    deps.policyRepo.insert(policy);
+
+    const curator = new Curator(deps, { tenantId: TENANT });
+    // Minimal candidate — low relevance score triggers flag
+    const candidate = makeCandidate({
+      title: 'note',
+      content: 'Short.',
+      category: 'reference',
+      trustLevel: 'low',
+      metadata: { filePaths: [], tags: [] },
+    });
+    const result = curator.processSingle(candidate);
+    expect(result.outcome).toBe('flagged');
+    expect(result.memoryId).toBeUndefined();
+  });
+
+  it('candidate from wrong tenant gets rejected by tenant_match rule', () => {
+    // Policy is stored under 'team-beta' (the curator's tenantId) so it gets found.
+    // The candidate has tenantId 'team-alpha'. The rule compares candidate.tenantId
+    // against context.tenantId ('team-beta') → mismatch → rejected.
+    const policy = makePolicy({
+      tenantId: 'team-beta',
+      rules: [
+        {
+          id: 'rule-tenant',
+          type: 'tenant_match',
+          action: 'reject',
+          enabled: true,
+          priority: 0,
+          parameters: {},
+        },
+      ],
+    });
+    deps.policyRepo.insert(policy);
+
+    const curator = new Curator(deps, { tenantId: 'team-beta' });
+    // Candidate tenantId is 'team-alpha' (from fixture), curator tenantId is 'team-beta'
+    const candidate = makeCandidate({ tenantId: TENANT });
+    const result = curator.processSingle(candidate);
+    expect(result.outcome).toBe('rejected');
+  });
+
+  it('candidate in same tenant passes tenant_match rule', () => {
+    const policy = makePolicy({
+      rules: [
+        {
+          id: 'rule-tenant',
+          type: 'tenant_match',
+          action: 'reject',
+          enabled: true,
+          priority: 0,
+          parameters: {},
+        },
+      ],
+    });
+    deps.policyRepo.insert(policy);
+
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const candidate = makeCandidate({ tenantId: TENANT });
+    const result = curator.processSingle(candidate);
+    expect(result.outcome).toBe('promoted');
+  });
+});
+
+describe('Curator.processBatch', () => {
+  let deps: CuratorDependencies;
+
+  beforeEach(() => {
+    const db = createTestDatabase();
+    deps = makeDeps(db);
+  });
+
+  it('processes mixed batch and returns correct counts', () => {
+    const policy = makePolicy();
+    deps.policyRepo.insert(policy);
+    const curator = new Curator(deps, { tenantId: TENANT });
+
+    const cleanContent =
+      'Clean architectural decision for the monorepo setup with pnpm workspaces.';
+    const secretContent = 'API key is AKIAIOSFODNN7EXAMPLE — store this safely somewhere';
+    const dupContent = cleanContent; // same content — first will promote, second is dup
+
+    const candidates = [
+      makeCandidate({ content: cleanContent }),
+      makeCandidate({ content: secretContent }),
+      makeCandidate({ content: dupContent }),
+    ];
+
+    const batchResult = curator.processBatch(candidates);
+
+    expect(batchResult.processed).toBe(3);
+    expect(batchResult.promoted).toBe(1);
+    expect(batchResult.rejected).toBe(1);
+    expect(batchResult.duplicates).toBe(1);
+    expect(batchResult.results).toHaveLength(3);
+  });
+
+  it('CurationBatchResult has correct structure', () => {
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const candidates = [makeCandidate(), makeCandidate()];
+    const result = curator.processBatch(candidates);
+
+    expect(typeof result.processed).toBe('number');
+    expect(typeof result.promoted).toBe('number');
+    expect(typeof result.rejected).toBe('number');
+    expect(typeof result.flagged).toBe('number');
+    expect(typeof result.duplicates).toBe('number');
+    expect(Array.isArray(result.results)).toBe(true);
+  });
+
+  it('empty batch returns zeroed counts', () => {
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const result = curator.processBatch([]);
+    expect(result.processed).toBe(0);
+    expect(result.promoted).toBe(0);
+    expect(result.rejected).toBe(0);
+    expect(result.flagged).toBe(0);
+    expect(result.duplicates).toBe(0);
+    expect(result.results).toHaveLength(0);
+  });
+
+  it('dry run mode returns same outcomes but does not persist', () => {
+    const curator = new Curator(deps, { tenantId: TENANT, dryRun: true });
+    const candidates = [makeCandidate(), makeCandidate()];
+    const result = curator.processBatch(candidates);
+
+    // Outcomes are computed
+    expect(result.promoted).toBe(2);
+    // But nothing is persisted
+    expect(deps.memoryRepo.count()).toBe(0);
+    expect(deps.auditRepo.findByTenant(TENANT)).toHaveLength(0);
+  });
+
+  it('dry run processes all candidates and returns results', () => {
+    const curator = new Curator(deps, { tenantId: TENANT, dryRun: true });
+    const candidate = makeCandidate();
+    const result = curator.processBatch([candidate]);
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]?.candidateId).toBe(candidate.id);
+    expect(result.results[0]?.outcome).toBe('promoted');
+    // memoryId is set (computed in dry run)
+    expect(result.results[0]?.memoryId).toBeDefined();
+  });
+
+  it('second candidate with same content as first is detected as duplicate', () => {
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const content = 'Specific unique content for duplicate detection across batch here.';
+    const c1 = makeCandidate({ content });
+    const c2 = makeCandidate({ content });
+
+    const result = curator.processBatch([c1, c2]);
+    expect(result.promoted).toBe(1);
+    expect(result.duplicates).toBe(1);
+  });
+
+  it('batch counting: flagged candidates counted separately', () => {
+    const policy = makePolicy({
+      rules: [
+        {
+          id: 'rule-relevance',
+          type: 'relevance_score',
+          action: 'flag',
+          enabled: true,
+          priority: 0,
+          parameters: { minimumScore: 0.99 },
+        },
+      ],
+    });
+    deps.policyRepo.insert(policy);
+
+    const curator = new Curator(deps, { tenantId: TENANT });
+    // Minimal content → low score → flagged
+    const flaggedCandidate = makeCandidate({
+      title: 'x',
+      content: 'short',
+      trustLevel: 'low',
+      metadata: { filePaths: [], tags: [] },
+    });
+    const result = curator.processBatch([flaggedCandidate]);
+    expect(result.flagged).toBe(1);
+    expect(result.promoted).toBe(0);
+  });
+
+  it('full pipeline: multiple candidates with varied outcomes', () => {
+    const policy = makePolicy();
+    deps.policyRepo.insert(policy);
+    const curator = new Curator(deps, { tenantId: TENANT });
+
+    const candidates = [
+      makeCandidate({
+        content: 'Use TypeScript strict mode always in this codebase for type safety benefits.',
+      }),
+      makeCandidate({
+        content: 'AKIAIOSFODNN7EXAMPLE is the test AWS key for secret detection tests here.',
+      }),
+    ];
+
+    const result = curator.processBatch(candidates);
+    expect(result.processed).toBe(2);
+    expect(result.promoted + result.rejected + result.flagged + result.duplicates).toBe(2);
+  });
+});

--- a/apps/curator/src/__tests__/dedup-checker.test.ts
+++ b/apps/curator/src/__tests__/dedup-checker.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestDatabase, MemoryRepository } from '@qmd-team-intent-kb/store';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import { checkDuplicate } from '../dedup/dedup-checker.js';
+import { makeCandidate, makeCuratedMemory } from './fixtures.js';
+
+describe('checkDuplicate', () => {
+  let memoryRepo: MemoryRepository;
+
+  beforeEach(() => {
+    const db = createTestDatabase();
+    memoryRepo = new MemoryRepository(db);
+  });
+
+  it('returns isDuplicate=false when no memories exist in store', () => {
+    const candidate = makeCandidate();
+    const result = checkDuplicate(candidate, memoryRepo);
+    expect(result.isDuplicate).toBe(false);
+    expect(result.matchedMemoryId).toBeUndefined();
+  });
+
+  it('returns isDuplicate=false for unique content not in store', () => {
+    const existing = makeCuratedMemory({ content: 'Some existing curated memory content here.' });
+    memoryRepo.insert(existing);
+
+    const candidate = makeCandidate({
+      content: 'Completely different content for this candidate.',
+    });
+    const result = checkDuplicate(candidate, memoryRepo);
+    expect(result.isDuplicate).toBe(false);
+    expect(result.matchedMemoryId).toBeUndefined();
+  });
+
+  it('detects exact hash duplicate and returns matched memory ID', () => {
+    const content = 'Use Result<T, E> for all fallible operations in the codebase';
+    const existing = makeCuratedMemory({ content });
+    memoryRepo.insert(existing);
+
+    const candidate = makeCandidate({ content });
+    const result = checkDuplicate(candidate, memoryRepo);
+    expect(result.isDuplicate).toBe(true);
+    expect(result.matchedMemoryId).toBe(existing.id);
+  });
+
+  it('returns matchType as exact_hash when duplicate is detected', () => {
+    const content = 'Always use strict null checks in TypeScript code';
+    const existing = makeCuratedMemory({ content });
+    memoryRepo.insert(existing);
+
+    const candidate = makeCandidate({ content });
+    const result = checkDuplicate(candidate, memoryRepo);
+    expect(result.matchType).toBe('exact_hash');
+  });
+
+  it('always includes contentHash in result', () => {
+    const candidate = makeCandidate({ content: 'Some unique content not in store at all' });
+    const result = checkDuplicate(candidate, memoryRepo);
+    const expected = computeContentHash(candidate.content);
+    expect(result.contentHash).toBe(expected);
+  });
+
+  it('contentHash in result matches expected SHA-256 for duplicate', () => {
+    const content = 'Repository pattern for database access in Node.js';
+    const existing = makeCuratedMemory({ content });
+    memoryRepo.insert(existing);
+
+    const candidate = makeCandidate({ content });
+    const result = checkDuplicate(candidate, memoryRepo);
+    expect(result.contentHash).toBe(computeContentHash(content));
+  });
+
+  it('different content produces different hashes and no duplicate', () => {
+    const content1 = 'First piece of content for testing dedup logic here';
+    const content2 = 'Second piece of content that is completely different here';
+
+    const existing = makeCuratedMemory({ content: content1 });
+    memoryRepo.insert(existing);
+
+    const candidate = makeCandidate({ content: content2 });
+    const result = checkDuplicate(candidate, memoryRepo);
+    expect(result.isDuplicate).toBe(false);
+    expect(result.contentHash).toBe(computeContentHash(content2));
+    expect(result.contentHash).not.toBe(computeContentHash(content1));
+  });
+
+  it('same content always produces same hash regardless of candidate ID', () => {
+    const content = 'Use pnpm workspaces for monorepo dependency management';
+    const candidate1 = makeCandidate({ content });
+    const candidate2 = makeCandidate({ content });
+    const result1 = checkDuplicate(candidate1, memoryRepo);
+    const result2 = checkDuplicate(candidate2, memoryRepo);
+    expect(result1.contentHash).toBe(result2.contentHash);
+  });
+});

--- a/apps/curator/src/__tests__/fixtures.ts
+++ b/apps/curator/src/__tests__/fixtures.ts
@@ -1,0 +1,88 @@
+import { randomUUID } from 'node:crypto';
+import { MemoryCandidate, CuratedMemory, GovernancePolicy } from '@qmd-team-intent-kb/schema';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+
+export const NOW = '2026-01-15T10:00:00.000Z';
+export const TENANT = 'team-alpha';
+
+/** Build a valid MemoryCandidate, merging optional overrides */
+export function makeCandidate(overrides?: Record<string, unknown>): MemoryCandidate {
+  return MemoryCandidate.parse({
+    id: randomUUID(),
+    status: 'inbox',
+    source: 'claude_session',
+    content: 'Use Result<T, E> for all fallible operations in the codebase',
+    title: 'Error handling convention',
+    category: 'convention',
+    trustLevel: 'medium',
+    author: { type: 'ai', id: 'claude-1' },
+    tenantId: TENANT,
+    metadata: { filePaths: ['src/utils.ts'], tags: ['error-handling'] },
+    prePolicyFlags: {},
+    capturedAt: NOW,
+    ...overrides,
+  });
+}
+
+/** Build a valid GovernancePolicy with basic rules, merging optional overrides */
+export function makePolicy(overrides?: Record<string, unknown>): GovernancePolicy {
+  return GovernancePolicy.parse({
+    id: randomUUID(),
+    name: 'Test Policy',
+    tenantId: TENANT,
+    rules: [
+      {
+        id: 'rule-secret',
+        type: 'secret_detection',
+        action: 'reject',
+        enabled: true,
+        priority: 0,
+        parameters: {},
+      },
+      {
+        id: 'rule-length',
+        type: 'content_length',
+        action: 'reject',
+        enabled: true,
+        priority: 1,
+        parameters: { min: 10, max: 50000 },
+      },
+    ],
+    enabled: true,
+    version: 1,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  });
+}
+
+/** Build a valid CuratedMemory for seeding the memory store */
+export function makeCuratedMemory(overrides?: Record<string, unknown>): CuratedMemory {
+  const defaultContent = 'Existing curated content for testing purposes here';
+  const base: Record<string, unknown> = {
+    id: randomUUID(),
+    candidateId: randomUUID(),
+    source: 'claude_session',
+    content: defaultContent,
+    title: 'Existing pattern',
+    category: 'pattern',
+    trustLevel: 'high',
+    sensitivity: 'internal',
+    author: { type: 'ai', id: 'claude-1' },
+    tenantId: TENANT,
+    metadata: {},
+    lifecycle: 'active',
+    policyEvaluations: [],
+    promotedAt: NOW,
+    promotedBy: { type: 'system', id: 'curator' },
+    updatedAt: NOW,
+    version: 1,
+    ...overrides,
+  };
+  // Compute contentHash from the resolved content (may have been overridden above)
+  const resolvedContent = typeof base['content'] === 'string' ? base['content'] : defaultContent;
+  if (base['contentHash'] === undefined) {
+    base['contentHash'] = computeContentHash(resolvedContent);
+  }
+  return CuratedMemory.parse(base);
+}

--- a/apps/curator/src/__tests__/promoter.test.ts
+++ b/apps/curator/src/__tests__/promoter.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { createTestDatabase, MemoryRepository, AuditRepository } from '@qmd-team-intent-kb/store';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
+import { promote } from '../promotion/promoter.js';
+import { makeCandidate, makeCuratedMemory, TENANT } from './fixtures.js';
+
+function makePipelineResult(overrides?: Partial<PipelineResult>): PipelineResult {
+  return {
+    candidateId: randomUUID(),
+    outcome: 'approved',
+    evaluations: [],
+    ...overrides,
+  };
+}
+
+describe('promote', () => {
+  let memoryRepo: MemoryRepository;
+  let auditRepo: AuditRepository;
+
+  beforeEach(() => {
+    const db = createTestDatabase();
+    memoryRepo = new MemoryRepository(db);
+    auditRepo = new AuditRepository(db);
+  });
+
+  it('creates a CuratedMemory from candidate with correct fields', () => {
+    const candidate = makeCandidate();
+    const contentHash = computeContentHash(candidate.content);
+    const pipelineResult = makePipelineResult({ candidateId: candidate.id });
+
+    const memory = promote({ candidate, contentHash, pipelineResult }, memoryRepo, auditRepo);
+
+    expect(memory.candidateId).toBe(candidate.id);
+    expect(memory.content).toBe(candidate.content);
+    expect(memory.title).toBe(candidate.title);
+    expect(memory.category).toBe(candidate.category);
+    expect(memory.trustLevel).toBe(candidate.trustLevel);
+    expect(memory.tenantId).toBe(candidate.tenantId);
+  });
+
+  it('sets lifecycle to active', () => {
+    const candidate = makeCandidate();
+    const contentHash = computeContentHash(candidate.content);
+    const memory = promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult() },
+      memoryRepo,
+      auditRepo,
+    );
+    expect(memory.lifecycle).toBe('active');
+  });
+
+  it('generates a valid UUID for the memory ID', () => {
+    const candidate = makeCandidate();
+    const contentHash = computeContentHash(candidate.content);
+    const memory = promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult() },
+      memoryRepo,
+      auditRepo,
+    );
+    expect(memory.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it('preserves the content hash from input', () => {
+    const candidate = makeCandidate();
+    const contentHash = computeContentHash(candidate.content);
+    const memory = promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult() },
+      memoryRepo,
+      auditRepo,
+    );
+    expect(memory.contentHash).toBe(contentHash);
+  });
+
+  it('sets promotedBy to system/curator', () => {
+    const candidate = makeCandidate();
+    const contentHash = computeContentHash(candidate.content);
+    const memory = promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult() },
+      memoryRepo,
+      auditRepo,
+    );
+    expect(memory.promotedBy).toEqual({ type: 'system', id: 'curator' });
+  });
+
+  it('converts pipeline evaluations to PolicyEvaluation records', () => {
+    const candidate = makeCandidate();
+    const contentHash = computeContentHash(candidate.content);
+    const pipelineResult = makePipelineResult({
+      evaluations: [
+        { ruleId: 'rule-secret', ruleType: 'secret_detection', outcome: 'pass', reason: 'Clean' },
+        { ruleId: 'rule-length', ruleType: 'content_length', outcome: 'pass', reason: 'OK' },
+      ],
+    });
+
+    const memory = promote({ candidate, contentHash, pipelineResult }, memoryRepo, auditRepo);
+
+    expect(memory.policyEvaluations).toHaveLength(2);
+    expect(memory.policyEvaluations[0]?.ruleId).toBe('rule-secret');
+    expect(memory.policyEvaluations[0]?.result).toBe('pass');
+    expect(memory.policyEvaluations[1]?.ruleId).toBe('rule-length');
+  });
+
+  it('inserts memory into store', () => {
+    const candidate = makeCandidate();
+    const contentHash = computeContentHash(candidate.content);
+    const memory = promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult() },
+      memoryRepo,
+      auditRepo,
+    );
+
+    expect(memoryRepo.count()).toBe(1);
+    expect(memoryRepo.findById(memory.id)).not.toBeNull();
+  });
+
+  it('records a promotion audit event', () => {
+    const candidate = makeCandidate({ tenantId: TENANT });
+    const contentHash = computeContentHash(candidate.content);
+    const memory = promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult() },
+      memoryRepo,
+      auditRepo,
+    );
+
+    const events = auditRepo.findByMemory(memory.id);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.action).toBe('promoted');
+    expect(events[0]?.tenantId).toBe(TENANT);
+  });
+
+  it('handles supersession: marks old memory as superseded with link', () => {
+    const old = makeCuratedMemory({ title: 'Error handling guide', category: 'convention' });
+    memoryRepo.insert(old);
+
+    const candidate = makeCandidate({
+      title: 'Error handling guide updated',
+      category: 'convention',
+    });
+    const contentHash = computeContentHash(candidate.content);
+    const supersession = {
+      supersededMemoryId: old.id,
+      supersededTitle: old.title,
+      similarity: 0.75,
+    };
+
+    const memory = promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult(), supersession },
+      memoryRepo,
+      auditRepo,
+    );
+
+    const updatedOld = memoryRepo.findById(old.id);
+    expect(updatedOld?.lifecycle).toBe('superseded');
+    expect(updatedOld?.supersession?.supersededBy).toBe(memory.id);
+    expect(updatedOld?.supersession?.reason).toContain('0.75');
+  });
+
+  it('creates a supersession audit event for the old memory', () => {
+    const old = makeCuratedMemory({ title: 'Error handling guide', category: 'convention' });
+    memoryRepo.insert(old);
+
+    const candidate = makeCandidate({ title: 'Error handling guide v2', category: 'convention' });
+    const contentHash = computeContentHash(candidate.content);
+    const supersession = {
+      supersededMemoryId: old.id,
+      supersededTitle: old.title,
+      similarity: 0.8,
+    };
+
+    promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult(), supersession },
+      memoryRepo,
+      auditRepo,
+    );
+
+    const events = auditRepo.findByMemory(old.id);
+    const supersededEvent = events.find((e) => e.action === 'superseded');
+    expect(supersededEvent).toBeDefined();
+    expect(supersededEvent?.tenantId).toBe(TENANT);
+  });
+
+  it('dry run does not insert memory into store', () => {
+    const candidate = makeCandidate();
+    const contentHash = computeContentHash(candidate.content);
+    promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult() },
+      memoryRepo,
+      auditRepo,
+      true, // dryRun
+    );
+
+    expect(memoryRepo.count()).toBe(0);
+  });
+
+  it('dry run does not record audit events', () => {
+    const candidate = makeCandidate({ tenantId: TENANT });
+    const contentHash = computeContentHash(candidate.content);
+    const memory = promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult() },
+      memoryRepo,
+      auditRepo,
+      true, // dryRun
+    );
+
+    expect(auditRepo.findByTenant(TENANT)).toHaveLength(0);
+    // Memory object is still returned
+    expect(memory.candidateId).toBe(candidate.id);
+  });
+
+  it('dry run still returns a valid CuratedMemory', () => {
+    const candidate = makeCandidate();
+    const contentHash = computeContentHash(candidate.content);
+    const memory = promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult() },
+      memoryRepo,
+      auditRepo,
+      true,
+    );
+    expect(memory.lifecycle).toBe('active');
+    expect(memory.contentHash).toBe(contentHash);
+  });
+
+  it('new memory has no supersession link (it is the superseder)', () => {
+    const candidate = makeCandidate();
+    const contentHash = computeContentHash(candidate.content);
+    const memory = promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult() },
+      memoryRepo,
+      auditRepo,
+    );
+    expect(memory.supersession).toBeUndefined();
+  });
+
+  // Additional: promotion timestamp is set
+  it('sets promotedAt and updatedAt to a valid ISO datetime', () => {
+    const candidate = makeCandidate();
+    const contentHash = computeContentHash(candidate.content);
+    const before = new Date().toISOString();
+    const memory = promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult() },
+      memoryRepo,
+      auditRepo,
+    );
+    const after = new Date().toISOString();
+    expect(memory.promotedAt >= before).toBe(true);
+    expect(memory.promotedAt <= after).toBe(true);
+    expect(memory.updatedAt).toBe(memory.promotedAt);
+  });
+});

--- a/apps/curator/src/__tests__/rejector.test.ts
+++ b/apps/curator/src/__tests__/rejector.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { createTestDatabase, AuditRepository } from '@qmd-team-intent-kb/store';
+import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
+import { reject } from '../rejection/rejector.js';
+import { makeCandidate, TENANT } from './fixtures.js';
+
+function makeRejectedResult(overrides?: Partial<PipelineResult>): PipelineResult {
+  return {
+    candidateId: randomUUID(),
+    outcome: 'rejected',
+    evaluations: [
+      {
+        ruleId: 'rule-secret',
+        ruleType: 'secret_detection',
+        outcome: 'fail',
+        reason: 'Secret found',
+      },
+    ],
+    rejectedBy: 'rule-secret',
+    ...overrides,
+  };
+}
+
+function makeFlaggedResult(overrides?: Partial<PipelineResult>): PipelineResult {
+  return {
+    candidateId: randomUUID(),
+    outcome: 'flagged',
+    evaluations: [
+      {
+        ruleId: 'rule-relevance',
+        ruleType: 'relevance_score',
+        outcome: 'flag',
+        reason: 'Low score',
+      },
+    ],
+    flaggedBy: ['rule-relevance'],
+    ...overrides,
+  };
+}
+
+describe('reject', () => {
+  let auditRepo: AuditRepository;
+
+  beforeEach(() => {
+    const db = createTestDatabase();
+    auditRepo = new AuditRepository(db);
+  });
+
+  it('returns a reason string including the rejectedBy rule ID', () => {
+    const candidate = makeCandidate({ tenantId: TENANT });
+    const pipelineResult = makeRejectedResult({ rejectedBy: 'rule-secret' });
+
+    const reason = reject(candidate, pipelineResult, auditRepo);
+    expect(reason).toContain('rule-secret');
+    expect(reason).toContain('Rejected by rule');
+  });
+
+  it('returns a reason string including flaggedBy rule IDs when rejected by flagging', () => {
+    const candidate = makeCandidate({ tenantId: TENANT });
+    const pipelineResult = makeFlaggedResult({ flaggedBy: ['rule-relevance', 'rule-trust'] });
+
+    const reason = reject(candidate, pipelineResult, auditRepo);
+    expect(reason).toContain('rule-relevance');
+    expect(reason).toContain('rule-trust');
+    expect(reason).toContain('Flagged by rules');
+  });
+
+  it('records an audit event in the repository', () => {
+    const candidate = makeCandidate({ tenantId: TENANT });
+    const pipelineResult = makeRejectedResult();
+
+    reject(candidate, pipelineResult, auditRepo);
+
+    const events = auditRepo.findByTenant(TENANT);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.action).toBe('deleted');
+  });
+
+  it('audit event includes candidateId in details', () => {
+    const candidate = makeCandidate({ tenantId: TENANT });
+    const pipelineResult = makeRejectedResult();
+
+    reject(candidate, pipelineResult, auditRepo);
+
+    const events = auditRepo.findByTenant(TENANT);
+    const details = events[0]?.details as Record<string, unknown>;
+    expect(details?.['candidateId']).toBe(candidate.id);
+  });
+
+  it('dry run does not insert audit event', () => {
+    const candidate = makeCandidate({ tenantId: TENANT });
+    const pipelineResult = makeRejectedResult();
+
+    reject(candidate, pipelineResult, auditRepo, true /* dryRun */);
+
+    expect(auditRepo.findByTenant(TENANT)).toHaveLength(0);
+  });
+
+  it('dry run still returns the reason string', () => {
+    const candidate = makeCandidate({ tenantId: TENANT });
+    const pipelineResult = makeRejectedResult({ rejectedBy: 'rule-length' });
+
+    const reason = reject(candidate, pipelineResult, auditRepo, true);
+    expect(reason).toBeTruthy();
+    expect(reason).toContain('rule-length');
+  });
+});

--- a/apps/curator/src/__tests__/spool-intake.test.ts
+++ b/apps/curator/src/__tests__/spool-intake.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createTestDatabase, CandidateRepository } from '@qmd-team-intent-kb/store';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import { ingestFromSpool } from '../intake/spool-intake.js';
+import { makeCandidate } from './fixtures.js';
+
+/** Serialise a candidate to a JSONL line */
+function candidateToJsonl(candidate: ReturnType<typeof makeCandidate>): string {
+  return JSON.stringify(candidate);
+}
+
+/** Write candidates to a spool-*.jsonl file in the given directory */
+async function writeSpoolFile(
+  dir: string,
+  name: string,
+  candidates: ReturnType<typeof makeCandidate>[],
+): Promise<string> {
+  const filepath = join(dir, name);
+  const lines = candidates.map(candidateToJsonl).join('\n');
+  await writeFile(filepath, lines, 'utf8');
+  return filepath;
+}
+
+describe('ingestFromSpool', () => {
+  let spoolDir: string;
+  let candidateRepo: CandidateRepository;
+
+  beforeEach(async () => {
+    spoolDir = await mkdtemp(join(tmpdir(), 'spool-intake-test-'));
+    const db = createTestDatabase();
+    candidateRepo = new CandidateRepository(db);
+  });
+
+  afterEach(async () => {
+    await rm(spoolDir, { recursive: true, force: true });
+  });
+
+  it('returns empty array when spool directory is empty', async () => {
+    const result = await ingestFromSpool(candidateRepo, spoolDir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(0);
+    }
+  });
+
+  it('inserts candidates from a single spool file into the store', async () => {
+    const candidate = makeCandidate();
+    await writeSpoolFile(spoolDir, 'spool-001.jsonl', [candidate]);
+
+    const result = await ingestFromSpool(candidateRepo, spoolDir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1);
+    }
+    expect(candidateRepo.count()).toBe(1);
+  });
+
+  it('returns the ingested candidates', async () => {
+    const candidate = makeCandidate({ title: 'Important architecture decision' });
+    await writeSpoolFile(spoolDir, 'spool-002.jsonl', [candidate]);
+
+    const result = await ingestFromSpool(candidateRepo, spoolDir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value[0]?.id).toBe(candidate.id);
+      expect(result.value[0]?.title).toBe('Important architecture decision');
+    }
+  });
+
+  it('preserves candidate IDs from spool file', async () => {
+    const candidate = makeCandidate();
+    await writeSpoolFile(spoolDir, 'spool-003.jsonl', [candidate]);
+
+    await ingestFromSpool(candidateRepo, spoolDir);
+
+    const stored = candidateRepo.findById(candidate.id);
+    expect(stored).not.toBeNull();
+    expect(stored?.id).toBe(candidate.id);
+  });
+
+  it('skips already-ingested candidates (idempotency by ID)', async () => {
+    const candidate = makeCandidate();
+    const hash = computeContentHash(candidate.content);
+    candidateRepo.insert(candidate, hash);
+
+    await writeSpoolFile(spoolDir, 'spool-004.jsonl', [candidate]);
+
+    const result = await ingestFromSpool(candidateRepo, spoolDir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(0); // nothing new ingested
+    }
+    expect(candidateRepo.count()).toBe(1); // still just the original
+  });
+
+  it('processes multiple spool files', async () => {
+    const c1 = makeCandidate({ title: 'Candidate from file one here' });
+    const c2 = makeCandidate({ title: 'Candidate from file two here' });
+    const c3 = makeCandidate({ title: 'Second candidate from file two' });
+
+    await writeSpoolFile(spoolDir, 'spool-010.jsonl', [c1]);
+    await writeSpoolFile(spoolDir, 'spool-011.jsonl', [c2, c3]);
+
+    const result = await ingestFromSpool(candidateRepo, spoolDir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(3);
+    }
+    expect(candidateRepo.count()).toBe(3);
+  });
+
+  it('computes and stores content hash for each candidate', async () => {
+    const content = 'Unique content for hash verification in spool intake test';
+    const candidate = makeCandidate({ content });
+    await writeSpoolFile(spoolDir, 'spool-005.jsonl', [candidate]);
+
+    await ingestFromSpool(candidateRepo, spoolDir);
+
+    const stored = candidateRepo.findById(candidate.id);
+    expect(stored).not.toBeNull();
+    // Verify by content hash lookup
+    const byHash = candidateRepo.findByContentHash(computeContentHash(content));
+    expect(byHash).not.toBeNull();
+    expect(byHash?.id).toBe(candidate.id);
+  });
+
+  it('handles unreadable spool file gracefully without aborting batch', async () => {
+    // Create a file with invalid JSON — should be skipped
+    const badFile = join(spoolDir, 'spool-bad.jsonl');
+    await writeFile(badFile, 'this is not valid json\n', 'utf8');
+
+    const goodCandidate = makeCandidate();
+    await writeSpoolFile(spoolDir, 'spool-good.jsonl', [goodCandidate]);
+
+    const result = await ingestFromSpool(candidateRepo, spoolDir);
+    // Should succeed overall even with bad file
+    expect(result.ok).toBe(true);
+    // The good file should still be processed
+    expect(candidateRepo.count()).toBe(1);
+  });
+
+  it('returns error when spool directory does not exist', async () => {
+    const nonExistentDir = join(tmpdir(), 'does-not-exist-spool-' + Date.now().toString());
+    const result = await ingestFromSpool(candidateRepo, nonExistentDir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBeTruthy();
+    }
+  });
+
+  it('only reads files named spool-*.jsonl, ignores other files', async () => {
+    const candidate = makeCandidate();
+    // Write a file that does NOT match the spool-*.jsonl pattern
+    const otherFile = join(spoolDir, 'not-a-spool-file.txt');
+    await writeFile(otherFile, candidateToJsonl(candidate), 'utf8');
+
+    const result = await ingestFromSpool(candidateRepo, spoolDir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(0); // non-matching file ignored
+    }
+  });
+});

--- a/apps/curator/src/__tests__/supersession-detector.test.ts
+++ b/apps/curator/src/__tests__/supersession-detector.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestDatabase, MemoryRepository } from '@qmd-team-intent-kb/store';
+import {
+  detectSupersession,
+  computeTitleSimilarity,
+} from '../supersession/supersession-detector.js';
+import { makeCandidate, makeCuratedMemory, TENANT } from './fixtures.js';
+
+describe('computeTitleSimilarity', () => {
+  it('returns 1.0 for identical titles', () => {
+    expect(computeTitleSimilarity('Error handling convention', 'Error handling convention')).toBe(
+      1.0,
+    );
+  });
+
+  it('returns 0.0 for completely different titles', () => {
+    expect(computeTitleSimilarity('Error handling convention', 'Database schema design')).toBe(0);
+  });
+
+  it('returns 1.0 when both strings are empty', () => {
+    expect(computeTitleSimilarity('', '')).toBe(1.0);
+  });
+
+  it('returns 0.0 when one string is empty and the other is not', () => {
+    expect(computeTitleSimilarity('Error handling', '')).toBe(0.0);
+    expect(computeTitleSimilarity('', 'Error handling')).toBe(0.0);
+  });
+
+  it('is case-insensitive', () => {
+    expect(computeTitleSimilarity('Error Handling Convention', 'error handling convention')).toBe(
+      1.0,
+    );
+  });
+
+  it('produces high similarity for overlapping titles', () => {
+    // "Error handling patterns" vs "Error handling conventions"
+    // tokens A: {error, handling, patterns}
+    // tokens B: {error, handling, conventions}
+    // intersection: {error, handling} = 2, union = 4, similarity = 0.5
+    const sim = computeTitleSimilarity('Error handling patterns', 'Error handling conventions');
+    expect(sim).toBeGreaterThan(0.4);
+    expect(sim).toBeLessThan(1.0);
+  });
+
+  it('treats multi-word phrases as token sets (Jaccard)', () => {
+    // "a b c" vs "a b d" → intersection={a,b}, union={a,b,c,d}=4 → 2/4 = 0.5
+    expect(computeTitleSimilarity('a b c', 'a b d')).toBeCloseTo(0.5, 5);
+  });
+
+  it('handles single-word titles correctly', () => {
+    expect(computeTitleSimilarity('Patterns', 'Patterns')).toBe(1.0);
+    expect(computeTitleSimilarity('Patterns', 'Conventions')).toBe(0.0);
+  });
+});
+
+describe('detectSupersession', () => {
+  let memoryRepo: MemoryRepository;
+
+  beforeEach(() => {
+    const db = createTestDatabase();
+    memoryRepo = new MemoryRepository(db);
+  });
+
+  it('returns null when no memories exist in store', () => {
+    const candidate = makeCandidate({ title: 'Error handling convention', category: 'convention' });
+    const result = detectSupersession(candidate, memoryRepo);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when titles are completely different', () => {
+    const existing = makeCuratedMemory({
+      title: 'Database schema design principles',
+      category: 'convention',
+    });
+    memoryRepo.insert(existing);
+
+    const candidate = makeCandidate({ title: 'Error handling convention', category: 'convention' });
+    const result = detectSupersession(candidate, memoryRepo);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when category does not match', () => {
+    const existing = makeCuratedMemory({
+      title: 'Error handling convention',
+      category: 'pattern',
+    });
+    memoryRepo.insert(existing);
+
+    const candidate = makeCandidate({ title: 'Error handling convention', category: 'convention' });
+    const result = detectSupersession(candidate, memoryRepo);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when tenant does not match', () => {
+    const existing = makeCuratedMemory({
+      title: 'Error handling convention',
+      category: 'convention',
+      tenantId: 'team-beta',
+    });
+    memoryRepo.insert(existing);
+
+    const candidate = makeCandidate({
+      title: 'Error handling convention',
+      category: 'convention',
+      tenantId: TENANT,
+    });
+    const result = detectSupersession(candidate, memoryRepo);
+    expect(result).toBeNull();
+  });
+
+  it('detects supersession when titles are similar in same category and tenant', () => {
+    const existing = makeCuratedMemory({
+      title: 'Error handling patterns',
+      category: 'convention',
+      tenantId: TENANT,
+    });
+    memoryRepo.insert(existing);
+
+    const candidate = makeCandidate({
+      title: 'Error handling conventions',
+      category: 'convention',
+      tenantId: TENANT,
+    });
+    // "error handling patterns" vs "error handling conventions": 2 shared / 4 total = 0.5
+    // Default threshold is 0.6 — should NOT match
+    const resultDefault = detectSupersession(candidate, memoryRepo, 0.6);
+    expect(resultDefault).toBeNull();
+
+    // With lower threshold 0.4 — should match
+    const resultLow = detectSupersession(candidate, memoryRepo, 0.4);
+    expect(resultLow).not.toBeNull();
+    expect(resultLow?.supersededMemoryId).toBe(existing.id);
+  });
+
+  it('returns the best match when multiple memories have similar titles', () => {
+    const existing1 = makeCuratedMemory({
+      title: 'Error handling guide',
+      category: 'convention',
+      tenantId: TENANT,
+    });
+    const existing2 = makeCuratedMemory({
+      title: 'Error handling patterns complete',
+      category: 'convention',
+      tenantId: TENANT,
+    });
+    memoryRepo.insert(existing1);
+    memoryRepo.insert(existing2);
+
+    // "error handling" vs "error handling guide" = 2/3 ≈ 0.667
+    // "error handling" vs "error handling patterns complete" = 2/4 = 0.5
+    const candidate = makeCandidate({
+      title: 'Error handling',
+      category: 'convention',
+      tenantId: TENANT,
+    });
+    const result = detectSupersession(candidate, memoryRepo, 0.5);
+    expect(result).not.toBeNull();
+    // Best match should be existing1 (higher similarity)
+    expect(result?.supersededMemoryId).toBe(existing1.id);
+  });
+
+  it('returns supersession match with correct fields', () => {
+    const existing = makeCuratedMemory({
+      title: 'Error handling convention',
+      category: 'convention',
+      tenantId: TENANT,
+    });
+    memoryRepo.insert(existing);
+
+    const candidate = makeCandidate({
+      title: 'Error handling convention',
+      category: 'convention',
+      tenantId: TENANT,
+    });
+    const result = detectSupersession(candidate, memoryRepo, 0.5);
+    expect(result).not.toBeNull();
+    expect(result?.supersededMemoryId).toBe(existing.id);
+    expect(result?.supersededTitle).toBe('Error handling convention');
+    expect(result?.similarity).toBe(1.0);
+  });
+
+  it('respects high threshold by requiring very similar titles', () => {
+    const existing = makeCuratedMemory({
+      title: 'Error handling patterns',
+      category: 'convention',
+      tenantId: TENANT,
+    });
+    memoryRepo.insert(existing);
+
+    const candidate = makeCandidate({
+      title: 'Error handling guide overview',
+      category: 'convention',
+      tenantId: TENANT,
+    });
+    // "error handling patterns" vs "error handling guide overview"
+    // A: {error, handling, patterns}, B: {error, handling, guide, overview}
+    // intersection=2, union=5, sim=0.4
+    const result = detectSupersession(candidate, memoryRepo, 0.9);
+    expect(result).toBeNull();
+  });
+
+  it('only considers active memories, not superseded ones', () => {
+    const existing = makeCuratedMemory({
+      title: 'Error handling convention',
+      category: 'convention',
+      tenantId: TENANT,
+      lifecycle: 'superseded',
+      supersession: {
+        supersededBy: '00000000-0000-4000-8000-000000000001',
+        reason: 'Old version',
+        linkedAt: '2026-01-15T10:00:00.000Z',
+      },
+    });
+    memoryRepo.insert(existing);
+
+    const candidate = makeCandidate({
+      title: 'Error handling convention',
+      category: 'convention',
+      tenantId: TENANT,
+    });
+    const result = detectSupersession(candidate, memoryRepo, 0.5);
+    expect(result).toBeNull();
+  });
+});

--- a/apps/curator/src/curator.ts
+++ b/apps/curator/src/curator.ts
@@ -1,0 +1,187 @@
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import { PolicyPipeline } from '@qmd-team-intent-kb/policy-engine';
+import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
+import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import type {
+  CandidateRepository,
+  MemoryRepository,
+  PolicyRepository,
+  AuditRepository,
+} from '@qmd-team-intent-kb/store';
+import type { CuratorConfig, CurationResult, CurationBatchResult } from './types.js';
+import { checkDuplicate } from './dedup/dedup-checker.js';
+import { detectSupersession } from './supersession/supersession-detector.js';
+import { promote } from './promotion/promoter.js';
+import { reject } from './rejection/rejector.js';
+
+/** Repository dependencies required by the Curator */
+export interface CuratorDependencies {
+  candidateRepo: CandidateRepository;
+  memoryRepo: MemoryRepository;
+  policyRepo: PolicyRepository;
+  auditRepo: AuditRepository;
+}
+
+/**
+ * Orchestrates the full curation pipeline for memory candidates.
+ *
+ * Pipeline steps (per candidate):
+ *   1. Compute SHA-256 content hash
+ *   2. Exact-hash duplicate check against curated memories
+ *   3. Load the first enabled governance policy for the tenant
+ *   4. Run policy pipeline (secret detection, length, trust, relevance, dedup, tenant match)
+ *   5. On rejection/flagging: record audit and return outcome
+ *   6. On approval: detect title-similarity supersession, then promote
+ *
+ * All operations are synchronous. Only `ingestFromSpool` (file I/O) is async.
+ */
+export class Curator {
+  constructor(
+    private readonly deps: CuratorDependencies,
+    private readonly config: CuratorConfig,
+  ) {}
+
+  /**
+   * Process a single candidate through the full governance pipeline.
+   *
+   * @returns A CurationResult describing the outcome.
+   */
+  processSingle(candidate: MemoryCandidate): CurationResult {
+    // Step 1: Compute content hash
+    const contentHash = computeContentHash(candidate.content);
+
+    // Step 2: Exact-hash duplicate check
+    const dedup = checkDuplicate(candidate, this.deps.memoryRepo);
+    if (dedup.isDuplicate) {
+      return {
+        candidateId: candidate.id,
+        outcome: 'duplicate',
+        reason: `Exact duplicate of memory ${dedup.matchedMemoryId}`,
+      };
+    }
+
+    // Step 3: Load governance policy (first enabled policy for tenant)
+    const policies = this.deps.policyRepo.findByTenant(this.config.tenantId);
+    const policy = policies.find((p) => p.enabled);
+
+    if (policy === undefined) {
+      // No enabled policy = auto-approve without evaluation
+      return this.promoteCandidate(candidate, contentHash, {
+        candidateId: candidate.id,
+        outcome: 'approved',
+        evaluations: [],
+      });
+    }
+
+    // Step 4: Run policy pipeline
+    const pipeline = new PolicyPipeline(policy);
+    const existingHashes = new Set(this.deps.memoryRepo.getAllContentHashes());
+    const pipelineResult = pipeline.evaluate(candidate, {
+      existingHashes,
+      tenantId: this.config.tenantId,
+    });
+
+    // Step 5: Rejected — record audit, return rejected outcome
+    if (pipelineResult.outcome === 'rejected') {
+      const reason = reject(candidate, pipelineResult, this.deps.auditRepo, this.config.dryRun);
+      return {
+        candidateId: candidate.id,
+        outcome: 'rejected',
+        pipelineResult,
+        reason,
+      };
+    }
+
+    // Step 5b: Flagged — record audit, return flagged outcome (not promoted)
+    if (pipelineResult.outcome === 'flagged') {
+      const reason = reject(candidate, pipelineResult, this.deps.auditRepo, this.config.dryRun);
+      return {
+        candidateId: candidate.id,
+        outcome: 'flagged',
+        pipelineResult,
+        reason,
+      };
+    }
+
+    // Step 6: Approved — detect supersession then promote
+    return this.promoteCandidate(candidate, contentHash, pipelineResult);
+  }
+
+  /**
+   * Process a batch of candidates through the pipeline.
+   *
+   * Candidates are processed in order; each is independent of the others.
+   */
+  processBatch(candidates: MemoryCandidate[]): CurationBatchResult {
+    const results: CurationResult[] = [];
+    let promoted = 0;
+    let rejected = 0;
+    let flagged = 0;
+    let duplicates = 0;
+
+    for (const candidate of candidates) {
+      const result = this.processSingle(candidate);
+      results.push(result);
+
+      switch (result.outcome) {
+        case 'promoted':
+          promoted++;
+          break;
+        case 'rejected':
+          rejected++;
+          break;
+        case 'flagged':
+          flagged++;
+          break;
+        case 'duplicate':
+          duplicates++;
+          break;
+      }
+    }
+
+    return {
+      processed: candidates.length,
+      promoted,
+      rejected,
+      flagged,
+      duplicates,
+      results,
+    };
+  }
+
+  private promoteCandidate(
+    candidate: MemoryCandidate,
+    contentHash: string,
+    pipelineResult: PipelineResult,
+  ): CurationResult {
+    const supersession = detectSupersession(
+      candidate,
+      this.deps.memoryRepo,
+      this.config.supersessionThreshold ?? 0.6,
+    );
+
+    const memory = promote(
+      {
+        candidate,
+        contentHash,
+        pipelineResult,
+        supersession: supersession ?? undefined,
+      },
+      this.deps.memoryRepo,
+      this.deps.auditRepo,
+      this.config.dryRun,
+    );
+
+    return {
+      candidateId: candidate.id,
+      outcome: 'promoted',
+      memoryId: memory.id,
+      supersedes: supersession?.supersededMemoryId,
+      pipelineResult,
+      reason:
+        supersession !== null
+          ? `Promoted (supersedes ${supersession.supersededMemoryId})`
+          : 'Promoted',
+    };
+  }
+}

--- a/apps/curator/src/dedup/dedup-checker.ts
+++ b/apps/curator/src/dedup/dedup-checker.ts
@@ -1,0 +1,40 @@
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type { MemoryRepository } from '@qmd-team-intent-kb/store';
+import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+
+/** Result of a duplicate check against the curated memory store */
+export interface DedupResult {
+  isDuplicate: boolean;
+  /** ID of the existing curated memory that matched, when isDuplicate is true */
+  matchedMemoryId?: string;
+  matchType?: 'exact_hash';
+  contentHash: string;
+}
+
+/**
+ * Two-tier deduplication check:
+ *   1. Exact SHA-256 content hash match against curated memories (definitive)
+ *   2. (Future) qmd similarity search — flagging only, not implemented here
+ *
+ * Returns a DedupResult with isDuplicate=true when an exact match is found,
+ * or isDuplicate=false for novel content. The contentHash is always populated
+ * so callers can reuse it without re-computing.
+ */
+export function checkDuplicate(
+  candidate: MemoryCandidate,
+  memoryRepo: MemoryRepository,
+): DedupResult {
+  const contentHash = computeContentHash(candidate.content);
+  const existing = memoryRepo.findByContentHash(contentHash);
+
+  if (existing !== null) {
+    return {
+      isDuplicate: true,
+      matchedMemoryId: existing.id,
+      matchType: 'exact_hash',
+      contentHash,
+    };
+  }
+
+  return { isDuplicate: false, contentHash };
+}

--- a/apps/curator/src/index.ts
+++ b/apps/curator/src/index.ts
@@ -1,3 +1,14 @@
-// TODO: Memory promotion engine — validate, dedupe, supersede, assign lifecycle (Phase 6)
-
-export const name = '@qmd-team-intent-kb/curator';
+export type { CurationResult, CurationBatchResult, CuratorConfig } from './types.js';
+export { Curator } from './curator.js';
+export type { CuratorDependencies } from './curator.js';
+export { ingestFromSpool } from './intake/spool-intake.js';
+export { checkDuplicate } from './dedup/dedup-checker.js';
+export type { DedupResult } from './dedup/dedup-checker.js';
+export {
+  detectSupersession,
+  computeTitleSimilarity,
+} from './supersession/supersession-detector.js';
+export type { SupersessionMatch } from './supersession/supersession-detector.js';
+export { promote } from './promotion/promoter.js';
+export type { PromotionInput } from './promotion/promoter.js';
+export { reject } from './rejection/rejector.js';

--- a/apps/curator/src/intake/spool-intake.ts
+++ b/apps/curator/src/intake/spool-intake.ts
@@ -1,0 +1,43 @@
+import { readSpoolFile, listSpoolFiles } from '@qmd-team-intent-kb/claude-runtime';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type { Result } from '@qmd-team-intent-kb/common';
+import type { CandidateRepository } from '@qmd-team-intent-kb/store';
+import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+
+/**
+ * Reads spool files from the given directory (or default spool path) and inserts
+ * new candidates into the candidate repository.
+ *
+ * Deduplication is ID-based: if a candidate with the same ID already exists in
+ * the store it is silently skipped to prevent re-ingestion on repeated runs.
+ * Unreadable or malformed spool files are skipped without aborting the batch.
+ *
+ * @returns ok with the list of newly-ingested candidates, or err if the spool
+ *          directory itself cannot be accessed.
+ */
+export async function ingestFromSpool(
+  candidateRepo: CandidateRepository,
+  spoolDir?: string,
+): Promise<Result<MemoryCandidate[], string>> {
+  const filesResult = await listSpoolFiles(spoolDir);
+  if (!filesResult.ok) return filesResult;
+
+  const ingested: MemoryCandidate[] = [];
+
+  for (const filepath of filesResult.value) {
+    const readResult = await readSpoolFile(filepath);
+    if (!readResult.ok) continue; // skip unreadable files, keep processing others
+
+    for (const candidate of readResult.value) {
+      // Skip if already ingested (idempotency by candidate ID)
+      const existing = candidateRepo.findById(candidate.id);
+      if (existing !== null) continue;
+
+      const hash = computeContentHash(candidate.content);
+      candidateRepo.insert(candidate, hash);
+      ingested.push(candidate);
+    }
+  }
+
+  return { ok: true, value: ingested };
+}

--- a/apps/curator/src/promotion/promoter.ts
+++ b/apps/curator/src/promotion/promoter.ts
@@ -1,0 +1,132 @@
+import { randomUUID } from 'node:crypto';
+import {
+  CuratedMemory as CuratedMemorySchema,
+  AuditEvent as AuditEventSchema,
+} from '@qmd-team-intent-kb/schema';
+import type { MemoryCandidate, CuratedMemory, PolicyEvaluation } from '@qmd-team-intent-kb/schema';
+import type { MemoryRepository, AuditRepository } from '@qmd-team-intent-kb/store';
+import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
+import type { SupersessionMatch } from '../supersession/supersession-detector.js';
+
+/** Input bundle for a single promotion operation */
+export interface PromotionInput {
+  candidate: MemoryCandidate;
+  contentHash: string;
+  pipelineResult: PipelineResult;
+  supersession?: SupersessionMatch;
+}
+
+/**
+ * Promotes a candidate to a CuratedMemory and persists everything to the store.
+ *
+ * Steps:
+ *   1. Convert pipeline evaluations to PolicyEvaluation records
+ *   2. Build and validate the CuratedMemory via Zod schema
+ *   3. If supersession: update old memory lifecycle to 'superseded' with link,
+ *      then emit a 'superseded' audit event for the old memory
+ *   4. Insert the new curated memory
+ *   5. Emit a 'promoted' audit event for the new memory
+ *
+ * When dryRun=true all logic runs (including schema validation) but nothing is
+ * written to the database.
+ *
+ * @returns The fully-formed CuratedMemory (always, even in dry-run mode).
+ */
+export function promote(
+  input: PromotionInput,
+  memoryRepo: MemoryRepository,
+  auditRepo: AuditRepository,
+  dryRun: boolean = false,
+): CuratedMemory {
+  const now = new Date().toISOString();
+  const memoryId = randomUUID();
+
+  // Convert pipeline rule evaluations to PolicyEvaluation schema format.
+  // The pipeline does not carry a per-evaluation policyId, so we generate one
+  // for each evaluation record.
+  const policyEvaluations: PolicyEvaluation[] = input.pipelineResult.evaluations.map((ev) => ({
+    policyId: randomUUID(),
+    ruleId: ev.ruleId,
+    result: ev.outcome,
+    reason: ev.reason,
+    evaluatedAt: now,
+  }));
+
+  // Build the new curated memory — active lifecycle, no supersession link on self
+  const memory = CuratedMemorySchema.parse({
+    id: memoryId,
+    candidateId: input.candidate.id,
+    source: input.candidate.source,
+    content: input.candidate.content,
+    title: input.candidate.title,
+    category: input.candidate.category,
+    trustLevel: input.candidate.trustLevel,
+    sensitivity: 'internal',
+    author: input.candidate.author,
+    tenantId: input.candidate.tenantId,
+    metadata: input.candidate.metadata,
+    lifecycle: 'active',
+    contentHash: input.contentHash,
+    policyEvaluations,
+    promotedAt: now,
+    promotedBy: { type: 'system', id: 'curator' },
+    updatedAt: now,
+    version: 1,
+  });
+
+  if (!dryRun) {
+    // Handle supersession: update the old memory to 'superseded' lifecycle with link
+    if (input.supersession !== undefined) {
+      const oldMemory = memoryRepo.findById(input.supersession.supersededMemoryId);
+      if (oldMemory !== null) {
+        const updatedOld = CuratedMemorySchema.parse({
+          ...oldMemory,
+          lifecycle: 'superseded',
+          supersession: {
+            supersededBy: memoryId,
+            reason: `Title similarity: ${input.supersession.similarity.toFixed(2)}`,
+            linkedAt: now,
+          },
+          updatedAt: now,
+        });
+        memoryRepo.update(updatedOld);
+      }
+
+      // Audit: the old memory was superseded
+      auditRepo.insert(
+        AuditEventSchema.parse({
+          id: randomUUID(),
+          action: 'superseded',
+          memoryId: input.supersession.supersededMemoryId,
+          tenantId: input.candidate.tenantId,
+          actor: { type: 'system', id: 'curator' },
+          reason: `Superseded by ${memoryId}`,
+          details: {
+            newMemoryId: memoryId,
+            similarity: input.supersession.similarity,
+          },
+          timestamp: now,
+        }),
+      );
+    }
+
+    // Persist the new memory
+    memoryRepo.insert(memory);
+
+    // Audit: the candidate was promoted
+    auditRepo.insert(
+      AuditEventSchema.parse({
+        id: randomUUID(),
+        action: 'promoted',
+        memoryId,
+        tenantId: input.candidate.tenantId,
+        actor: { type: 'system', id: 'curator' },
+        reason: 'Passed all governance rules',
+        details: { candidateId: input.candidate.id },
+        timestamp: now,
+      }),
+    );
+  }
+
+  return memory;
+}

--- a/apps/curator/src/rejection/rejector.ts
+++ b/apps/curator/src/rejection/rejector.ts
@@ -1,0 +1,49 @@
+import { randomUUID } from 'node:crypto';
+import { AuditEvent as AuditEventSchema } from '@qmd-team-intent-kb/schema';
+import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import type { AuditRepository } from '@qmd-team-intent-kb/store';
+import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
+
+/**
+ * Records a candidate rejection in the audit log and returns the human-readable
+ * rejection reason.
+ *
+ * The audit event uses the 'deleted' action because no curated memory was
+ * created — the candidate was turned away at the governance gate.
+ *
+ * When dryRun=true the audit event is not persisted.
+ *
+ * @returns A human-readable string describing why the candidate was rejected or flagged.
+ */
+export function reject(
+  candidate: MemoryCandidate,
+  pipelineResult: PipelineResult,
+  auditRepo: AuditRepository,
+  dryRun: boolean = false,
+): string {
+  const reason =
+    pipelineResult.rejectedBy !== undefined
+      ? `Rejected by rule: ${pipelineResult.rejectedBy}`
+      : `Flagged by rules: ${pipelineResult.flaggedBy?.join(', ') ?? 'unknown'}`;
+
+  if (!dryRun) {
+    auditRepo.insert(
+      AuditEventSchema.parse({
+        id: randomUUID(),
+        action: 'deleted',
+        memoryId: candidate.id,
+        tenantId: candidate.tenantId,
+        actor: { type: 'system', id: 'curator' },
+        reason,
+        details: {
+          candidateId: candidate.id,
+          outcome: pipelineResult.outcome,
+          evaluations: pipelineResult.evaluations,
+        },
+        timestamp: new Date().toISOString(),
+      }),
+    );
+  }
+
+  return reason;
+}

--- a/apps/curator/src/supersession/supersession-detector.ts
+++ b/apps/curator/src/supersession/supersession-detector.ts
@@ -1,0 +1,78 @@
+import type { MemoryRepository } from '@qmd-team-intent-kb/store';
+import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+
+/** A curated memory that may be superseded by the incoming candidate */
+export interface SupersessionMatch {
+  supersededMemoryId: string;
+  supersededTitle: string;
+  similarity: number;
+}
+
+/**
+ * Detects whether an incoming candidate should supersede an existing active
+ * curated memory, using Jaccard similarity on title word tokens within the
+ * same category and tenant.
+ *
+ * Only active memories in the same category as the candidate are considered.
+ * When multiple memories meet the threshold the one with the highest similarity
+ * is returned; ties are broken by whichever was found first.
+ *
+ * @param threshold - Minimum Jaccard similarity (0.0–1.0) to consider a match.
+ *                   Defaults to 0.6.
+ * @returns The best-matching memory above the threshold, or null if none found.
+ */
+export function detectSupersession(
+  candidate: MemoryCandidate,
+  memoryRepo: MemoryRepository,
+  threshold: number = 0.6,
+): SupersessionMatch | null {
+  const existingMemories = memoryRepo
+    .findByTenant(candidate.tenantId)
+    .filter((m) => m.lifecycle === 'active' && m.category === candidate.category);
+
+  let bestMatch: SupersessionMatch | null = null;
+
+  for (const memory of existingMemories) {
+    const similarity = computeTitleSimilarity(candidate.title, memory.title);
+    if (similarity >= threshold && (bestMatch === null || similarity > bestMatch.similarity)) {
+      bestMatch = {
+        supersededMemoryId: memory.id,
+        supersededTitle: memory.title,
+        similarity,
+      };
+    }
+  }
+
+  return bestMatch;
+}
+
+/**
+ * Computes Jaccard similarity between two strings using word-level tokenization.
+ *
+ * Jaccard similarity = |intersection| / |union|
+ *
+ * Both strings are lower-cased and split on whitespace. Empty strings produce
+ * 1.0 when both are empty (identical) and 0.0 when only one is empty.
+ */
+export function computeTitleSimilarity(a: string, b: string): number {
+  const tokensA = new Set(tokenize(a));
+  const tokensB = new Set(tokenize(b));
+
+  if (tokensA.size === 0 && tokensB.size === 0) return 1.0;
+  if (tokensA.size === 0 || tokensB.size === 0) return 0.0;
+
+  let intersection = 0;
+  for (const token of tokensA) {
+    if (tokensB.has(token)) intersection++;
+  }
+
+  const union = tokensA.size + tokensB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+}

--- a/apps/curator/src/types.ts
+++ b/apps/curator/src/types.ts
@@ -1,0 +1,35 @@
+import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
+
+/** Result of curating a single candidate */
+export interface CurationResult {
+  candidateId: string;
+  outcome: 'promoted' | 'rejected' | 'flagged' | 'duplicate';
+  /** Set when the candidate was promoted to a curated memory */
+  memoryId?: string;
+  /** memoryId of the curated memory that was superseded by this promotion */
+  supersedes?: string;
+  pipelineResult?: PipelineResult;
+  reason: string;
+}
+
+/** Aggregate result of a batch curation run */
+export interface CurationBatchResult {
+  processed: number;
+  promoted: number;
+  rejected: number;
+  flagged: number;
+  duplicates: number;
+  results: CurationResult[];
+}
+
+/** Configuration for a Curator instance */
+export interface CuratorConfig {
+  tenantId: string;
+  /** When true, all pipeline logic runs but nothing is persisted to the database */
+  dryRun?: boolean;
+  /**
+   * Jaccard similarity threshold for title-based supersession detection.
+   * Range 0.0–1.0. Default 0.6.
+   */
+  supersessionThreshold?: number;
+}

--- a/apps/curator/tsconfig.json
+++ b/apps/curator/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [
+    { "path": "../../packages/schema" },
+    { "path": "../../packages/common" },
+    { "path": "../../packages/store" },
+    { "path": "../../packages/policy-engine" },
+    { "path": "../../packages/claude-runtime" }
+  ]
 }

--- a/apps/git-exporter/package.json
+++ b/apps/git-exporter/package.json
@@ -9,5 +9,13 @@
     "test": "vitest run",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@qmd-team-intent-kb/schema": "workspace:*",
+    "@qmd-team-intent-kb/common": "workspace:*",
+    "@qmd-team-intent-kb/store": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0"
   }
 }

--- a/apps/git-exporter/src/__tests__/change-detector.test.ts
+++ b/apps/git-exporter/src/__tests__/change-detector.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createTestDatabase,
+  MemoryRepository,
+  ExportStateRepository,
+} from '@qmd-team-intent-kb/store';
+import type Database from 'better-sqlite3';
+import { detectChanges } from '../diff/change-detector.js';
+import { makeCuratedMemory, NOW, LATER, TENANT } from './fixtures.js';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+const OUTPUT_DIR = '/tmp/kb-export-test';
+const TARGET_ID = 'kb-export-default';
+
+function makeConfig(tenantId?: string) {
+  return { outputDir: OUTPUT_DIR, targetId: TARGET_ID, tenantId };
+}
+
+describe('detectChanges', () => {
+  let db: Database.Database;
+  let memoryRepo: MemoryRepository;
+  let exportStateRepo: ExportStateRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    memoryRepo = new MemoryRepository(db);
+    exportStateRepo = new ExportStateRepository(db);
+  });
+
+  it('first run with no export state returns all memories', () => {
+    const m1 = makeCuratedMemory({ lifecycle: 'active' });
+    const m2 = makeCuratedMemory({ lifecycle: 'active' });
+    memoryRepo.insert(m1);
+    memoryRepo.insert(m2);
+
+    const changeset = detectChanges(memoryRepo, exportStateRepo, makeConfig());
+    expect(changeset.toWrite).toHaveLength(2);
+    expect(changeset.toArchive).toHaveLength(0);
+    expect(changeset.toRemove).toHaveLength(0);
+  });
+
+  it('subsequent run with no updated memories returns empty changeset', () => {
+    const m = makeCuratedMemory({ updatedAt: NOW });
+    memoryRepo.insert(m);
+    exportStateRepo.set(TARGET_ID, LATER); // export timestamp is after memory
+
+    const changeset = detectChanges(memoryRepo, exportStateRepo, makeConfig());
+    expect(changeset.toWrite).toHaveLength(0);
+    expect(changeset.toArchive).toHaveLength(0);
+  });
+
+  it('detects newly added memory after last export', () => {
+    const old = makeCuratedMemory({ updatedAt: NOW });
+    memoryRepo.insert(old);
+    exportStateRepo.set(TARGET_ID, NOW); // exported exactly at NOW
+
+    const newMemory = makeCuratedMemory({ updatedAt: LATER });
+    memoryRepo.insert(newMemory);
+
+    const changeset = detectChanges(memoryRepo, exportStateRepo, makeConfig());
+    expect(changeset.toWrite).toHaveLength(1);
+    expect(changeset.toWrite[0]?.memory.id).toBe(newMemory.id);
+  });
+
+  it('detects memory updated after last export timestamp', () => {
+    const m = makeCuratedMemory({ updatedAt: NOW });
+    memoryRepo.insert(m);
+    exportStateRepo.set(TARGET_ID, NOW);
+
+    // Simulate update: re-insert with later timestamp
+    memoryRepo.update({ ...m, updatedAt: LATER, version: 2 });
+
+    const changeset = detectChanges(memoryRepo, exportStateRepo, makeConfig());
+    expect(changeset.toWrite).toHaveLength(1);
+  });
+
+  it('superseded memory goes to toArchive', () => {
+    const supersededById = randomUUID();
+    const m = makeCuratedMemory({
+      lifecycle: 'superseded',
+      supersession: { supersededBy: supersededById, reason: 'Updated', linkedAt: NOW },
+    });
+    memoryRepo.insert(m);
+
+    const changeset = detectChanges(memoryRepo, exportStateRepo, makeConfig());
+    expect(changeset.toArchive).toHaveLength(1);
+    expect(changeset.toWrite).toHaveLength(0);
+  });
+
+  it('archived memory goes to toArchive', () => {
+    const m = makeCuratedMemory({ lifecycle: 'archived' });
+    memoryRepo.insert(m);
+
+    const changeset = detectChanges(memoryRepo, exportStateRepo, makeConfig());
+    expect(changeset.toArchive).toHaveLength(1);
+    expect(changeset.toWrite).toHaveLength(0);
+  });
+
+  it('tenant filter returns only memories for that tenant', () => {
+    const m1 = makeCuratedMemory({ tenantId: TENANT });
+    const m2 = makeCuratedMemory({ tenantId: 'team-beta' });
+    memoryRepo.insert(m1);
+    memoryRepo.insert(m2);
+
+    const changeset = detectChanges(memoryRepo, exportStateRepo, makeConfig(TENANT));
+    expect(changeset.toWrite).toHaveLength(1);
+    expect(changeset.toWrite[0]?.memory.tenantId).toBe(TENANT);
+  });
+
+  it('archive toArchive has correct fromPath in category directory', () => {
+    const m = makeCuratedMemory({ category: 'pattern', lifecycle: 'archived' });
+    memoryRepo.insert(m);
+
+    const changeset = detectChanges(memoryRepo, exportStateRepo, makeConfig());
+    const item = changeset.toArchive[0];
+    expect(item).toBeDefined();
+    expect(item!.fromPath).toBe(join(OUTPUT_DIR, 'curated', `${m.id}.md`));
+  });
+
+  it('archive toArchive has correct toPath in archive directory', () => {
+    const m = makeCuratedMemory({ category: 'decision', lifecycle: 'archived' });
+    memoryRepo.insert(m);
+
+    const changeset = detectChanges(memoryRepo, exportStateRepo, makeConfig());
+    const item = changeset.toArchive[0];
+    expect(item).toBeDefined();
+    expect(item!.toPath).toBe(join(OUTPUT_DIR, 'archive', `${m.id}.md`));
+  });
+
+  it('mixed lifecycle memories are correctly distributed across toWrite and toArchive', () => {
+    const active = makeCuratedMemory({ lifecycle: 'active' });
+    const deprecated = makeCuratedMemory({ lifecycle: 'deprecated' });
+    const archived = makeCuratedMemory({ lifecycle: 'archived' });
+    const supersededById = randomUUID();
+    const superseded = makeCuratedMemory({
+      lifecycle: 'superseded',
+      supersession: { supersededBy: supersededById, reason: 'Replaced', linkedAt: NOW },
+    });
+
+    memoryRepo.insert(active);
+    memoryRepo.insert(deprecated);
+    memoryRepo.insert(archived);
+    memoryRepo.insert(superseded);
+
+    const changeset = detectChanges(memoryRepo, exportStateRepo, makeConfig());
+    expect(changeset.toWrite).toHaveLength(2); // active + deprecated
+    expect(changeset.toArchive).toHaveLength(2); // archived + superseded
+  });
+});

--- a/apps/git-exporter/src/__tests__/directory-mapper.test.ts
+++ b/apps/git-exporter/src/__tests__/directory-mapper.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getDirectory,
+  getCategoryDirectory,
+  getRelativePath,
+} from '../formatter/directory-mapper.js';
+import { makeCuratedMemory, NOW } from './fixtures.js';
+import { randomUUID } from 'node:crypto';
+
+describe('getCategoryDirectory', () => {
+  it('maps decision → decisions', () => {
+    expect(getCategoryDirectory('decision')).toBe('decisions');
+  });
+
+  it('maps pattern → curated', () => {
+    expect(getCategoryDirectory('pattern')).toBe('curated');
+  });
+
+  it('maps convention → curated', () => {
+    expect(getCategoryDirectory('convention')).toBe('curated');
+  });
+
+  it('maps architecture → curated', () => {
+    expect(getCategoryDirectory('architecture')).toBe('curated');
+  });
+
+  it('maps troubleshooting → guides', () => {
+    expect(getCategoryDirectory('troubleshooting')).toBe('guides');
+  });
+
+  it('maps reference → guides', () => {
+    expect(getCategoryDirectory('reference')).toBe('guides');
+  });
+
+  it('maps onboarding → guides', () => {
+    expect(getCategoryDirectory('onboarding')).toBe('guides');
+  });
+
+  it('maps unknown category → curated (fallback)', () => {
+    expect(getCategoryDirectory('unknown-category')).toBe('curated');
+  });
+});
+
+describe('getDirectory', () => {
+  it('archived lifecycle → archive regardless of category', () => {
+    const memory = makeCuratedMemory({ category: 'decision', lifecycle: 'archived' });
+    expect(getDirectory(memory)).toBe('archive');
+  });
+
+  it('superseded lifecycle → archive regardless of category', () => {
+    const supersededById = randomUUID();
+    const memory = makeCuratedMemory({
+      category: 'pattern',
+      lifecycle: 'superseded',
+      supersession: { supersededBy: supersededById, reason: 'Updated', linkedAt: NOW },
+    });
+    expect(getDirectory(memory)).toBe('archive');
+  });
+
+  it('active lifecycle uses category mapping', () => {
+    const memory = makeCuratedMemory({ category: 'decision', lifecycle: 'active' });
+    expect(getDirectory(memory)).toBe('decisions');
+  });
+
+  it('deprecated lifecycle uses category mapping', () => {
+    const memory = makeCuratedMemory({ category: 'pattern', lifecycle: 'deprecated' });
+    expect(getDirectory(memory)).toBe('curated');
+  });
+
+  it('active architecture → curated', () => {
+    const memory = makeCuratedMemory({ category: 'architecture', lifecycle: 'active' });
+    expect(getDirectory(memory)).toBe('curated');
+  });
+
+  it('active reference → guides', () => {
+    const memory = makeCuratedMemory({ category: 'reference', lifecycle: 'active' });
+    expect(getDirectory(memory)).toBe('guides');
+  });
+});
+
+describe('getRelativePath', () => {
+  it('combines directory with {id}.md', () => {
+    const memory = makeCuratedMemory({ category: 'decision', lifecycle: 'active' });
+    expect(getRelativePath(memory)).toBe(`decisions/${memory.id}.md`);
+  });
+
+  it('archived memory path uses archive/', () => {
+    const memory = makeCuratedMemory({ category: 'pattern', lifecycle: 'archived' });
+    expect(getRelativePath(memory)).toBe(`archive/${memory.id}.md`);
+  });
+
+  it('pattern memory path uses curated/', () => {
+    const memory = makeCuratedMemory({ category: 'pattern', lifecycle: 'active' });
+    expect(getRelativePath(memory)).toBe(`curated/${memory.id}.md`);
+  });
+
+  it('guides memory path uses guides/', () => {
+    const memory = makeCuratedMemory({ category: 'onboarding', lifecycle: 'active' });
+    expect(getRelativePath(memory)).toBe(`guides/${memory.id}.md`);
+  });
+});

--- a/apps/git-exporter/src/__tests__/exporter.test.ts
+++ b/apps/git-exporter/src/__tests__/exporter.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  createTestDatabase,
+  MemoryRepository,
+  ExportStateRepository,
+} from '@qmd-team-intent-kb/store';
+import type Database from 'better-sqlite3';
+import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { runExport } from '../exporter.js';
+import { makeCuratedMemory, NOW, LATER } from './fixtures.js';
+import { formatMemoryAsMarkdown } from '../formatter/markdown-formatter.js';
+
+function makeConfig(outputDir: string, tenantId?: string) {
+  return { outputDir, targetId: 'kb-export-default', tenantId };
+}
+
+describe('runExport', () => {
+  let db: Database.Database;
+  let memoryRepo: MemoryRepository;
+  let exportStateRepo: ExportStateRepository;
+  let outputDir: string;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    memoryRepo = new MemoryRepository(db);
+    exportStateRepo = new ExportStateRepository(db);
+    outputDir = mkdtempSync(join(tmpdir(), 'git-exporter-run-'));
+  });
+
+  afterEach(() => {
+    rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it('first export writes all active memories', () => {
+    const m1 = makeCuratedMemory({ category: 'pattern', lifecycle: 'active' });
+    const m2 = makeCuratedMemory({ category: 'decision', lifecycle: 'active' });
+    memoryRepo.insert(m1);
+    memoryRepo.insert(m2);
+
+    const result = runExport(memoryRepo, exportStateRepo, makeConfig(outputDir));
+
+    expect(result.written).toHaveLength(2);
+    expect(result.archived).toHaveLength(0);
+    expect(result.removed).toHaveLength(0);
+    expect(result.unchanged).toBe(0);
+    expect(result.totalProcessed).toBe(2);
+  });
+
+  it('re-export with no changes produces no new writes (idempotent)', () => {
+    const m = makeCuratedMemory({ lifecycle: 'active', updatedAt: NOW });
+    memoryRepo.insert(m);
+
+    // First export
+    runExport(memoryRepo, exportStateRepo, makeConfig(outputDir));
+
+    // Second export — nothing has changed
+    const result = runExport(memoryRepo, exportStateRepo, makeConfig(outputDir));
+
+    expect(result.written).toHaveLength(0);
+    expect(result.unchanged).toBe(0); // not in toWrite because filter removes it
+    expect(result.totalProcessed).toBe(0);
+  });
+
+  it('updates export state after run', () => {
+    const m = makeCuratedMemory();
+    memoryRepo.insert(m);
+
+    const before = exportStateRepo.get('kb-export-default');
+    expect(before).toBeNull();
+
+    runExport(memoryRepo, exportStateRepo, makeConfig(outputDir));
+
+    const after = exportStateRepo.get('kb-export-default');
+    expect(after).not.toBeNull();
+    expect(after!.lastExportedAt).toBeDefined();
+  });
+
+  it('written files contain correct frontmatter', () => {
+    const m = makeCuratedMemory({
+      title: 'Test Pattern',
+      category: 'pattern',
+      lifecycle: 'active',
+    });
+    memoryRepo.insert(m);
+
+    const result = runExport(memoryRepo, exportStateRepo, makeConfig(outputDir));
+
+    expect(result.written).toHaveLength(1);
+    const content = readFileSync(result.written[0]!, 'utf8');
+    expect(content).toContain(`id: "${m.id}"`);
+    expect(content).toContain('title: "Test Pattern"');
+    expect(content).toContain('category: "pattern"');
+  });
+
+  it('written files are placed in correct subdirectory', () => {
+    const pattern = makeCuratedMemory({ category: 'pattern', lifecycle: 'active' });
+    const decision = makeCuratedMemory({ category: 'decision', lifecycle: 'active' });
+    const guide = makeCuratedMemory({ category: 'reference', lifecycle: 'active' });
+    memoryRepo.insert(pattern);
+    memoryRepo.insert(decision);
+    memoryRepo.insert(guide);
+
+    const result = runExport(memoryRepo, exportStateRepo, makeConfig(outputDir));
+
+    const paths = result.written;
+    expect(paths.some((p) => p.includes('/curated/'))).toBe(true);
+    expect(paths.some((p) => p.includes('/decisions/'))).toBe(true);
+    expect(paths.some((p) => p.includes('/guides/'))).toBe(true);
+  });
+
+  it('archived memory is moved from category dir to archive dir', () => {
+    // Seed an archived memory directly
+    const m = makeCuratedMemory({ category: 'pattern', lifecycle: 'archived' });
+    memoryRepo.insert(m);
+
+    const result = runExport(memoryRepo, exportStateRepo, makeConfig(outputDir));
+
+    expect(result.archived).toHaveLength(1);
+    expect(result.archived[0]).toContain('/archive/');
+    expect(result.written).toHaveLength(0);
+  });
+
+  it('ExportResult counts are correct for a mixed run', () => {
+    const active = makeCuratedMemory({ lifecycle: 'active' });
+    const archived = makeCuratedMemory({ lifecycle: 'archived' });
+    const supersededById = randomUUID();
+    const superseded = makeCuratedMemory({
+      lifecycle: 'superseded',
+      supersession: { supersededBy: supersededById, reason: 'Replaced', linkedAt: NOW },
+    });
+    memoryRepo.insert(active);
+    memoryRepo.insert(archived);
+    memoryRepo.insert(superseded);
+
+    const result = runExport(memoryRepo, exportStateRepo, makeConfig(outputDir));
+
+    expect(result.written).toHaveLength(1);
+    expect(result.archived).toHaveLength(2);
+    expect(result.totalProcessed).toBe(3);
+  });
+
+  it('new memory added after first export is written on re-export', () => {
+    const m1 = makeCuratedMemory({ lifecycle: 'active', updatedAt: NOW });
+    memoryRepo.insert(m1);
+    // Record NOW as the export timestamp so LATER memories pass the filter
+    runExport(memoryRepo, exportStateRepo, makeConfig(outputDir), () => NOW);
+
+    const m2 = makeCuratedMemory({ lifecycle: 'active', updatedAt: LATER });
+    memoryRepo.insert(m2);
+
+    const result = runExport(memoryRepo, exportStateRepo, makeConfig(outputDir), () => LATER);
+    expect(result.written).toHaveLength(1);
+    expect(result.written[0]).toContain(m2.id);
+  });
+
+  it('memory updated after first export is re-written', () => {
+    const m = makeCuratedMemory({ lifecycle: 'active', updatedAt: NOW });
+    memoryRepo.insert(m);
+    // Record NOW so the subsequent LATER update is detected
+    runExport(memoryRepo, exportStateRepo, makeConfig(outputDir), () => NOW);
+
+    // Update the memory
+    memoryRepo.update({ ...m, content: 'Updated content here', updatedAt: LATER, version: 2 });
+
+    const result = runExport(memoryRepo, exportStateRepo, makeConfig(outputDir), () => LATER);
+    expect(result.written).toHaveLength(1);
+    const content = readFileSync(result.written[0]!, 'utf8');
+    expect(content).toContain('Updated content here');
+  });
+
+  it('superseded memory after first export is archived on re-export', () => {
+    const m = makeCuratedMemory({ lifecycle: 'active', updatedAt: NOW });
+    memoryRepo.insert(m);
+    // Record NOW so the LATER supersession is detected on re-export
+    runExport(memoryRepo, exportStateRepo, makeConfig(outputDir), () => NOW);
+
+    // Transition to superseded
+    const supersededById = randomUUID();
+    memoryRepo.update({
+      ...m,
+      lifecycle: 'superseded',
+      supersession: { supersededBy: supersededById, reason: 'Replaced', linkedAt: LATER },
+      updatedAt: LATER,
+      version: 2,
+    });
+
+    const result = runExport(memoryRepo, exportStateRepo, makeConfig(outputDir), () => LATER);
+    expect(result.archived).toHaveLength(1);
+    expect(result.archived[0]).toContain('/archive/');
+    expect(result.written).toHaveLength(0);
+  });
+
+  it('full cycle: write → supersede → re-export → archive removes source file', () => {
+    // Step 1: initial export — record NOW as the export timestamp
+    const m = makeCuratedMemory({ category: 'pattern', lifecycle: 'active', updatedAt: NOW });
+    memoryRepo.insert(m);
+    const first = runExport(memoryRepo, exportStateRepo, makeConfig(outputDir), () => NOW);
+    expect(first.written).toHaveLength(1);
+    const originalPath = first.written[0]!;
+    expect(existsSync(originalPath)).toBe(true);
+
+    // Step 2: supersede and re-export — LATER > NOW so the update is detected
+    const supersededById = randomUUID();
+    memoryRepo.update({
+      ...m,
+      lifecycle: 'superseded',
+      supersession: { supersededBy: supersededById, reason: 'Replaced', linkedAt: LATER },
+      updatedAt: LATER,
+      version: 2,
+    });
+    const second = runExport(memoryRepo, exportStateRepo, makeConfig(outputDir), () => LATER);
+
+    // Original file is removed, archive file is created
+    expect(existsSync(originalPath)).toBe(false);
+    expect(second.archived).toHaveLength(1);
+    expect(existsSync(second.archived[0]!)).toBe(true);
+  });
+
+  it('empty database produces an empty result', () => {
+    const result = runExport(memoryRepo, exportStateRepo, makeConfig(outputDir));
+    expect(result.written).toHaveLength(0);
+    expect(result.archived).toHaveLength(0);
+    expect(result.removed).toHaveLength(0);
+    expect(result.unchanged).toBe(0);
+    expect(result.totalProcessed).toBe(0);
+  });
+
+  it('idempotency check increments unchanged count when file content matches', () => {
+    const m = makeCuratedMemory({ lifecycle: 'active', updatedAt: NOW });
+    memoryRepo.insert(m);
+
+    // First export creates the file
+    runExport(memoryRepo, exportStateRepo, makeConfig(outputDir));
+
+    // Manually force the memory into toWrite by resetting export state
+    // so it passes the date filter, but content hasn't changed.
+    // Write the file with identical content before second export
+    const filePath = join(outputDir, 'curated', `${m.id}.md`);
+    const content = formatMemoryAsMarkdown(m);
+    mkdirSync(join(outputDir, 'curated'), { recursive: true });
+    writeFileSync(filePath, content, 'utf8');
+
+    // Force re-run via state manipulation: set lastExportedAt before memory's updatedAt
+    exportStateRepo.set('kb-export-default', '2025-01-01T00:00:00.000Z');
+
+    const result = runExport(memoryRepo, exportStateRepo, makeConfig(outputDir));
+    expect(result.unchanged).toBe(1);
+    expect(result.written).toHaveLength(0);
+  });
+});

--- a/apps/git-exporter/src/__tests__/file-writer.test.ts
+++ b/apps/git-exporter/src/__tests__/file-writer.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { writeFile, archiveFile, removeFile } from '../writer/file-writer.js';
+
+describe('writeFile', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'git-exporter-write-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('creates file and parent directories', () => {
+    const filePath = join(dir, 'subdir', 'nested', 'file.md');
+    writeFile(filePath, 'hello world');
+    expect(existsSync(filePath)).toBe(true);
+    expect(readFileSync(filePath, 'utf8')).toBe('hello world');
+  });
+
+  it('overwrites existing file with new content', () => {
+    const filePath = join(dir, 'file.md');
+    writeFile(filePath, 'original');
+    writeFile(filePath, 'updated');
+    expect(readFileSync(filePath, 'utf8')).toBe('updated');
+  });
+
+  it('creates file with exact content (no trailing mutation)', () => {
+    const content = '---\nid: "abc"\n---\n\n# Title\n\nContent\n';
+    const filePath = join(dir, 'memory.md');
+    writeFile(filePath, content);
+    expect(readFileSync(filePath, 'utf8')).toBe(content);
+  });
+});
+
+describe('archiveFile', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'git-exporter-archive-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('removes source file and writes to destination', () => {
+    const fromPath = join(dir, 'curated', 'mem.md');
+    const toPath = join(dir, 'archive', 'mem.md');
+    mkdirSync(join(dir, 'curated'), { recursive: true });
+    writeFileSync(fromPath, 'old content', 'utf8');
+
+    archiveFile(fromPath, toPath, 'new content');
+
+    expect(existsSync(fromPath)).toBe(false);
+    expect(existsSync(toPath)).toBe(true);
+    expect(readFileSync(toPath, 'utf8')).toBe('new content');
+  });
+
+  it('writes to destination even when source does not exist', () => {
+    const fromPath = join(dir, 'curated', 'nonexistent.md');
+    const toPath = join(dir, 'archive', 'mem.md');
+
+    archiveFile(fromPath, toPath, 'archive content');
+
+    expect(existsSync(toPath)).toBe(true);
+    expect(readFileSync(toPath, 'utf8')).toBe('archive content');
+  });
+
+  it('creates destination parent directories', () => {
+    const toPath = join(dir, 'deep', 'nested', 'archive', 'mem.md');
+    archiveFile(join(dir, 'nonexistent.md'), toPath, 'content');
+    expect(existsSync(toPath)).toBe(true);
+  });
+});
+
+describe('removeFile', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'git-exporter-remove-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('deletes file and returns true', () => {
+    const filePath = join(dir, 'file.md');
+    writeFileSync(filePath, 'content', 'utf8');
+
+    const result = removeFile(filePath);
+    expect(result).toBe(true);
+    expect(existsSync(filePath)).toBe(false);
+  });
+
+  it('returns false for non-existent file', () => {
+    const filePath = join(dir, 'nonexistent.md');
+    const result = removeFile(filePath);
+    expect(result).toBe(false);
+  });
+});

--- a/apps/git-exporter/src/__tests__/fixtures.ts
+++ b/apps/git-exporter/src/__tests__/fixtures.ts
@@ -1,0 +1,42 @@
+import { randomUUID } from 'node:crypto';
+import { CuratedMemory } from '@qmd-team-intent-kb/schema';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+
+export const NOW = '2026-01-15T10:00:00.000Z';
+export const LATER = '2026-01-16T10:00:00.000Z';
+export const TENANT = 'team-alpha';
+
+/**
+ * Build a valid CuratedMemory, merging optional overrides.
+ * `contentHash` is computed from the resolved `content` unless explicitly overridden.
+ */
+export function makeCuratedMemory(overrides?: Record<string, unknown>): CuratedMemory {
+  const defaultContent = 'Use dependency injection for all services';
+  const base: Record<string, unknown> = {
+    id: randomUUID(),
+    candidateId: randomUUID(),
+    source: 'claude_session',
+    content: defaultContent,
+    title: 'Dependency injection pattern',
+    category: 'pattern',
+    trustLevel: 'high',
+    sensitivity: 'internal',
+    author: { type: 'ai', id: 'claude-1' },
+    tenantId: TENANT,
+    metadata: { filePaths: [], tags: ['di', 'architecture'] },
+    lifecycle: 'active',
+    policyEvaluations: [],
+    promotedAt: NOW,
+    promotedBy: { type: 'system', id: 'curator' },
+    updatedAt: NOW,
+    version: 1,
+    ...overrides,
+  };
+
+  const resolvedContent = typeof base['content'] === 'string' ? base['content'] : defaultContent;
+  if (base['contentHash'] === undefined) {
+    base['contentHash'] = computeContentHash(resolvedContent);
+  }
+
+  return CuratedMemory.parse(base);
+}

--- a/apps/git-exporter/src/__tests__/frontmatter.test.ts
+++ b/apps/git-exporter/src/__tests__/frontmatter.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { extractFrontmatter, renderFrontmatter } from '../formatter/frontmatter.js';
+import { makeCuratedMemory, NOW, TENANT } from './fixtures.js';
+import { randomUUID } from 'node:crypto';
+
+describe('extractFrontmatter', () => {
+  it('extracts id from memory', () => {
+    const memory = makeCuratedMemory();
+    const fm = extractFrontmatter(memory);
+    expect(fm.id).toBe(memory.id);
+  });
+
+  it('extracts title from memory', () => {
+    const memory = makeCuratedMemory({ title: 'My Pattern' });
+    const fm = extractFrontmatter(memory);
+    expect(fm.title).toBe('My Pattern');
+  });
+
+  it('extracts category from memory', () => {
+    const memory = makeCuratedMemory({ category: 'decision' });
+    const fm = extractFrontmatter(memory);
+    expect(fm.category).toBe('decision');
+  });
+
+  it('formats author as "type:id"', () => {
+    const memory = makeCuratedMemory({ author: { type: 'human', id: 'alice' } });
+    const fm = extractFrontmatter(memory);
+    expect(fm.author).toBe('human:alice');
+  });
+
+  it('extracts tags from metadata', () => {
+    const memory = makeCuratedMemory({ metadata: { filePaths: [], tags: ['di', 'architecture'] } });
+    const fm = extractFrontmatter(memory);
+    expect(fm.tags).toEqual(['di', 'architecture']);
+  });
+
+  it('extracts empty tags when metadata.tags is empty', () => {
+    const memory = makeCuratedMemory({ metadata: { filePaths: [], tags: [] } });
+    const fm = extractFrontmatter(memory);
+    expect(fm.tags).toEqual([]);
+  });
+
+  it('includes supersededBy when supersession is present', () => {
+    const supersededById = randomUUID();
+    const memory = makeCuratedMemory({
+      lifecycle: 'superseded',
+      supersession: {
+        supersededBy: supersededById,
+        reason: 'Updated version',
+        linkedAt: NOW,
+      },
+    });
+    const fm = extractFrontmatter(memory);
+    expect(fm.supersededBy).toBe(supersededById);
+  });
+
+  it('omits supersededBy when supersession is absent', () => {
+    const memory = makeCuratedMemory({ lifecycle: 'active' });
+    const fm = extractFrontmatter(memory);
+    expect(fm.supersededBy).toBeUndefined();
+  });
+
+  it('extracts all scalar fields correctly', () => {
+    const memory = makeCuratedMemory();
+    const fm = extractFrontmatter(memory);
+    expect(fm.lifecycle).toBe('active');
+    expect(fm.trustLevel).toBe('high');
+    expect(fm.sensitivity).toBe('internal');
+    expect(fm.tenantId).toBe(TENANT);
+    expect(fm.contentHash).toBe(memory.contentHash);
+    expect(fm.promotedAt).toBe(NOW);
+    expect(fm.updatedAt).toBe(NOW);
+    expect(fm.version).toBe(1);
+  });
+});
+
+describe('renderFrontmatter', () => {
+  it('starts and ends with ---', () => {
+    const memory = makeCuratedMemory();
+    const rendered = renderFrontmatter(extractFrontmatter(memory));
+    const lines = rendered.split('\n');
+    expect(lines[0]).toBe('---');
+    expect(lines[lines.length - 1]).toBe('---');
+  });
+
+  it('renders all keys in deterministic order', () => {
+    const memory = makeCuratedMemory();
+    const rendered = renderFrontmatter(extractFrontmatter(memory));
+    const lines = rendered.split('\n');
+    const keys = lines
+      .filter((l) => l.includes(':') && !l.startsWith('---') && !l.startsWith('  '))
+      .map((l) => l.split(':')[0]);
+    expect(keys).toEqual([
+      'id',
+      'title',
+      'category',
+      'lifecycle',
+      'trust_level',
+      'sensitivity',
+      'tenant_id',
+      'content_hash',
+      'author',
+      'promoted_at',
+      'updated_at',
+      'version',
+      'tags',
+    ]);
+  });
+
+  it('quotes all string values', () => {
+    const memory = makeCuratedMemory({ title: 'Simple title' });
+    const rendered = renderFrontmatter(extractFrontmatter(memory));
+    expect(rendered).toContain('title: "Simple title"');
+    expect(rendered).toContain('category: "pattern"');
+    expect(rendered).toContain('lifecycle: "active"');
+  });
+
+  it('renders tags array with quoted items', () => {
+    const memory = makeCuratedMemory({ metadata: { filePaths: [], tags: ['di', 'architecture'] } });
+    const rendered = renderFrontmatter(extractFrontmatter(memory));
+    expect(rendered).toContain('tags:');
+    expect(rendered).toContain('  - "di"');
+    expect(rendered).toContain('  - "architecture"');
+  });
+
+  it('renders empty tags as tags: []', () => {
+    const memory = makeCuratedMemory({ metadata: { filePaths: [], tags: [] } });
+    const rendered = renderFrontmatter(extractFrontmatter(memory));
+    expect(rendered).toContain('tags: []');
+  });
+
+  it('includes superseded_by when supersession is present', () => {
+    const supersededById = randomUUID();
+    const memory = makeCuratedMemory({
+      lifecycle: 'superseded',
+      supersession: {
+        supersededBy: supersededById,
+        reason: 'Updated',
+        linkedAt: NOW,
+      },
+    });
+    const rendered = renderFrontmatter(extractFrontmatter(memory));
+    expect(rendered).toContain(`superseded_by: "${supersededById}"`);
+  });
+
+  it('omits superseded_by when supersession is absent', () => {
+    const memory = makeCuratedMemory({ lifecycle: 'active' });
+    const rendered = renderFrontmatter(extractFrontmatter(memory));
+    expect(rendered).not.toContain('superseded_by');
+  });
+
+  it('escapes double quotes in title', () => {
+    const memory = makeCuratedMemory({ title: 'Pattern: use "strict" mode' });
+    const rendered = renderFrontmatter(extractFrontmatter(memory));
+    expect(rendered).toContain('title: "Pattern: use \\"strict\\" mode"');
+  });
+
+  it('escapes backslashes in title', () => {
+    const memory = makeCuratedMemory({ title: 'Path is C:\\\\Users' });
+    const rendered = renderFrontmatter(extractFrontmatter(memory));
+    expect(rendered).toContain('title: "Path is C:\\\\\\\\Users"');
+  });
+
+  it('renders version as an unquoted integer', () => {
+    const memory = makeCuratedMemory({ version: 3 });
+    const rendered = renderFrontmatter(extractFrontmatter(memory));
+    expect(rendered).toContain('version: 3');
+    expect(rendered).not.toContain('version: "3"');
+  });
+});

--- a/apps/git-exporter/src/__tests__/markdown-formatter.test.ts
+++ b/apps/git-exporter/src/__tests__/markdown-formatter.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { formatMemoryAsMarkdown, getFilename } from '../formatter/markdown-formatter.js';
+import { makeCuratedMemory } from './fixtures.js';
+
+describe('formatMemoryAsMarkdown', () => {
+  it('produces a document that starts with ---', () => {
+    const memory = makeCuratedMemory();
+    const doc = formatMemoryAsMarkdown(memory);
+    expect(doc.startsWith('---\n')).toBe(true);
+  });
+
+  it('includes the frontmatter block closed with ---', () => {
+    const memory = makeCuratedMemory();
+    const doc = formatMemoryAsMarkdown(memory);
+    const lines = doc.split('\n');
+    // First line is ---, second --- that closes frontmatter should exist
+    const closingIdx = lines.indexOf('---', 1);
+    expect(closingIdx).toBeGreaterThan(0);
+  });
+
+  it('heading matches the memory title', () => {
+    const memory = makeCuratedMemory({ title: 'My Custom Pattern' });
+    const doc = formatMemoryAsMarkdown(memory);
+    expect(doc).toContain('# My Custom Pattern\n');
+  });
+
+  it('content is preserved verbatim', () => {
+    const content = 'Use dependency injection for all services';
+    const memory = makeCuratedMemory({ content });
+    const doc = formatMemoryAsMarkdown(memory);
+    expect(doc).toContain(content);
+  });
+
+  it('preserves multi-line content verbatim', () => {
+    const content = 'Line one\nLine two\nLine three';
+    const memory = makeCuratedMemory({ content });
+    const doc = formatMemoryAsMarkdown(memory);
+    expect(doc).toContain('Line one\nLine two\nLine three');
+  });
+
+  it('document structure is frontmatter + blank line + heading + blank line + content + trailing newline', () => {
+    const memory = makeCuratedMemory({
+      title: 'Test Title',
+      content: 'Test content here.',
+    });
+    const doc = formatMemoryAsMarkdown(memory);
+    // After the closing ---, expect \n\n# Title\n\nContent\n
+    const afterFrontmatter = doc.substring(doc.lastIndexOf('---') + 3);
+    expect(afterFrontmatter).toBe('\n\n# Test Title\n\nTest content here.\n');
+  });
+});
+
+describe('getFilename', () => {
+  it('returns {id}.md', () => {
+    const memory = makeCuratedMemory();
+    expect(getFilename(memory)).toBe(`${memory.id}.md`);
+  });
+
+  it('filename changes when id changes', () => {
+    const m1 = makeCuratedMemory();
+    const m2 = makeCuratedMemory();
+    expect(getFilename(m1)).not.toBe(getFilename(m2));
+  });
+});

--- a/apps/git-exporter/src/diff/change-detector.ts
+++ b/apps/git-exporter/src/diff/change-detector.ts
@@ -1,0 +1,56 @@
+import type { MemoryRepository, ExportStateRepository } from '@qmd-team-intent-kb/store';
+import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
+import type { ExportChangeset, ExportConfig } from '../types.js';
+import { getRelativePath, getCategoryDirectory } from '../formatter/directory-mapper.js';
+import { join } from 'node:path';
+
+/**
+ * Detect what has changed since the last export and build a changeset.
+ *
+ * - First run (no export state): returns all memories across all lifecycle states.
+ * - Subsequent runs: only memories whose `updatedAt` is strictly after `lastExportedAt`.
+ *
+ * Active / deprecated memories → `toWrite`
+ * Archived / superseded memories → `toArchive` (move from category dir to archive/)
+ */
+export function detectChanges(
+  memoryRepo: MemoryRepository,
+  exportStateRepo: ExportStateRepository,
+  config: ExportConfig,
+): ExportChangeset {
+  const exportState = exportStateRepo.get(config.targetId);
+
+  let memories: CuratedMemory[];
+
+  if (config.tenantId !== undefined) {
+    memories = memoryRepo.findByTenant(config.tenantId);
+  } else {
+    const active = memoryRepo.findByLifecycle('active');
+    const deprecated = memoryRepo.findByLifecycle('deprecated');
+    const superseded = memoryRepo.findByLifecycle('superseded');
+    const archived = memoryRepo.findByLifecycle('archived');
+    memories = [...active, ...deprecated, ...superseded, ...archived];
+  }
+
+  if (exportState !== null) {
+    memories = memories.filter((m) => m.updatedAt > exportState.lastExportedAt);
+  }
+
+  const toWrite: ExportChangeset['toWrite'] = [];
+  const toArchive: ExportChangeset['toArchive'] = [];
+
+  for (const memory of memories) {
+    if (memory.lifecycle === 'archived' || memory.lifecycle === 'superseded') {
+      // File may currently live in its category directory (from when it was active).
+      const categoryDir = getCategoryDirectory(memory.category);
+      const fromPath = join(config.outputDir, categoryDir, `${memory.id}.md`);
+      const toPath = join(config.outputDir, getRelativePath(memory));
+      toArchive.push({ memory, fromPath, toPath });
+    } else {
+      const filePath = join(config.outputDir, getRelativePath(memory));
+      toWrite.push({ memory, filePath });
+    }
+  }
+
+  return { toWrite, toArchive, toRemove: [] };
+}

--- a/apps/git-exporter/src/exporter.ts
+++ b/apps/git-exporter/src/exporter.ts
@@ -1,0 +1,79 @@
+import type { MemoryRepository, ExportStateRepository } from '@qmd-team-intent-kb/store';
+import type { ExportConfig, ExportResult } from './types.js';
+import { detectChanges } from './diff/change-detector.js';
+import { formatMemoryAsMarkdown } from './formatter/markdown-formatter.js';
+import { writeFile, archiveFile, removeFile } from './writer/file-writer.js';
+import { readFileSync, existsSync } from 'node:fs';
+
+/**
+ * Main export orchestrator.
+ *
+ * Steps:
+ * 1. Detect changes since last export
+ * 2. Write new/updated files to their category directory
+ * 3. Archive superseded/archived files to `archive/`
+ * 4. Remove deleted files (changeset `toRemove`)
+ * 5. Record the current timestamp as the new export state
+ *
+ * Idempotent: re-running when there are no changes produces no file writes.
+ * Does NOT run `git commit` or `git push` — file generation only.
+ *
+ * @param nowFn - Optional injectable clock, defaults to `new Date().toISOString()`.
+ *                Pass a deterministic value in tests to avoid real-time skew.
+ */
+export function runExport(
+  memoryRepo: MemoryRepository,
+  exportStateRepo: ExportStateRepository,
+  config: ExportConfig,
+  nowFn: () => string = () => new Date().toISOString(),
+): ExportResult {
+  const changeset = detectChanges(memoryRepo, exportStateRepo, config);
+
+  const written: string[] = [];
+  const archived: string[] = [];
+  const removed: string[] = [];
+  let unchanged = 0;
+
+  // Write new/updated files
+  for (const item of changeset.toWrite) {
+    const content = formatMemoryAsMarkdown(item.memory);
+
+    // Skip if the file already contains identical content (idempotency guard)
+    if (existsSync(item.filePath)) {
+      const existing = readFileSync(item.filePath, 'utf8');
+      if (existing === content) {
+        unchanged++;
+        continue;
+      }
+    }
+
+    writeFile(item.filePath, content);
+    written.push(item.filePath);
+  }
+
+  // Move archived/superseded files from category dir → archive/
+  for (const item of changeset.toArchive) {
+    const content = formatMemoryAsMarkdown(item.memory);
+    archiveFile(item.fromPath, item.toPath, content);
+    archived.push(item.toPath);
+  }
+
+  // Remove explicitly deleted files
+  for (const filePath of changeset.toRemove) {
+    if (removeFile(filePath)) {
+      removed.push(filePath);
+    }
+  }
+
+  // Persist the new export state timestamp
+  exportStateRepo.set(config.targetId, nowFn());
+
+  return {
+    written,
+    archived,
+    removed,
+    unchanged,
+    totalProcessed:
+      changeset.toWrite.length + changeset.toArchive.length + changeset.toRemove.length,
+  };
+}

--- a/apps/git-exporter/src/formatter/directory-mapper.ts
+++ b/apps/git-exporter/src/formatter/directory-mapper.ts
@@ -1,0 +1,49 @@
+import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
+
+/**
+ * Resolve the export subdirectory for a memory.
+ *
+ * Lifecycle takes precedence over category:
+ * - `archived` or `superseded` → `archive/`
+ *
+ * Category mapping (active / deprecated):
+ * - `decision`                                → `decisions/`
+ * - `pattern`, `convention`, `architecture`  → `curated/`
+ * - `troubleshooting`, `reference`, `onboarding` → `guides/`
+ * - unknown / fallback                        → `curated/`
+ */
+export function getDirectory(memory: CuratedMemory): string {
+  if (memory.lifecycle === 'archived' || memory.lifecycle === 'superseded') {
+    return 'archive';
+  }
+  return getCategoryDirectory(memory.category);
+}
+
+/**
+ * Map a category string to its export subdirectory name.
+ * Does not consider lifecycle — use {@link getDirectory} for that.
+ */
+export function getCategoryDirectory(category: string): string {
+  switch (category) {
+    case 'decision':
+      return 'decisions';
+    case 'pattern':
+    case 'convention':
+    case 'architecture':
+      return 'curated';
+    case 'troubleshooting':
+    case 'reference':
+    case 'onboarding':
+      return 'guides';
+    default:
+      return 'curated';
+  }
+}
+
+/**
+ * Get the full relative path for a memory file within the export directory.
+ * Format: `{directory}/{id}.md`
+ */
+export function getRelativePath(memory: CuratedMemory): string {
+  return `${getDirectory(memory)}/${memory.id}.md`;
+}

--- a/apps/git-exporter/src/formatter/frontmatter.ts
+++ b/apps/git-exporter/src/formatter/frontmatter.ts
@@ -1,0 +1,67 @@
+import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
+import type { FrontmatterData } from '../types.js';
+
+/**
+ * Extract frontmatter data from a CuratedMemory.
+ */
+export function extractFrontmatter(memory: CuratedMemory): FrontmatterData {
+  return {
+    id: memory.id,
+    title: memory.title,
+    category: memory.category,
+    lifecycle: memory.lifecycle,
+    trustLevel: memory.trustLevel,
+    sensitivity: memory.sensitivity,
+    tenantId: memory.tenantId,
+    contentHash: memory.contentHash,
+    author: `${memory.author.type}:${memory.author.id}`,
+    promotedAt: memory.promotedAt,
+    updatedAt: memory.updatedAt,
+    version: memory.version,
+    tags: memory.metadata.tags,
+    supersededBy: memory.supersession?.supersededBy,
+  };
+}
+
+/**
+ * Render YAML frontmatter string from FrontmatterData.
+ *
+ * String-templated (no yaml library), deterministic key order, quoted strings.
+ * Output begins and ends with `---` on its own line.
+ */
+export function renderFrontmatter(data: FrontmatterData): string {
+  const lines: string[] = ['---'];
+
+  lines.push(`id: "${data.id}"`);
+  lines.push(`title: "${escapeYamlString(data.title)}"`);
+  lines.push(`category: "${data.category}"`);
+  lines.push(`lifecycle: "${data.lifecycle}"`);
+  lines.push(`trust_level: "${data.trustLevel}"`);
+  lines.push(`sensitivity: "${data.sensitivity}"`);
+  lines.push(`tenant_id: "${data.tenantId}"`);
+  lines.push(`content_hash: "${data.contentHash}"`);
+  lines.push(`author: "${data.author}"`);
+  lines.push(`promoted_at: "${data.promotedAt}"`);
+  lines.push(`updated_at: "${data.updatedAt}"`);
+  lines.push(`version: ${data.version}`);
+
+  if (data.tags.length > 0) {
+    lines.push(`tags:`);
+    for (const tag of data.tags) {
+      lines.push(`  - "${escapeYamlString(tag)}"`);
+    }
+  } else {
+    lines.push(`tags: []`);
+  }
+
+  if (data.supersededBy !== undefined) {
+    lines.push(`superseded_by: "${data.supersededBy}"`);
+  }
+
+  lines.push('---');
+  return lines.join('\n');
+}
+
+function escapeYamlString(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}

--- a/apps/git-exporter/src/formatter/markdown-formatter.ts
+++ b/apps/git-exporter/src/formatter/markdown-formatter.ts
@@ -1,0 +1,28 @@
+import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
+import { extractFrontmatter, renderFrontmatter } from './frontmatter.js';
+
+/**
+ * Format a CuratedMemory as a full Markdown document with YAML frontmatter.
+ *
+ * Structure:
+ * ```
+ * ---
+ * <frontmatter>
+ * ---
+ *
+ * # <title>
+ *
+ * <content>
+ * ```
+ */
+export function formatMemoryAsMarkdown(memory: CuratedMemory): string {
+  const frontmatter = renderFrontmatter(extractFrontmatter(memory));
+  return `${frontmatter}\n\n# ${memory.title}\n\n${memory.content}\n`;
+}
+
+/**
+ * Generate the filename for a memory: `{id}.md`
+ */
+export function getFilename(memory: CuratedMemory): string {
+  return `${memory.id}.md`;
+}

--- a/apps/git-exporter/src/index.ts
+++ b/apps/git-exporter/src/index.ts
@@ -1,3 +1,11 @@
-// TODO: Git export mirror — publish curated knowledge to git repos (Phase 7)
-
-export const name = '@qmd-team-intent-kb/git-exporter';
+export type { ExportConfig, ExportResult, FrontmatterData, ExportChangeset } from './types.js';
+export { extractFrontmatter, renderFrontmatter } from './formatter/frontmatter.js';
+export { formatMemoryAsMarkdown, getFilename } from './formatter/markdown-formatter.js';
+export {
+  getDirectory,
+  getCategoryDirectory,
+  getRelativePath,
+} from './formatter/directory-mapper.js';
+export { detectChanges } from './diff/change-detector.js';
+export { writeFile, archiveFile, removeFile } from './writer/file-writer.js';
+export { runExport } from './exporter.js';

--- a/apps/git-exporter/src/types.ts
+++ b/apps/git-exporter/src/types.ts
@@ -1,0 +1,46 @@
+import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
+
+export interface ExportConfig {
+  /** Root directory for exported files (e.g., kb-export/) */
+  outputDir: string;
+  /** Identifier for this export target (e.g., 'kb-export-default') */
+  targetId: string;
+  /** Optional tenant filter */
+  tenantId?: string;
+}
+
+export interface ExportResult {
+  /** File paths written */
+  written: string[];
+  /** File paths moved to archive */
+  archived: string[];
+  /** File paths removed */
+  removed: string[];
+  /** Count of files that didn't need updating */
+  unchanged: number;
+  totalProcessed: number;
+}
+
+export interface FrontmatterData {
+  id: string;
+  title: string;
+  category: string;
+  lifecycle: string;
+  trustLevel: string;
+  sensitivity: string;
+  tenantId: string;
+  contentHash: string;
+  /** "type:id" format */
+  author: string;
+  promotedAt: string;
+  updatedAt: string;
+  version: number;
+  tags: string[];
+  supersededBy?: string;
+}
+
+export interface ExportChangeset {
+  toWrite: Array<{ memory: CuratedMemory; filePath: string }>;
+  toArchive: Array<{ memory: CuratedMemory; fromPath: string; toPath: string }>;
+  toRemove: string[];
+}

--- a/apps/git-exporter/src/writer/file-writer.ts
+++ b/apps/git-exporter/src/writer/file-writer.ts
@@ -1,0 +1,39 @@
+import { writeFileSync, mkdirSync, unlinkSync, existsSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/**
+ * Write content to a file, creating all parent directories as needed.
+ */
+export function writeFile(filePath: string, content: string): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, 'utf8');
+}
+
+/**
+ * Archive a memory file by removing it from `fromPath` (if it exists)
+ * and writing updated content to `toPath`.
+ *
+ * If the source file does not exist, writes directly to the destination.
+ */
+export function archiveFile(fromPath: string, toPath: string, content: string): void {
+  mkdirSync(dirname(toPath), { recursive: true });
+
+  if (existsSync(fromPath)) {
+    unlinkSync(fromPath);
+  }
+
+  writeFileSync(toPath, content, 'utf8');
+}
+
+/**
+ * Remove a file if it exists.
+ *
+ * @returns `true` if the file was deleted, `false` if it did not exist.
+ */
+export function removeFile(filePath: string): boolean {
+  if (existsSync(filePath)) {
+    unlinkSync(filePath);
+    return true;
+  }
+  return false;
+}

--- a/apps/git-exporter/tsconfig.json
+++ b/apps/git-exporter/tsconfig.json
@@ -2,7 +2,15 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [
+    { "path": "../../packages/schema" },
+    { "path": "../../packages/common" },
+    { "path": "../../packages/store" }
+  ]
 }

--- a/packages/policy-engine/package.json
+++ b/packages/policy-engine/package.json
@@ -17,5 +17,10 @@
     "test": "vitest run",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@qmd-team-intent-kb/schema": "workspace:*",
+    "@qmd-team-intent-kb/common": "workspace:*",
+    "@qmd-team-intent-kb/claude-runtime": "workspace:*"
   }
 }

--- a/packages/policy-engine/src/__tests__/content-length-rule.test.ts
+++ b/packages/policy-engine/src/__tests__/content-length-rule.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { MemoryCandidate, GovernancePolicy } from '@qmd-team-intent-kb/schema';
+import { evaluateContentLength } from '../rules/content-length-rule.js';
+import type { EvaluationContext } from '../types.js';
+
+function makeCandidate(content: string) {
+  return MemoryCandidate.parse({
+    id: randomUUID(),
+    status: 'inbox',
+    source: 'claude_session',
+    content,
+    title: 'Test candidate',
+    category: 'convention',
+    trustLevel: 'medium',
+    author: { type: 'ai', id: 'claude-1' },
+    tenantId: 'team-alpha',
+    metadata: { filePaths: [], tags: [] },
+    prePolicyFlags: { potentialSecret: false, lowConfidence: false, duplicateSuspect: false },
+    capturedAt: '2026-01-15T10:00:00.000Z',
+  });
+}
+
+function makeRule(parameters: Record<string, unknown> = {}) {
+  return {
+    id: 'rule-content-length',
+    type: 'content_length' as const,
+    action: 'reject' as const,
+    enabled: true,
+    priority: 0,
+    parameters,
+  };
+}
+
+function makeContext(candidate: MemoryCandidate): EvaluationContext {
+  return {
+    candidate,
+    policy: GovernancePolicy.parse({
+      id: randomUUID(),
+      name: 'Test Policy',
+      tenantId: 'team-alpha',
+      rules: [makeRule()],
+      enabled: true,
+      version: 1,
+      createdAt: '2026-01-15T10:00:00.000Z',
+      updatedAt: '2026-01-15T10:00:00.000Z',
+    }),
+  };
+}
+
+describe('evaluateContentLength', () => {
+  it('rejects content below default minimum length', () => {
+    // Default min is 10; provide 5 chars
+    const candidate = makeCandidate('short');
+    const rule = makeRule();
+    const result = evaluateContentLength(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('fail');
+    expect(result.reason).toContain('too short');
+    expect(result.reason).toContain('5');
+    expect(result.reason).toContain('10');
+  });
+
+  it('rejects content above default maximum length', () => {
+    // Default max is 50000; provide 50001 chars
+    const content = 'x'.repeat(50001);
+    const candidate = makeCandidate(content);
+    const rule = makeRule();
+    const result = evaluateContentLength(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('fail');
+    expect(result.reason).toContain('too long');
+    expect(result.reason).toContain('50001');
+    expect(result.reason).toContain('50000');
+  });
+
+  it('passes content within default bounds', () => {
+    const content = 'Use Result<T, E> for all fallible operations in the codebase';
+    const candidate = makeCandidate(content);
+    const rule = makeRule();
+    const result = evaluateContentLength(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('pass');
+    expect(result.score).toBeDefined();
+    expect(result.score).toBeGreaterThan(0);
+    expect(result.score).toBeLessThanOrEqual(1);
+  });
+
+  it('uses default min=10 max=50000 when parameters are empty', () => {
+    // Exactly 10 chars — on the boundary, should pass
+    const candidate = makeCandidate('0123456789');
+    const rule = makeRule({});
+    const result = evaluateContentLength(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('pass');
+  });
+
+  it('respects custom min parameter', () => {
+    // content is 20 chars, custom min is 50 — should fail
+    const content = 'exactly twenty chars!';
+    const candidate = makeCandidate(content);
+    const rule = makeRule({ min: 50 });
+    const result = evaluateContentLength(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('fail');
+    expect(result.reason).toContain('50');
+  });
+
+  it('respects custom max parameter', () => {
+    // content is 100 chars, custom max is 50 — should fail
+    const content = 'x'.repeat(100);
+    const candidate = makeCandidate(content);
+    const rule = makeRule({ max: 50 });
+    const result = evaluateContentLength(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('fail');
+    expect(result.reason).toContain('50');
+  });
+
+  it('returns normalized score equal to content.length / max on pass', () => {
+    // Use custom max=1000 and content of length 500 — score should be 0.5
+    const content = 'x'.repeat(500);
+    const candidate = makeCandidate(content);
+    const rule = makeRule({ min: 10, max: 1000 });
+    const result = evaluateContentLength(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('pass');
+    expect(result.score).toBeCloseTo(0.5, 5);
+  });
+});

--- a/packages/policy-engine/src/__tests__/dedup-check-rule.test.ts
+++ b/packages/policy-engine/src/__tests__/dedup-check-rule.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { MemoryCandidate, GovernancePolicy } from '@qmd-team-intent-kb/schema';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import { evaluateDedupCheck } from '../rules/dedup-check-rule.js';
+import type { EvaluationContext } from '../types.js';
+
+const CLEAN_CONTENT = 'Use Result<T, E> for all fallible operations in the codebase';
+
+function makeCandidate(content = CLEAN_CONTENT) {
+  return MemoryCandidate.parse({
+    id: randomUUID(),
+    status: 'inbox',
+    source: 'claude_session',
+    content,
+    title: 'Error handling convention',
+    category: 'convention',
+    trustLevel: 'medium',
+    author: { type: 'ai', id: 'claude-1' },
+    tenantId: 'team-alpha',
+    metadata: { filePaths: [], tags: [] },
+    prePolicyFlags: { potentialSecret: false, lowConfidence: false, duplicateSuspect: false },
+    capturedAt: '2026-01-15T10:00:00.000Z',
+  });
+}
+
+function makeRule() {
+  return {
+    id: 'rule-dedup-check',
+    type: 'dedup_check' as const,
+    action: 'reject' as const,
+    enabled: true,
+    priority: 0,
+    parameters: {},
+  };
+}
+
+function makeContext(candidate: MemoryCandidate, existingHashes?: Set<string>): EvaluationContext {
+  return {
+    candidate,
+    existingHashes,
+    policy: GovernancePolicy.parse({
+      id: randomUUID(),
+      name: 'Test Policy',
+      tenantId: 'team-alpha',
+      rules: [makeRule()],
+      enabled: true,
+      version: 1,
+      createdAt: '2026-01-15T10:00:00.000Z',
+      updatedAt: '2026-01-15T10:00:00.000Z',
+    }),
+  };
+}
+
+describe('evaluateDedupCheck', () => {
+  it('detects exact duplicate via hash match', () => {
+    const candidate = makeCandidate(CLEAN_CONTENT);
+    const existingHashes = new Set([computeContentHash(CLEAN_CONTENT)]);
+    const rule = makeRule();
+    const result = evaluateDedupCheck(candidate, rule, makeContext(candidate, existingHashes));
+    expect(result.outcome).toBe('fail');
+    expect(result.reason).toContain('Exact duplicate detected');
+  });
+
+  it('passes unique content not in existing hashes', () => {
+    const candidate = makeCandidate('This is unique content that does not exist yet');
+    const existingHashes = new Set([computeContentHash(CLEAN_CONTENT)]);
+    const rule = makeRule();
+    const result = evaluateDedupCheck(candidate, rule, makeContext(candidate, existingHashes));
+    expect(result.outcome).toBe('pass');
+  });
+
+  it('passes when no existingHashes are provided', () => {
+    const candidate = makeCandidate(CLEAN_CONTENT);
+    const rule = makeRule();
+    const result = evaluateDedupCheck(candidate, rule, makeContext(candidate, undefined));
+    expect(result.outcome).toBe('pass');
+    expect(result.reason).toContain('skipped');
+  });
+
+  it('passes when existingHashes is an empty set', () => {
+    const candidate = makeCandidate(CLEAN_CONTENT);
+    const rule = makeRule();
+    const result = evaluateDedupCheck(candidate, rule, makeContext(candidate, new Set()));
+    expect(result.outcome).toBe('pass');
+  });
+
+  it('reports the hash in the failure reason', () => {
+    const candidate = makeCandidate(CLEAN_CONTENT);
+    const expectedHash = computeContentHash(CLEAN_CONTENT);
+    const existingHashes = new Set([expectedHash]);
+    const rule = makeRule();
+    const result = evaluateDedupCheck(candidate, rule, makeContext(candidate, existingHashes));
+    expect(result.outcome).toBe('fail');
+    expect(result.reason).toContain(expectedHash);
+  });
+});

--- a/packages/policy-engine/src/__tests__/pipeline.test.ts
+++ b/packages/policy-engine/src/__tests__/pipeline.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { MemoryCandidate, GovernancePolicy } from '@qmd-team-intent-kb/schema';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import { PolicyPipeline } from '../pipeline.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeCandidate(overrides?: Record<string, unknown>) {
+  return MemoryCandidate.parse({
+    id: randomUUID(),
+    status: 'inbox',
+    source: 'claude_session',
+    content: 'Use Result<T, E> for all fallible operations in the codebase',
+    title: 'Error handling convention',
+    category: 'convention',
+    trustLevel: 'medium',
+    author: { type: 'ai', id: 'claude-1' },
+    tenantId: 'team-alpha',
+    metadata: { filePaths: [], tags: [] },
+    prePolicyFlags: { potentialSecret: false, lowConfidence: false, duplicateSuspect: false },
+    capturedAt: '2026-01-15T10:00:00.000Z',
+    ...overrides,
+  });
+}
+
+function makePolicy(rules: unknown[], overrides?: Record<string, unknown>) {
+  return GovernancePolicy.parse({
+    id: randomUUID(),
+    name: 'Test Policy',
+    tenantId: 'team-alpha',
+    rules,
+    enabled: true,
+    version: 1,
+    createdAt: '2026-01-15T10:00:00.000Z',
+    updatedAt: '2026-01-15T10:00:00.000Z',
+    ...overrides,
+  });
+}
+
+function makeRule(type: string, overrides?: Record<string, unknown>) {
+  return {
+    id: `rule-${type}`,
+    type,
+    action: 'reject',
+    enabled: true,
+    priority: 0,
+    parameters: {},
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PolicyPipeline', () => {
+  it('approves a candidate that passes all rules', () => {
+    const policy = makePolicy([makeRule('content_length'), makeRule('tenant_match')]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate();
+    const result = pipeline.evaluate(candidate, { tenantId: 'team-alpha' });
+    expect(result.outcome).toBe('approved');
+    expect(result.candidateId).toBe(candidate.id);
+    expect(result.rejectedBy).toBeUndefined();
+    expect(result.flaggedBy).toBeUndefined();
+  });
+
+  it('rejects on first reject-action rule failure', () => {
+    // tenant_match will fail because context tenantId doesn't match
+    const policy = makePolicy([
+      makeRule('tenant_match', { action: 'reject', priority: 0 }),
+      makeRule('content_length', { priority: 1 }),
+    ]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate({ tenantId: 'team-alpha' });
+    const result = pipeline.evaluate(candidate, { tenantId: 'team-beta' });
+    expect(result.outcome).toBe('rejected');
+    expect(result.rejectedBy).toBe('rule-tenant_match');
+  });
+
+  it('short-circuits after rejection and does not evaluate remaining rules', () => {
+    // First rule rejects. Second rule would also fail, but should never run.
+    const policy = makePolicy([
+      makeRule('tenant_match', { action: 'reject', priority: 0 }),
+      // This rule would reject too, but we verify only 1 evaluation runs
+      makeRule('content_length', { action: 'reject', priority: 1, parameters: { min: 999999 } }),
+    ]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate({ tenantId: 'team-alpha' });
+    const result = pipeline.evaluate(candidate, { tenantId: 'team-beta' });
+    expect(result.outcome).toBe('rejected');
+    // Only the first rule ran — short-circuit happened before second rule
+    expect(result.evaluations).toHaveLength(1);
+    expect(result.evaluations[0]?.ruleId).toBe('rule-tenant_match');
+  });
+
+  it('flags but does not reject on flag-action rule failure', () => {
+    const policy = makePolicy([
+      makeRule('tenant_match', { action: 'flag', priority: 0 }),
+      makeRule('content_length', { action: 'reject', priority: 1 }),
+    ]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate({ tenantId: 'team-alpha' });
+    // tenantId mismatch → tenant_match flags; content_length passes
+    const result = pipeline.evaluate(candidate, { tenantId: 'team-beta' });
+    expect(result.outcome).toBe('flagged');
+    expect(result.flaggedBy).toContain('rule-tenant_match');
+    expect(result.rejectedBy).toBeUndefined();
+  });
+
+  it('returns all evaluations in execution order', () => {
+    const policy = makePolicy([
+      makeRule('content_length', { priority: 0 }),
+      makeRule('tenant_match', { priority: 1 }),
+    ]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate();
+    const result = pipeline.evaluate(candidate, { tenantId: 'team-alpha' });
+    expect(result.outcome).toBe('approved');
+    expect(result.evaluations).toHaveLength(2);
+    expect(result.evaluations[0]?.ruleId).toBe('rule-content_length');
+    expect(result.evaluations[1]?.ruleId).toBe('rule-tenant_match');
+  });
+
+  it('skips disabled rules', () => {
+    const policy = makePolicy([
+      makeRule('tenant_match', { enabled: false, priority: 0 }),
+      makeRule('content_length', { enabled: true, priority: 1 }),
+    ]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate({ tenantId: 'team-alpha' });
+    // tenant_match disabled — would have failed; only content_length runs
+    const result = pipeline.evaluate(candidate, { tenantId: 'team-beta' });
+    expect(result.outcome).toBe('approved');
+    expect(result.evaluations).toHaveLength(1);
+    expect(result.evaluations[0]?.ruleId).toBe('rule-content_length');
+  });
+
+  it('sorts rules by priority (lower number = higher priority, runs first)', () => {
+    // Assign priorities in reverse order to confirm sorting
+    const policy = makePolicy([
+      makeRule('content_length', { id: 'rule-low-priority', priority: 10 }),
+      makeRule('tenant_match', { id: 'rule-high-priority', priority: 1 }),
+    ]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate();
+    const result = pipeline.evaluate(candidate, { tenantId: 'team-alpha' });
+    expect(result.evaluations[0]?.ruleId).toBe('rule-high-priority');
+    expect(result.evaluations[1]?.ruleId).toBe('rule-low-priority');
+  });
+
+  it('pipeline with only secret detection rule approves clean content', () => {
+    const policy = makePolicy([makeRule('secret_detection')]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate();
+    const result = pipeline.evaluate(candidate);
+    expect(result.outcome).toBe('approved');
+    expect(result.evaluations).toHaveLength(1);
+    expect(result.evaluations[0]?.outcome).toBe('pass');
+  });
+
+  it('pipeline with all rule types completes without error on well-formed candidate', () => {
+    const policy = makePolicy([
+      makeRule('secret_detection', { priority: 0 }),
+      makeRule('content_length', { priority: 1 }),
+      makeRule('source_trust', { priority: 2, parameters: { minimumTrust: 'low' } }),
+      makeRule('relevance_score', { priority: 3, action: 'flag' }),
+      makeRule('dedup_check', { priority: 4 }),
+      makeRule('tenant_match', { priority: 5 }),
+    ]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate();
+    const result = pipeline.evaluate(candidate, { tenantId: 'team-alpha' });
+    // All hard rules pass; relevance_score may flag (score depends on candidate shape)
+    expect(['approved', 'flagged']).toContain(result.outcome);
+    expect(result.evaluations).toHaveLength(6);
+  });
+
+  it('records rejectedBy ruleId on rejection', () => {
+    const policy = makePolicy([
+      makeRule('content_length', {
+        id: 'length-guard',
+        action: 'reject',
+        parameters: { min: 99999 },
+      }),
+    ]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate();
+    const result = pipeline.evaluate(candidate);
+    expect(result.outcome).toBe('rejected');
+    expect(result.rejectedBy).toBe('length-guard');
+  });
+
+  it('records flaggedBy ruleIds including all flagging rules', () => {
+    const policy = makePolicy([
+      makeRule('relevance_score', {
+        id: 'relevance-flag',
+        action: 'flag',
+        parameters: { minimumScore: 0.99 },
+      }),
+      makeRule('source_trust', {
+        id: 'trust-flag',
+        action: 'flag',
+        parameters: { minimumTrust: 'high' },
+      }),
+    ]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate({ trustLevel: 'low' });
+    const result = pipeline.evaluate(candidate);
+    expect(result.outcome).toBe('flagged');
+    expect(result.flaggedBy).toContain('relevance-flag');
+    expect(result.flaggedBy).toContain('trust-flag');
+  });
+
+  it('full integration: candidate with secrets gets rejected', () => {
+    const policy = makePolicy([
+      makeRule('secret_detection', { action: 'reject', priority: 0 }),
+      makeRule('content_length', { action: 'reject', priority: 1 }),
+    ]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate({
+      content: 'API key is AKIAIOSFODNN7EXAMPLE — store safely',
+    });
+    const result = pipeline.evaluate(candidate);
+    expect(result.outcome).toBe('rejected');
+    expect(result.rejectedBy).toBe('rule-secret_detection');
+  });
+
+  it('full integration: clean candidate with good metadata gets approved', () => {
+    const policy = makePolicy([
+      makeRule('secret_detection', { action: 'reject', priority: 0 }),
+      makeRule('content_length', { action: 'reject', priority: 1 }),
+      makeRule('tenant_match', { action: 'reject', priority: 2 }),
+    ]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate({
+      content: 'Always wrap async boundaries in try/catch and convert to Result<T, E>.',
+    });
+    const result = pipeline.evaluate(candidate, { tenantId: 'team-alpha' });
+    expect(result.outcome).toBe('approved');
+    expect(result.rejectedBy).toBeUndefined();
+  });
+
+  it('full integration: low-relevance candidate gets flagged', () => {
+    const policy = makePolicy([
+      makeRule('relevance_score', {
+        action: 'flag',
+        priority: 0,
+        parameters: { minimumScore: 0.9 },
+      }),
+    ]);
+    const pipeline = new PolicyPipeline(policy);
+    // Minimal candidate — title + category only → score ~0.4
+    const candidate = makeCandidate({
+      title: 'note',
+      content: 'Short note.', // <= 50 chars
+      category: 'reference',
+      trustLevel: 'low',
+      metadata: { filePaths: [], tags: [] },
+    });
+    const result = pipeline.evaluate(candidate);
+    expect(result.outcome).toBe('flagged');
+    expect(result.flaggedBy).toContain('rule-relevance_score');
+  });
+
+  it('context with existingHashes triggers dedup rejection', () => {
+    const content = 'Use Result<T, E> for all fallible operations in the codebase';
+    const policy = makePolicy([makeRule('dedup_check', { action: 'reject' })]);
+    const pipeline = new PolicyPipeline(policy);
+    const candidate = makeCandidate({ content });
+    const existingHashes = new Set([computeContentHash(content)]);
+    const result = pipeline.evaluate(candidate, { existingHashes });
+    expect(result.outcome).toBe('rejected');
+    expect(result.rejectedBy).toBe('rule-dedup_check');
+  });
+});

--- a/packages/policy-engine/src/__tests__/relevance-score-rule.test.ts
+++ b/packages/policy-engine/src/__tests__/relevance-score-rule.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { MemoryCandidate, GovernancePolicy } from '@qmd-team-intent-kb/schema';
+import { evaluateRelevanceScore } from '../rules/relevance-score-rule.js';
+import type { EvaluationContext } from '../types.js';
+
+function makeCandidate(overrides?: Record<string, unknown>) {
+  return MemoryCandidate.parse({
+    id: randomUUID(),
+    status: 'inbox',
+    source: 'claude_session',
+    content: 'Use Result<T, E> for all fallible operations in the codebase',
+    title: 'Error handling convention',
+    category: 'convention',
+    trustLevel: 'medium',
+    author: { type: 'ai', id: 'claude-1' },
+    tenantId: 'team-alpha',
+    metadata: { filePaths: [], tags: [] },
+    prePolicyFlags: { potentialSecret: false, lowConfidence: false, duplicateSuspect: false },
+    capturedAt: '2026-01-15T10:00:00.000Z',
+    ...overrides,
+  });
+}
+
+function makeRule(parameters: Record<string, unknown> = {}) {
+  return {
+    id: 'rule-relevance-score',
+    type: 'relevance_score' as const,
+    action: 'flag' as const,
+    enabled: true,
+    priority: 0,
+    parameters,
+  };
+}
+
+function makeContext(candidate: MemoryCandidate): EvaluationContext {
+  return {
+    candidate,
+    policy: GovernancePolicy.parse({
+      id: randomUUID(),
+      name: 'Test Policy',
+      tenantId: 'team-alpha',
+      rules: [makeRule()],
+      enabled: true,
+      version: 1,
+      createdAt: '2026-01-15T10:00:00.000Z',
+      updatedAt: '2026-01-15T10:00:00.000Z',
+    }),
+  };
+}
+
+describe('evaluateRelevanceScore', () => {
+  it('scores 1.0 for a fully decorated candidate', () => {
+    const candidate = makeCandidate({
+      title: 'Full metadata candidate',
+      // content > 50 chars (default is already 59 chars)
+      content: 'Use Result<T, E> for all fallible operations in the codebase',
+      category: 'convention',
+      trustLevel: 'high',
+      metadata: {
+        filePaths: ['src/utils.ts'],
+        projectContext: 'main-api',
+        tags: ['typescript'],
+      },
+    });
+    const rule = makeRule({ minimumScore: 0.0 });
+    const result = evaluateRelevanceScore(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('pass');
+    // All 7 criteria met: 0.3 + 0.2 + 0.1 + 0.1 + 0.1 + 0.1 + 0.1 = 1.0
+    expect(result.score).toBeCloseTo(1.0, 5);
+  });
+
+  it('scores low for bare minimum candidate', () => {
+    // Minimal: short content (<=50 chars), no filePaths, no tags, no projectContext, not high trust
+    const candidate = makeCandidate({
+      title: 'minimal',
+      content: 'Short content here.', // 19 chars, <=50
+      category: 'reference',
+      trustLevel: 'low',
+      metadata: { filePaths: [], tags: [] },
+    });
+    const rule = makeRule({ minimumScore: 0.0 });
+    const result = evaluateRelevanceScore(candidate, rule, makeContext(candidate));
+    // Only title (+0.3) and category (+0.1) contribute → 0.4
+    expect(result.score).toBeCloseTo(0.4, 5);
+  });
+
+  it('title adds 0.3 to score', () => {
+    // Start with a candidate with no other contributing factors beyond title and category
+    const candidateWithTitle = makeCandidate({
+      title: 'My title',
+      content: 'Short.', // <=50 chars
+      category: 'reference',
+      trustLevel: 'low',
+      metadata: { filePaths: [], tags: [] },
+    });
+    const rule = makeRule({ minimumScore: 0.0 });
+    const result = evaluateRelevanceScore(
+      candidateWithTitle,
+      rule,
+      makeContext(candidateWithTitle),
+    );
+    // title=0.3, category=0.1, total=0.4
+    expect(result.score).toBeCloseTo(0.4, 5);
+  });
+
+  it('content length > 50 chars adds 0.2', () => {
+    const longContent = 'x'.repeat(51);
+    const candidate = makeCandidate({
+      title: 'T',
+      content: longContent,
+      category: 'reference',
+      trustLevel: 'low',
+      metadata: { filePaths: [], tags: [] },
+    });
+    const rule = makeRule({ minimumScore: 0.0 });
+    const result = evaluateRelevanceScore(candidate, rule, makeContext(candidate));
+    // title=0.3, content>50=0.2, category=0.1 → 0.6
+    expect(result.score).toBeCloseTo(0.6, 5);
+  });
+
+  it('filePaths add 0.1 to score', () => {
+    const candidate = makeCandidate({
+      title: 'T',
+      content: 'Short.', // <=50 chars
+      category: 'reference',
+      trustLevel: 'low',
+      metadata: { filePaths: ['src/index.ts'], tags: [] },
+    });
+    const rule = makeRule({ minimumScore: 0.0 });
+    const result = evaluateRelevanceScore(candidate, rule, makeContext(candidate));
+    // title=0.3, category=0.1, filePaths=0.1 → 0.5
+    expect(result.score).toBeCloseTo(0.5, 5);
+  });
+
+  it('tags add 0.1 to score', () => {
+    const candidate = makeCandidate({
+      title: 'T',
+      content: 'Short.', // <=50 chars
+      category: 'reference',
+      trustLevel: 'low',
+      metadata: { filePaths: [], tags: ['typescript'] },
+    });
+    const rule = makeRule({ minimumScore: 0.0 });
+    const result = evaluateRelevanceScore(candidate, rule, makeContext(candidate));
+    // title=0.3, category=0.1, tags=0.1 → 0.5
+    expect(result.score).toBeCloseTo(0.5, 5);
+  });
+
+  it('high trust adds 0.1 to score', () => {
+    const candidate = makeCandidate({
+      title: 'T',
+      content: 'Short.', // <=50 chars
+      category: 'reference',
+      trustLevel: 'high',
+      metadata: { filePaths: [], tags: [] },
+    });
+    const rule = makeRule({ minimumScore: 0.0 });
+    const result = evaluateRelevanceScore(candidate, rule, makeContext(candidate));
+    // title=0.3, category=0.1, high trust=0.1 → 0.5
+    expect(result.score).toBeCloseTo(0.5, 5);
+  });
+
+  it('flags when score is below minimumScore threshold', () => {
+    // Score will be 0.4 (title + category only), minimum is 0.8
+    const candidate = makeCandidate({
+      title: 'minimal',
+      content: 'Short.', // <=50 chars
+      category: 'reference',
+      trustLevel: 'low',
+      metadata: { filePaths: [], tags: [] },
+    });
+    const rule = makeRule({ minimumScore: 0.8 });
+    const result = evaluateRelevanceScore(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('flag');
+    expect(result.reason).toContain('below minimum');
+  });
+});

--- a/packages/policy-engine/src/__tests__/secret-detection-rule.test.ts
+++ b/packages/policy-engine/src/__tests__/secret-detection-rule.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { MemoryCandidate, GovernancePolicy } from '@qmd-team-intent-kb/schema';
+import { evaluateSecretDetection } from '../rules/secret-detection-rule.js';
+import type { EvaluationContext } from '../types.js';
+
+function makeCandidate(overrides?: Record<string, unknown>) {
+  return MemoryCandidate.parse({
+    id: randomUUID(),
+    status: 'inbox',
+    source: 'claude_session',
+    content: 'Use Result<T, E> for all fallible operations in the codebase',
+    title: 'Error handling convention',
+    category: 'convention',
+    trustLevel: 'medium',
+    author: { type: 'ai', id: 'claude-1' },
+    tenantId: 'team-alpha',
+    metadata: { filePaths: [], tags: [] },
+    prePolicyFlags: { potentialSecret: false, lowConfidence: false, duplicateSuspect: false },
+    capturedAt: '2026-01-15T10:00:00.000Z',
+    ...overrides,
+  });
+}
+
+function makeRule(overrides?: Record<string, unknown>) {
+  return {
+    id: 'rule-secret-detection',
+    type: 'secret_detection' as const,
+    action: 'reject' as const,
+    enabled: true,
+    priority: 0,
+    parameters: {},
+    ...overrides,
+  };
+}
+
+function makeContext(candidate: MemoryCandidate): EvaluationContext {
+  return {
+    candidate,
+    policy: GovernancePolicy.parse({
+      id: randomUUID(),
+      name: 'Test Policy',
+      tenantId: 'team-alpha',
+      rules: [makeRule()],
+      enabled: true,
+      version: 1,
+      createdAt: '2026-01-15T10:00:00.000Z',
+      updatedAt: '2026-01-15T10:00:00.000Z',
+    }),
+  };
+}
+
+describe('evaluateSecretDetection', () => {
+  it('detects JWT tokens in content', () => {
+    const content =
+      'token: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+    const candidate = makeCandidate({ content });
+    const rule = makeRule();
+    const result = evaluateSecretDetection(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('fail');
+    expect(result.reason).toContain('jwt');
+  });
+
+  it('detects AWS access keys', () => {
+    const content = 'aws_key = AKIAIOSFODNN7EXAMPLE';
+    const candidate = makeCandidate({ content });
+    const rule = makeRule();
+    const result = evaluateSecretDetection(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('fail');
+    expect(result.reason).toContain('aws-key');
+  });
+
+  it('detects GitHub tokens', () => {
+    const content = 'GITHUB_TOKEN=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij';
+    const candidate = makeCandidate({ content });
+    const rule = makeRule();
+    const result = evaluateSecretDetection(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('fail');
+    expect(result.reason).toContain('github-token');
+  });
+
+  it('detects generic API keys (sk-*)', () => {
+    const content = 'api_key: sk-abcdefghijklmnopqrstuvwxyz';
+    const candidate = makeCandidate({ content });
+    const rule = makeRule();
+    const result = evaluateSecretDetection(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('fail');
+    expect(result.reason).toContain('generic-api-key');
+  });
+
+  it('passes clean content', () => {
+    const candidate = makeCandidate({
+      content: 'Use Result<T, E> for all fallible operations in the codebase.',
+    });
+    const rule = makeRule();
+    const result = evaluateSecretDetection(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('pass');
+    expect(result.ruleId).toBe(rule.id);
+  });
+
+  it('includes pattern ids in failure reason', () => {
+    const content = 'AWS_KEY=AKIAIOSFODNN7EXAMPLE';
+    const candidate = makeCandidate({ content });
+    const rule = makeRule();
+    const result = evaluateSecretDetection(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('fail');
+    expect(result.reason).toContain('aws-key');
+    expect(result.reason).toContain('AWS Access Key');
+  });
+
+  it('handles multiple secrets in the same content', () => {
+    const content = [
+      'AWS_KEY=AKIAIOSFODNN7EXAMPLE',
+      'GITHUB_TOKEN=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij',
+    ].join('\n');
+    const candidate = makeCandidate({ content });
+    const rule = makeRule();
+    const result = evaluateSecretDetection(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('fail');
+    expect(result.reason).toContain('aws-key');
+    expect(result.reason).toContain('github-token');
+  });
+
+  it('passes content that is effectively clean despite length', () => {
+    // Long clean content — should not trigger any pattern
+    const content = 'Always use const for variables that are never reassigned. '.repeat(10);
+    const candidate = makeCandidate({ content });
+    const rule = makeRule();
+    const result = evaluateSecretDetection(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('pass');
+  });
+});

--- a/packages/policy-engine/src/__tests__/source-trust-rule.test.ts
+++ b/packages/policy-engine/src/__tests__/source-trust-rule.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { MemoryCandidate, GovernancePolicy } from '@qmd-team-intent-kb/schema';
+import { evaluateSourceTrust } from '../rules/source-trust-rule.js';
+import type { EvaluationContext } from '../types.js';
+
+function makeCandidate(overrides?: Record<string, unknown>) {
+  return MemoryCandidate.parse({
+    id: randomUUID(),
+    status: 'inbox',
+    source: 'claude_session',
+    content: 'Use Result<T, E> for all fallible operations in the codebase',
+    title: 'Error handling convention',
+    category: 'convention',
+    trustLevel: 'medium',
+    author: { type: 'ai', id: 'claude-1' },
+    tenantId: 'team-alpha',
+    metadata: { filePaths: [], tags: [] },
+    prePolicyFlags: { potentialSecret: false, lowConfidence: false, duplicateSuspect: false },
+    capturedAt: '2026-01-15T10:00:00.000Z',
+    ...overrides,
+  });
+}
+
+function makeRule(parameters: Record<string, unknown> = {}, action: 'reject' | 'flag' = 'reject') {
+  return {
+    id: 'rule-source-trust',
+    type: 'source_trust' as const,
+    action,
+    enabled: true,
+    priority: 0,
+    parameters,
+  };
+}
+
+function makeContext(candidate: MemoryCandidate): EvaluationContext {
+  return {
+    candidate,
+    policy: GovernancePolicy.parse({
+      id: randomUUID(),
+      name: 'Test Policy',
+      tenantId: 'team-alpha',
+      rules: [makeRule()],
+      enabled: true,
+      version: 1,
+      createdAt: '2026-01-15T10:00:00.000Z',
+      updatedAt: '2026-01-15T10:00:00.000Z',
+    }),
+  };
+}
+
+describe('evaluateSourceTrust', () => {
+  it('passes high trust when minimum is low', () => {
+    const candidate = makeCandidate({ trustLevel: 'high' });
+    const rule = makeRule({ minimumTrust: 'low' });
+    const result = evaluateSourceTrust(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('pass');
+    expect(result.score).toBeDefined();
+    expect(result.score).toBeGreaterThan(0);
+  });
+
+  it('fails untrusted when minimum is medium', () => {
+    const candidate = makeCandidate({ trustLevel: 'untrusted' });
+    const rule = makeRule({ minimumTrust: 'medium' });
+    const result = evaluateSourceTrust(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('fail');
+    expect(result.reason).toContain('untrusted');
+    expect(result.reason).toContain('medium');
+  });
+
+  it('uses default minimum of low when not specified', () => {
+    // 'low' trust against default minimum 'low' — should pass
+    const candidate = makeCandidate({ trustLevel: 'low' });
+    const rule = makeRule({});
+    const result = evaluateSourceTrust(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('pass');
+  });
+
+  it('handles all trust levels in correct order', () => {
+    const levels = ['untrusted', 'low', 'medium', 'high'] as const;
+    // With minimumTrust='medium', only medium and high should pass
+    for (const level of levels) {
+      const candidate = makeCandidate({ trustLevel: level });
+      const rule = makeRule({ minimumTrust: 'medium' });
+      const result = evaluateSourceTrust(candidate, rule, makeContext(candidate));
+      if (level === 'medium' || level === 'high') {
+        expect(result.outcome).toBe('pass');
+      } else {
+        expect(result.outcome).toBe('fail');
+      }
+    }
+  });
+
+  it('returns a trust score on pass', () => {
+    const candidate = makeCandidate({ trustLevel: 'high' });
+    const rule = makeRule({ minimumTrust: 'low' });
+    const result = evaluateSourceTrust(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('pass');
+    // high = 4/4 = 1.0
+    expect(result.score).toBeCloseTo(1.0, 5);
+  });
+
+  it('uses rule.action to determine fail outcome: flag action yields flag outcome', () => {
+    const candidate = makeCandidate({ trustLevel: 'untrusted' });
+    const rule = makeRule({ minimumTrust: 'high' }, 'flag');
+    const result = evaluateSourceTrust(candidate, rule, makeContext(candidate));
+    expect(result.outcome).toBe('flag');
+  });
+});

--- a/packages/policy-engine/src/__tests__/tenant-match-rule.test.ts
+++ b/packages/policy-engine/src/__tests__/tenant-match-rule.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { MemoryCandidate, GovernancePolicy } from '@qmd-team-intent-kb/schema';
+import { evaluateTenantMatch } from '../rules/tenant-match-rule.js';
+import type { EvaluationContext } from '../types.js';
+
+function makeCandidate(tenantId = 'team-alpha') {
+  return MemoryCandidate.parse({
+    id: randomUUID(),
+    status: 'inbox',
+    source: 'claude_session',
+    content: 'Use Result<T, E> for all fallible operations in the codebase',
+    title: 'Error handling convention',
+    category: 'convention',
+    trustLevel: 'medium',
+    author: { type: 'ai', id: 'claude-1' },
+    tenantId,
+    metadata: { filePaths: [], tags: [] },
+    prePolicyFlags: { potentialSecret: false, lowConfidence: false, duplicateSuspect: false },
+    capturedAt: '2026-01-15T10:00:00.000Z',
+  });
+}
+
+function makeRule() {
+  return {
+    id: 'rule-tenant-match',
+    type: 'tenant_match' as const,
+    action: 'reject' as const,
+    enabled: true,
+    priority: 0,
+    parameters: {},
+  };
+}
+
+function makeContext(candidate: MemoryCandidate, tenantId?: string): EvaluationContext {
+  return {
+    candidate,
+    tenantId,
+    policy: GovernancePolicy.parse({
+      id: randomUUID(),
+      name: 'Test Policy',
+      tenantId: 'team-alpha',
+      rules: [makeRule()],
+      enabled: true,
+      version: 1,
+      createdAt: '2026-01-15T10:00:00.000Z',
+      updatedAt: '2026-01-15T10:00:00.000Z',
+    }),
+  };
+}
+
+describe('evaluateTenantMatch', () => {
+  it('passes when candidate and context tenants match', () => {
+    const candidate = makeCandidate('team-alpha');
+    const rule = makeRule();
+    const result = evaluateTenantMatch(candidate, rule, makeContext(candidate, 'team-alpha'));
+    expect(result.outcome).toBe('pass');
+    expect(result.reason).toContain('team-alpha');
+  });
+
+  it('rejects when candidate and context tenants mismatch', () => {
+    const candidate = makeCandidate('team-alpha');
+    const rule = makeRule();
+    const result = evaluateTenantMatch(candidate, rule, makeContext(candidate, 'team-beta'));
+    expect(result.outcome).toBe('fail');
+    expect(result.reason).toContain('team-alpha');
+    expect(result.reason).toContain('team-beta');
+  });
+
+  it('passes when no tenantId is set in context', () => {
+    const candidate = makeCandidate('team-alpha');
+    const rule = makeRule();
+    const result = evaluateTenantMatch(candidate, rule, makeContext(candidate, undefined));
+    expect(result.outcome).toBe('pass');
+    expect(result.reason).toContain('not active');
+  });
+
+  it('reports both candidate and expected tenants in failure reason', () => {
+    const candidate = makeCandidate('org-x');
+    const rule = makeRule();
+    const result = evaluateTenantMatch(candidate, rule, makeContext(candidate, 'org-y'));
+    expect(result.outcome).toBe('fail');
+    expect(result.reason).toContain('org-x');
+    expect(result.reason).toContain('org-y');
+  });
+
+  it('works with various tenant ID formats', () => {
+    const formats = [
+      'simple',
+      'team-with-dashes',
+      'org_with_underscores',
+      'UPPERCASE',
+      'mixed-Case-123',
+    ] as const;
+
+    for (const fmt of formats) {
+      const candidate = makeCandidate(fmt);
+      const rule = makeRule();
+      const result = evaluateTenantMatch(candidate, rule, makeContext(candidate, fmt));
+      expect(result.outcome).toBe('pass');
+    }
+  });
+});

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -1,3 +1,9 @@
-// TODO: Memory governance policy evaluation engine (Phase 4)
-
-export const name = '@qmd-team-intent-kb/policy-engine';
+export type { RuleResult, EvaluationContext, RuleEvaluator, PipelineResult } from './types.js';
+export { createRule, RULE_REGISTRY } from './rules/index.js';
+export { evaluateSecretDetection } from './rules/secret-detection-rule.js';
+export { evaluateContentLength } from './rules/content-length-rule.js';
+export { evaluateSourceTrust } from './rules/source-trust-rule.js';
+export { evaluateRelevanceScore } from './rules/relevance-score-rule.js';
+export { evaluateDedupCheck } from './rules/dedup-check-rule.js';
+export { evaluateTenantMatch } from './rules/tenant-match-rule.js';
+export { PolicyPipeline } from './pipeline.js';

--- a/packages/policy-engine/src/pipeline.ts
+++ b/packages/policy-engine/src/pipeline.ts
@@ -1,0 +1,79 @@
+import type { GovernancePolicy, MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import type { EvaluationContext, PipelineResult, RuleResult } from './types.js';
+import { createRule } from './rules/index.js';
+
+/**
+ * Executes the full governance policy pipeline against a memory candidate.
+ *
+ * Rule execution order:
+ *   1. Sort by priority ascending (0 = highest priority, runs first)
+ *   2. Skip disabled rules
+ *   3. Execute each rule's evaluator
+ *   4. On 'fail' + action='reject' → short-circuit and return 'rejected'
+ *   5. On 'fail' + action='flag' OR outcome='flag' → record and continue
+ *   6. After all rules → 'flagged' if any flags, otherwise 'approved'
+ */
+export class PolicyPipeline {
+  private readonly policy: GovernancePolicy;
+
+  constructor(policy: GovernancePolicy) {
+    this.policy = policy;
+  }
+
+  evaluate(
+    candidate: MemoryCandidate,
+    partialContext: Partial<EvaluationContext> = {},
+  ): PipelineResult {
+    const context: EvaluationContext = {
+      candidate,
+      policy: this.policy,
+      existingHashes: partialContext.existingHashes,
+      tenantId: partialContext.tenantId,
+    };
+
+    // Sort enabled rules by priority ascending (lower number = higher priority)
+    const orderedRules = this.policy.rules
+      .filter((r) => r.enabled)
+      .sort((a, b) => a.priority - b.priority);
+
+    const evaluations: RuleResult[] = [];
+    const flaggedBy: string[] = [];
+
+    for (const rule of orderedRules) {
+      const evaluator = createRule(rule.type);
+      const result = evaluator(candidate, rule, context);
+      evaluations.push(result);
+
+      if (result.outcome === 'fail') {
+        if (rule.action === 'reject') {
+          // Hard stop — candidate is rejected
+          return {
+            candidateId: candidate.id,
+            outcome: 'rejected',
+            evaluations,
+            rejectedBy: rule.id,
+          };
+        }
+        // action is 'flag' (or 'approve'/'require_review') — record as flagged and continue
+        flaggedBy.push(rule.id);
+      } else if (result.outcome === 'flag') {
+        flaggedBy.push(rule.id);
+      }
+    }
+
+    if (flaggedBy.length > 0) {
+      return {
+        candidateId: candidate.id,
+        outcome: 'flagged',
+        evaluations,
+        flaggedBy,
+      };
+    }
+
+    return {
+      candidateId: candidate.id,
+      outcome: 'approved',
+      evaluations,
+    };
+  }
+}

--- a/packages/policy-engine/src/rules/content-length-rule.ts
+++ b/packages/policy-engine/src/rules/content-length-rule.ts
@@ -1,0 +1,48 @@
+import type { MemoryCandidate, PolicyRule } from '@qmd-team-intent-kb/schema';
+import type { EvaluationContext, RuleResult } from '../types.js';
+
+const DEFAULT_MIN = 10;
+const DEFAULT_MAX = 50000;
+
+/**
+ * Rule evaluator that validates candidate content length falls within configured bounds.
+ * Returns a normalized score (content.length / max) on pass.
+ */
+export function evaluateContentLength(
+  candidate: MemoryCandidate,
+  rule: PolicyRule,
+  _context: EvaluationContext,
+): RuleResult {
+  const min = typeof rule.parameters['min'] === 'number' ? rule.parameters['min'] : DEFAULT_MIN;
+  const max = typeof rule.parameters['max'] === 'number' ? rule.parameters['max'] : DEFAULT_MAX;
+
+  const length = candidate.content.length;
+
+  if (length < min) {
+    return {
+      ruleId: rule.id,
+      ruleType: rule.type,
+      outcome: 'fail',
+      reason: `Content too short (${length} chars, minimum ${min})`,
+    };
+  }
+
+  if (length > max) {
+    return {
+      ruleId: rule.id,
+      ruleType: rule.type,
+      outcome: 'fail',
+      reason: `Content too long (${length} chars, maximum ${max})`,
+    };
+  }
+
+  const score = Math.min(length / max, 1);
+
+  return {
+    ruleId: rule.id,
+    ruleType: rule.type,
+    outcome: 'pass',
+    reason: `Content length ${length} chars is within bounds [${min}, ${max}]`,
+    score,
+  };
+}

--- a/packages/policy-engine/src/rules/dedup-check-rule.ts
+++ b/packages/policy-engine/src/rules/dedup-check-rule.ts
@@ -1,0 +1,41 @@
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type { MemoryCandidate, PolicyRule } from '@qmd-team-intent-kb/schema';
+import type { EvaluationContext, RuleResult } from '../types.js';
+
+/**
+ * Rule evaluator that detects exact duplicate content by comparing SHA-256 hashes.
+ * Requires context.existingHashes to be populated for dedup to function; if not
+ * provided the rule passes vacuously.
+ */
+export function evaluateDedupCheck(
+  candidate: MemoryCandidate,
+  rule: PolicyRule,
+  context: EvaluationContext,
+): RuleResult {
+  if (context.existingHashes === undefined || context.existingHashes.size === 0) {
+    return {
+      ruleId: rule.id,
+      ruleType: rule.type,
+      outcome: 'pass',
+      reason: 'No existing hashes provided — dedup check skipped',
+    };
+  }
+
+  const hash = computeContentHash(candidate.content);
+
+  if (context.existingHashes.has(hash)) {
+    return {
+      ruleId: rule.id,
+      ruleType: rule.type,
+      outcome: 'fail',
+      reason: `Exact duplicate detected (hash: ${hash})`,
+    };
+  }
+
+  return {
+    ruleId: rule.id,
+    ruleType: rule.type,
+    outcome: 'pass',
+    reason: `Content is unique (hash: ${hash})`,
+  };
+}

--- a/packages/policy-engine/src/rules/index.ts
+++ b/packages/policy-engine/src/rules/index.ts
@@ -1,0 +1,28 @@
+import type { PolicyRuleType } from '@qmd-team-intent-kb/schema';
+import type { RuleEvaluator } from '../types.js';
+import { evaluateSecretDetection } from './secret-detection-rule.js';
+import { evaluateContentLength } from './content-length-rule.js';
+import { evaluateSourceTrust } from './source-trust-rule.js';
+import { evaluateRelevanceScore } from './relevance-score-rule.js';
+import { evaluateDedupCheck } from './dedup-check-rule.js';
+import { evaluateTenantMatch } from './tenant-match-rule.js';
+
+/** Registry mapping PolicyRuleType values to their evaluator functions */
+export const RULE_REGISTRY: Record<PolicyRuleType, RuleEvaluator> = {
+  secret_detection: evaluateSecretDetection,
+  content_length: evaluateContentLength,
+  source_trust: evaluateSourceTrust,
+  relevance_score: evaluateRelevanceScore,
+  dedup_check: evaluateDedupCheck,
+  tenant_match: evaluateTenantMatch,
+};
+
+/**
+ * Factory function that looks up the evaluator for a given rule type.
+ * Throws a TypeError at development time if an unregistered type is requested
+ * (this is a programming error, not a runtime data error).
+ */
+export function createRule(type: PolicyRuleType): RuleEvaluator {
+  const evaluator = RULE_REGISTRY[type];
+  return evaluator;
+}

--- a/packages/policy-engine/src/rules/relevance-score-rule.ts
+++ b/packages/policy-engine/src/rules/relevance-score-rule.ts
@@ -1,0 +1,87 @@
+import type { MemoryCandidate, PolicyRule } from '@qmd-team-intent-kb/schema';
+import type { EvaluationContext, RuleResult } from '../types.js';
+
+const DEFAULT_MINIMUM_SCORE = 0.3;
+
+/**
+ * Deterministic relevance scoring rule. No LLM involvement — purely structural heuristics.
+ *
+ * Scoring breakdown (max 1.0):
+ *   +0.3  title present and non-empty
+ *   +0.2  content length > 50 chars
+ *   +0.1  category is set
+ *   +0.1  metadata has at least one filePath
+ *   +0.1  metadata has projectContext
+ *   +0.1  metadata has at least one tag
+ *   +0.1  trustLevel is 'high'
+ *
+ * Candidates scoring below minimumScore are flagged (not rejected — low relevance is not fatal).
+ */
+export function evaluateRelevanceScore(
+  candidate: MemoryCandidate,
+  rule: PolicyRule,
+  _context: EvaluationContext,
+): RuleResult {
+  const minimumScore =
+    typeof rule.parameters['minimumScore'] === 'number'
+      ? rule.parameters['minimumScore']
+      : DEFAULT_MINIMUM_SCORE;
+
+  let score = 0;
+
+  // +0.3 for a non-empty title (NonEmptyString guarantees at least 1 char after trim, but be safe)
+  if (candidate.title.trim().length > 0) {
+    score += 0.3;
+  }
+
+  // +0.2 for content length > 50 chars
+  if (candidate.content.length > 50) {
+    score += 0.2;
+  }
+
+  // +0.1 for category being set (it always is per schema, but we check for type safety)
+  if (candidate.category) {
+    score += 0.1;
+  }
+
+  // +0.1 for at least one filePath in metadata
+  if (candidate.metadata.filePaths.length > 0) {
+    score += 0.1;
+  }
+
+  // +0.1 for projectContext being present
+  if (candidate.metadata.projectContext !== undefined && candidate.metadata.projectContext !== '') {
+    score += 0.1;
+  }
+
+  // +0.1 for at least one tag
+  if (candidate.metadata.tags.length > 0) {
+    score += 0.1;
+  }
+
+  // +0.1 for high trust level
+  if (candidate.trustLevel === 'high') {
+    score += 0.1;
+  }
+
+  // Round to avoid floating point noise
+  score = Math.round(score * 100) / 100;
+
+  if (score >= minimumScore) {
+    return {
+      ruleId: rule.id,
+      ruleType: rule.type,
+      outcome: 'pass',
+      reason: `Relevance score ${score.toFixed(2)} meets minimum ${minimumScore.toFixed(2)}`,
+      score,
+    };
+  }
+
+  return {
+    ruleId: rule.id,
+    ruleType: rule.type,
+    outcome: 'flag',
+    reason: `Relevance score ${score.toFixed(2)} is below minimum ${minimumScore.toFixed(2)}`,
+    score,
+  };
+}

--- a/packages/policy-engine/src/rules/secret-detection-rule.ts
+++ b/packages/policy-engine/src/rules/secret-detection-rule.ts
@@ -1,0 +1,34 @@
+import { scanForSecrets } from '@qmd-team-intent-kb/claude-runtime';
+import type { MemoryCandidate, PolicyRule } from '@qmd-team-intent-kb/schema';
+import type { EvaluationContext, RuleResult } from '../types.js';
+
+/**
+ * Rule evaluator that scans candidate content for secrets using the claude-runtime
+ * secret scanner. Any detected patterns cause a 'fail' outcome; clean content passes.
+ */
+export function evaluateSecretDetection(
+  candidate: MemoryCandidate,
+  rule: PolicyRule,
+  _context: EvaluationContext,
+): RuleResult {
+  const matches = scanForSecrets(candidate.content);
+
+  if (matches.length === 0) {
+    return {
+      ruleId: rule.id,
+      ruleType: rule.type,
+      outcome: 'pass',
+      reason: 'No secrets detected in content',
+    };
+  }
+
+  const patternIds = [...new Set(matches.map((m) => m.patternId))].join(', ');
+  const patternNames = [...new Set(matches.map((m) => m.patternName))].join(', ');
+
+  return {
+    ruleId: rule.id,
+    ruleType: rule.type,
+    outcome: 'fail',
+    reason: `Secrets detected — patterns matched: ${patternNames} (ids: ${patternIds})`,
+  };
+}

--- a/packages/policy-engine/src/rules/source-trust-rule.ts
+++ b/packages/policy-engine/src/rules/source-trust-rule.ts
@@ -1,0 +1,55 @@
+import type { MemoryCandidate, PolicyRule, TrustLevel } from '@qmd-team-intent-kb/schema';
+import type { EvaluationContext, RuleResult } from '../types.js';
+
+/** Numeric ordering for trust levels — higher = more trusted */
+const TRUST_ORDER: Record<TrustLevel, number> = {
+  high: 4,
+  medium: 3,
+  low: 2,
+  untrusted: 1,
+};
+
+const DEFAULT_MINIMUM_TRUST: TrustLevel = 'low';
+
+function isTrustLevel(value: unknown): value is TrustLevel {
+  return value === 'high' || value === 'medium' || value === 'low' || value === 'untrusted';
+}
+
+/**
+ * Rule evaluator that enforces a minimum trust level for candidates.
+ * The outcome on failure uses rule.action: 'reject' → 'fail', 'flag' → 'flag'.
+ * Returns a normalized trust score (0.25–1.0) on pass.
+ */
+export function evaluateSourceTrust(
+  candidate: MemoryCandidate,
+  rule: PolicyRule,
+  _context: EvaluationContext,
+): RuleResult {
+  const minimumRaw = rule.parameters['minimumTrust'];
+  const minimumTrust: TrustLevel = isTrustLevel(minimumRaw) ? minimumRaw : DEFAULT_MINIMUM_TRUST;
+
+  const candidateScore = TRUST_ORDER[candidate.trustLevel];
+  const minimumScore = TRUST_ORDER[minimumTrust];
+
+  if (candidateScore >= minimumScore) {
+    const score = candidateScore / 4; // normalize to 0.25–1.0
+
+    return {
+      ruleId: rule.id,
+      ruleType: rule.type,
+      outcome: 'pass',
+      reason: `Trust level '${candidate.trustLevel}' meets minimum '${minimumTrust}'`,
+      score,
+    };
+  }
+
+  // Map rule action to outcome: 'flag' action → 'flag' outcome, anything else → 'fail'
+  const outcome = rule.action === 'flag' ? 'flag' : 'fail';
+
+  return {
+    ruleId: rule.id,
+    ruleType: rule.type,
+    outcome,
+    reason: `Trust level '${candidate.trustLevel}' is below minimum '${minimumTrust}'`,
+  };
+}

--- a/packages/policy-engine/src/rules/tenant-match-rule.ts
+++ b/packages/policy-engine/src/rules/tenant-match-rule.ts
@@ -1,0 +1,38 @@
+import type { MemoryCandidate, PolicyRule } from '@qmd-team-intent-kb/schema';
+import type { EvaluationContext, RuleResult } from '../types.js';
+
+/**
+ * Rule evaluator that enforces tenant isolation. When context.tenantId is set,
+ * the candidate's tenantId must match exactly. If context.tenantId is not set,
+ * the rule passes with no enforcement (opt-in boundary check).
+ */
+export function evaluateTenantMatch(
+  candidate: MemoryCandidate,
+  rule: PolicyRule,
+  context: EvaluationContext,
+): RuleResult {
+  if (context.tenantId === undefined) {
+    return {
+      ruleId: rule.id,
+      ruleType: rule.type,
+      outcome: 'pass',
+      reason: 'No tenantId in context — tenant enforcement not active',
+    };
+  }
+
+  if (candidate.tenantId === context.tenantId) {
+    return {
+      ruleId: rule.id,
+      ruleType: rule.type,
+      outcome: 'pass',
+      reason: `Tenant match confirmed: '${candidate.tenantId}'`,
+    };
+  }
+
+  return {
+    ruleId: rule.id,
+    ruleType: rule.type,
+    outcome: 'fail',
+    reason: `Tenant mismatch: candidate tenant '${candidate.tenantId}' != expected '${context.tenantId}'`,
+  };
+}

--- a/packages/policy-engine/src/types.ts
+++ b/packages/policy-engine/src/types.ts
@@ -1,0 +1,34 @@
+import type { MemoryCandidate, GovernancePolicy, PolicyRule } from '@qmd-team-intent-kb/schema';
+
+/** Result of evaluating a single rule against a candidate */
+export interface RuleResult {
+  ruleId: string;
+  ruleType: string;
+  outcome: 'pass' | 'fail' | 'flag';
+  reason: string;
+  score?: number; // for scoring rules (relevance, trust)
+}
+
+/** Context provided to rule evaluators */
+export interface EvaluationContext {
+  candidate: MemoryCandidate;
+  policy: GovernancePolicy;
+  existingHashes?: Set<string>; // for dedup checking
+  tenantId?: string; // for tenant match validation
+}
+
+/** Function signature for a rule evaluator */
+export type RuleEvaluator = (
+  candidate: MemoryCandidate,
+  rule: PolicyRule,
+  context: EvaluationContext,
+) => RuleResult;
+
+/** Result of running the full pipeline */
+export interface PipelineResult {
+  candidateId: string;
+  outcome: 'approved' | 'rejected' | 'flagged';
+  evaluations: RuleResult[];
+  rejectedBy?: string; // ruleId that caused rejection
+  flaggedBy?: string[]; // ruleIds that flagged
+}

--- a/packages/policy-engine/tsconfig.json
+++ b/packages/policy-engine/tsconfig.json
@@ -7,5 +7,6 @@
     "declaration": true,
     "declarationMap": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [{ "path": "../schema" }, { "path": "../common" }, { "path": "../claude-runtime" }]
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@qmd-team-intent-kb/store",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@qmd-team-intent-kb/common": "workspace:*",
+    "@qmd-team-intent-kb/schema": "workspace:*",
+    "better-sqlite3": "^11.10.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0"
+  }
+}

--- a/packages/store/src/__tests__/audit-repository.test.ts
+++ b/packages/store/src/__tests__/audit-repository.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '../database.js';
+import { AuditRepository } from '../repositories/audit-repository.js';
+import { makeAuditEvent } from './fixtures.js';
+
+describe('AuditRepository', () => {
+  let db: Database.Database;
+  let repo: AuditRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new AuditRepository(db);
+  });
+
+  it('inserts an event and retrieves it by memoryId', () => {
+    const memoryId = randomUUID();
+    const event = makeAuditEvent({ memoryId });
+    repo.insert(event);
+    const found = repo.findByMemory(memoryId);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.id).toBe(event.id);
+    expect(found[0]?.action).toBe('promoted');
+    expect(found[0]?.memoryId).toBe(memoryId);
+  });
+
+  it('findByTenant returns all events for the tenant', () => {
+    const tenantId = 'team-alpha';
+    const e1 = makeAuditEvent({ tenantId, memoryId: randomUUID() });
+    const e2 = makeAuditEvent({ tenantId, memoryId: randomUUID(), action: 'archived' });
+    const e3 = makeAuditEvent({ tenantId: 'team-beta', memoryId: randomUUID() });
+    repo.insert(e1);
+    repo.insert(e2);
+    repo.insert(e3);
+
+    const results = repo.findByTenant(tenantId);
+    expect(results).toHaveLength(2);
+    expect(results.every((e) => e.tenantId === tenantId)).toBe(true);
+  });
+
+  it('findByAction returns only events with the specified action', () => {
+    const e1 = makeAuditEvent({ action: 'promoted', memoryId: randomUUID() });
+    const e2 = makeAuditEvent({ action: 'archived', memoryId: randomUUID() });
+    const e3 = makeAuditEvent({ action: 'promoted', memoryId: randomUUID() });
+    repo.insert(e1);
+    repo.insert(e2);
+    repo.insert(e3);
+
+    const promoted = repo.findByAction('promoted');
+    expect(promoted).toHaveLength(2);
+    expect(promoted.every((e) => e.action === 'promoted')).toBe(true);
+
+    const archived = repo.findByAction('archived');
+    expect(archived).toHaveLength(1);
+    expect(archived[0]?.action).toBe('archived');
+  });
+
+  it('multiple events for the same memory are all returned in order', () => {
+    const memoryId = randomUUID();
+    const e1 = makeAuditEvent({
+      memoryId,
+      action: 'promoted',
+      timestamp: '2026-01-01T10:00:00.000Z',
+    });
+    const e2 = makeAuditEvent({
+      memoryId,
+      action: 'archived',
+      timestamp: '2026-01-02T10:00:00.000Z',
+    });
+    repo.insert(e1);
+    repo.insert(e2);
+
+    const found = repo.findByMemory(memoryId);
+    expect(found).toHaveLength(2);
+    expect(found[0]?.action).toBe('promoted');
+    expect(found[1]?.action).toBe('archived');
+  });
+});

--- a/packages/store/src/__tests__/candidate-repository.test.ts
+++ b/packages/store/src/__tests__/candidate-repository.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '../database.js';
+import { CandidateRepository } from '../repositories/candidate-repository.js';
+import { makeCandidate } from './fixtures.js';
+
+describe('CandidateRepository', () => {
+  let db: Database.Database;
+  let repo: CandidateRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new CandidateRepository(db);
+  });
+
+  it('inserts a candidate and retrieves it by id', () => {
+    const { candidate, contentHash } = makeCandidate();
+    repo.insert(candidate, contentHash);
+    const found = repo.findById(candidate.id);
+    expect(found).not.toBeNull();
+    expect(found?.id).toBe(candidate.id);
+    expect(found?.content).toBe(candidate.content);
+    expect(found?.title).toBe(candidate.title);
+    expect(found?.status).toBe('inbox');
+  });
+
+  it('findByTenant returns only candidates for the matching tenant', () => {
+    const { candidate: c1, contentHash: h1 } = makeCandidate({ tenantId: 'team-alpha' });
+    const { candidate: c2, contentHash: h2 } = makeCandidate({
+      tenantId: 'team-beta',
+      content: 'different content',
+    });
+    repo.insert(c1, h1);
+    repo.insert(c2, h2);
+
+    const alphaResults = repo.findByTenant('team-alpha');
+    expect(alphaResults).toHaveLength(1);
+    expect(alphaResults[0]?.tenantId).toBe('team-alpha');
+
+    const betaResults = repo.findByTenant('team-beta');
+    expect(betaResults).toHaveLength(1);
+    expect(betaResults[0]?.tenantId).toBe('team-beta');
+  });
+
+  it('findByContentHash returns the matching candidate', () => {
+    const { candidate, contentHash } = makeCandidate();
+    repo.insert(candidate, contentHash);
+    const found = repo.findByContentHash(contentHash);
+    expect(found).not.toBeNull();
+    expect(found?.id).toBe(candidate.id);
+  });
+
+  it('count returns the correct number of candidates', () => {
+    expect(repo.count()).toBe(0);
+    const { candidate: c1, contentHash: h1 } = makeCandidate();
+    const { candidate: c2, contentHash: h2 } = makeCandidate({ content: 'second candidate' });
+    repo.insert(c1, h1);
+    expect(repo.count()).toBe(1);
+    repo.insert(c2, h2);
+    expect(repo.count()).toBe(2);
+  });
+
+  it('returns null for a non-existent id', () => {
+    expect(repo.findById(randomUUID())).toBeNull();
+  });
+
+  it('preserves full metadata on insert and retrieval', () => {
+    const { candidate, contentHash } = makeCandidate({
+      metadata: {
+        filePaths: ['src/api.ts', 'src/auth.ts'],
+        language: 'typescript',
+        projectContext: 'backend',
+        tags: ['api', 'auth'],
+      },
+      prePolicyFlags: { potentialSecret: true, lowConfidence: false, duplicateSuspect: true },
+    });
+    repo.insert(candidate, contentHash);
+    const found = repo.findById(candidate.id);
+    expect(found?.metadata.filePaths).toEqual(['src/api.ts', 'src/auth.ts']);
+    expect(found?.metadata.language).toBe('typescript');
+    expect(found?.prePolicyFlags.potentialSecret).toBe(true);
+    expect(found?.prePolicyFlags.duplicateSuspect).toBe(true);
+  });
+
+  it('multiple inserts produce a correct count', () => {
+    for (let i = 0; i < 5; i++) {
+      const { candidate, contentHash } = makeCandidate({ content: `content-${i.toString()}` });
+      repo.insert(candidate, contentHash);
+    }
+    expect(repo.count()).toBe(5);
+  });
+
+  it('handles special characters in content without corruption', () => {
+    const specialContent = `Use "double-quotes", 'single-quotes', <tags>, & ampersands\nnewlines\ttabs`;
+    const { candidate, contentHash } = makeCandidate({ content: specialContent });
+    repo.insert(candidate, contentHash);
+    const found = repo.findById(candidate.id);
+    expect(found?.content).toBe(specialContent);
+    expect(found && computeContentHash(found.content)).toBe(contentHash);
+  });
+});

--- a/packages/store/src/__tests__/database.test.ts
+++ b/packages/store/src/__tests__/database.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { createDatabase, createTestDatabase } from '../database.js';
+
+describe('createTestDatabase', () => {
+  it('creates an in-memory database without throwing', () => {
+    const db = createTestDatabase();
+    expect(db).toBeDefined();
+    db.close();
+  });
+
+  it('creates all expected tables', () => {
+    const db = createTestDatabase();
+    const tables = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' ORDER BY name`)
+      .all() as Array<{ name: string }>;
+    const names = tables.map((t) => t.name);
+    expect(names).toContain('candidates');
+    expect(names).toContain('curated_memories');
+    expect(names).toContain('governance_policies');
+    expect(names).toContain('audit_events');
+    expect(names).toContain('export_state');
+    db.close();
+  });
+
+  it('creates tables idempotently — calling createDatabase twice does not throw', () => {
+    // Use a shared in-memory path approach: call createDatabase with :memory:
+    // twice (each call is an independent connection, both succeed).
+    expect(() => {
+      const db1 = createDatabase({ path: ':memory:' });
+      db1.close();
+      const db2 = createDatabase({ path: ':memory:' });
+      db2.close();
+    }).not.toThrow();
+  });
+
+  it('has WAL journal mode enabled', () => {
+    const db = createTestDatabase();
+    const row = db.pragma('journal_mode', { simple: true });
+    // In-memory databases may report 'memory' instead of 'wal' — both indicate
+    // the pragma was accepted without error. For an on-disk DB it would be 'wal'.
+    expect(typeof row).toBe('string');
+    db.close();
+  });
+
+  it('has foreign keys enabled', () => {
+    const db = createTestDatabase();
+    const fk = db.pragma('foreign_keys', { simple: true });
+    expect(fk).toBe(1);
+    db.close();
+  });
+});

--- a/packages/store/src/__tests__/export-state-repository.test.ts
+++ b/packages/store/src/__tests__/export-state-repository.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '../database.js';
+import { ExportStateRepository } from '../repositories/export-state-repository.js';
+
+const TS_A = '2026-01-15T10:00:00.000Z';
+const TS_B = '2026-02-01T12:00:00.000Z';
+
+describe('ExportStateRepository', () => {
+  let db: Database.Database;
+  let repo: ExportStateRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new ExportStateRepository(db);
+  });
+
+  it('set stores state and get retrieves it', () => {
+    repo.set('git-mirror-1', TS_A);
+    const state = repo.get('git-mirror-1');
+    expect(state).not.toBeNull();
+    expect(state?.targetId).toBe('git-mirror-1');
+    expect(state?.lastExportedAt).toBe(TS_A);
+    // updatedAt is set by the DB — just verify it is a non-empty string
+    expect(typeof state?.updatedAt).toBe('string');
+    expect((state?.updatedAt ?? '').length).toBeGreaterThan(0);
+  });
+
+  it('set performs an upsert — calling again updates lastExportedAt', () => {
+    repo.set('git-mirror-1', TS_A);
+    repo.set('git-mirror-1', TS_B);
+    const state = repo.get('git-mirror-1');
+    expect(state?.lastExportedAt).toBe(TS_B);
+  });
+
+  it('returns null for a target that has never been set', () => {
+    expect(repo.get('unknown-target')).toBeNull();
+  });
+});

--- a/packages/store/src/__tests__/fixtures.ts
+++ b/packages/store/src/__tests__/fixtures.ts
@@ -1,0 +1,96 @@
+import { randomUUID } from 'node:crypto';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type {
+  MemoryCandidate,
+  CuratedMemory,
+  GovernancePolicy,
+  AuditEvent,
+} from '@qmd-team-intent-kb/schema';
+
+const NOW = '2026-01-15T10:00:00.000Z';
+export const HASH_A = 'a'.repeat(64);
+export const HASH_B = 'b'.repeat(64);
+
+export function makeCandidate(overrides?: Partial<MemoryCandidate>): {
+  candidate: MemoryCandidate;
+  contentHash: string;
+} {
+  const content = overrides?.content ?? 'Use Result<T, E> for all fallible operations';
+  const candidate: MemoryCandidate = {
+    id: randomUUID(),
+    status: 'inbox',
+    source: 'claude_session',
+    content,
+    title: 'Error handling convention',
+    category: 'convention',
+    trustLevel: 'medium',
+    author: { type: 'ai', id: 'claude-session-1', name: 'Claude' },
+    tenantId: 'team-alpha',
+    metadata: { filePaths: [], tags: [] },
+    prePolicyFlags: { potentialSecret: false, lowConfidence: false, duplicateSuspect: false },
+    capturedAt: NOW,
+    ...overrides,
+  };
+  return { candidate, contentHash: computeContentHash(content) };
+}
+
+export function makeMemory(overrides?: Partial<CuratedMemory>): CuratedMemory {
+  return {
+    id: randomUUID(),
+    candidateId: randomUUID(),
+    source: 'claude_session',
+    content: 'All API endpoints must validate input with Zod schemas',
+    title: 'API input validation pattern',
+    category: 'pattern',
+    trustLevel: 'high',
+    sensitivity: 'internal',
+    author: { type: 'ai', id: 'claude-session-2', name: 'Claude' },
+    tenantId: 'team-alpha',
+    metadata: { filePaths: [], tags: [] },
+    lifecycle: 'active',
+    contentHash: HASH_A,
+    policyEvaluations: [],
+    promotedAt: NOW,
+    promotedBy: { type: 'human', id: 'user-1', name: 'Test User' },
+    updatedAt: NOW,
+    version: 1,
+    ...overrides,
+  } as CuratedMemory;
+}
+
+export function makePolicy(overrides?: Partial<GovernancePolicy>): GovernancePolicy {
+  return {
+    id: randomUUID(),
+    name: 'Default Security Policy',
+    tenantId: 'team-alpha',
+    rules: [
+      {
+        id: 'rule-secret-detect',
+        type: 'secret_detection',
+        action: 'reject',
+        enabled: true,
+        priority: 0,
+        parameters: {},
+      },
+    ],
+    enabled: true,
+    version: 1,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+export function makeAuditEvent(overrides?: Partial<AuditEvent>): AuditEvent {
+  return {
+    id: randomUUID(),
+    action: 'promoted',
+    memoryId: randomUUID(),
+    tenantId: 'team-alpha',
+    actor: { type: 'human', id: 'user-1', name: 'Test User' },
+    reason: 'Passed all governance rules',
+    details: {},
+    timestamp: NOW,
+    ...overrides,
+  };
+}

--- a/packages/store/src/__tests__/memory-repository.test.ts
+++ b/packages/store/src/__tests__/memory-repository.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '../database.js';
+import { MemoryRepository } from '../repositories/memory-repository.js';
+import { makeMemory, HASH_A, HASH_B } from './fixtures.js';
+
+const NOW = '2026-01-15T10:00:00.000Z';
+const LATER = '2026-02-01T12:00:00.000Z';
+
+describe('MemoryRepository', () => {
+  let db: Database.Database;
+  let repo: MemoryRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new MemoryRepository(db);
+  });
+
+  it('inserts a memory and retrieves it by id', () => {
+    const memory = makeMemory();
+    repo.insert(memory);
+    const found = repo.findById(memory.id);
+    expect(found).not.toBeNull();
+    expect(found?.id).toBe(memory.id);
+    expect(found?.content).toBe(memory.content);
+    expect(found?.lifecycle).toBe('active');
+  });
+
+  it('findByTenant returns only memories for the matching tenant', () => {
+    const m1 = makeMemory({ tenantId: 'team-alpha' });
+    const m2 = makeMemory({ tenantId: 'team-beta', contentHash: HASH_B });
+    repo.insert(m1);
+    repo.insert(m2);
+
+    const alphaResults = repo.findByTenant('team-alpha');
+    expect(alphaResults).toHaveLength(1);
+    expect(alphaResults[0]?.tenantId).toBe('team-alpha');
+
+    const betaResults = repo.findByTenant('team-beta');
+    expect(betaResults).toHaveLength(1);
+    expect(betaResults[0]?.tenantId).toBe('team-beta');
+  });
+
+  it('findByContentHash returns the matching memory', () => {
+    const memory = makeMemory({ contentHash: HASH_A });
+    repo.insert(memory);
+    const found = repo.findByContentHash(HASH_A);
+    expect(found).not.toBeNull();
+    expect(found?.id).toBe(memory.id);
+  });
+
+  it('findByLifecycle filters correctly to requested state', () => {
+    const active = makeMemory({ lifecycle: 'active' });
+    const deprecated = makeMemory({ lifecycle: 'deprecated', contentHash: HASH_B });
+    repo.insert(active);
+    repo.insert(deprecated);
+
+    const activeResults = repo.findByLifecycle('active');
+    expect(activeResults).toHaveLength(1);
+    expect(activeResults[0]?.lifecycle).toBe('active');
+
+    const deprecatedResults = repo.findByLifecycle('deprecated');
+    expect(deprecatedResults).toHaveLength(1);
+    expect(deprecatedResults[0]?.lifecycle).toBe('deprecated');
+  });
+
+  it('updateLifecycle changes the lifecycle state and returns true', () => {
+    const memory = makeMemory({ lifecycle: 'active' });
+    repo.insert(memory);
+    const updated = repo.updateLifecycle(memory.id, 'deprecated', LATER);
+    expect(updated).toBe(true);
+    const found = repo.findById(memory.id);
+    expect(found?.lifecycle).toBe('deprecated');
+    expect(found?.updatedAt).toBe(LATER);
+  });
+
+  it('update performs a full record update and returns true', () => {
+    const memory = makeMemory();
+    repo.insert(memory);
+    const updatedMemory = { ...memory, title: 'Updated title', version: 2, updatedAt: LATER };
+    const result = repo.update(updatedMemory);
+    expect(result).toBe(true);
+    const found = repo.findById(memory.id);
+    expect(found?.title).toBe('Updated title');
+    expect(found?.version).toBe(2);
+    expect(found?.updatedAt).toBe(LATER);
+  });
+
+  it('count returns the correct number of memories', () => {
+    expect(repo.count()).toBe(0);
+    repo.insert(makeMemory({ contentHash: HASH_A }));
+    expect(repo.count()).toBe(1);
+    repo.insert(makeMemory({ contentHash: HASH_B }));
+    expect(repo.count()).toBe(2);
+  });
+
+  it('getAllContentHashes returns all stored hashes', () => {
+    repo.insert(makeMemory({ contentHash: HASH_A }));
+    repo.insert(makeMemory({ contentHash: HASH_B }));
+    const hashes = repo.getAllContentHashes();
+    expect(hashes).toHaveLength(2);
+    expect(hashes).toContain(HASH_A);
+    expect(hashes).toContain(HASH_B);
+  });
+
+  it('returns null for a non-existent id', () => {
+    expect(repo.findById(randomUUID())).toBeNull();
+  });
+
+  it('multiple memories with different lifecycles are all retrievable', () => {
+    const states = ['active', 'deprecated', 'archived'] as const;
+    const hashes = ['a'.repeat(64), 'b'.repeat(64), 'c'.repeat(64)] as const;
+    states.forEach((lifecycle, i) => {
+      repo.insert(makeMemory({ lifecycle, contentHash: hashes[i] }));
+    });
+    expect(repo.count()).toBe(3);
+    expect(repo.findByLifecycle('active')).toHaveLength(1);
+    expect(repo.findByLifecycle('deprecated')).toHaveLength(1);
+    expect(repo.findByLifecycle('archived')).toHaveLength(1);
+    expect(repo.findByLifecycle('superseded')).toHaveLength(0);
+  });
+
+  it('preserves policyEvaluations and supersession on round-trip', () => {
+    const supersessionLink = {
+      supersededBy: randomUUID(),
+      reason: 'Replaced by newer version',
+      linkedAt: NOW,
+    };
+    const policyEvaluations = [
+      {
+        policyId: randomUUID(),
+        ruleId: 'rule-1',
+        result: 'pass' as const,
+        reason: 'Passed check',
+        evaluatedAt: NOW,
+      },
+    ];
+    const memory = makeMemory({
+      lifecycle: 'superseded',
+      supersession: supersessionLink,
+      policyEvaluations,
+      contentHash: HASH_B,
+    });
+    repo.insert(memory);
+    const found = repo.findById(memory.id);
+    expect(found?.supersession?.reason).toBe('Replaced by newer version');
+    expect(found?.policyEvaluations).toHaveLength(1);
+    expect(found?.policyEvaluations[0]?.result).toBe('pass');
+  });
+});

--- a/packages/store/src/__tests__/policy-repository.test.ts
+++ b/packages/store/src/__tests__/policy-repository.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '../database.js';
+import { PolicyRepository } from '../repositories/policy-repository.js';
+import { makePolicy } from './fixtures.js';
+
+const LATER = '2026-02-01T12:00:00.000Z';
+
+describe('PolicyRepository', () => {
+  let db: Database.Database;
+  let repo: PolicyRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new PolicyRepository(db);
+  });
+
+  it('inserts a policy and retrieves it by id', () => {
+    const policy = makePolicy();
+    repo.insert(policy);
+    const found = repo.findById(policy.id);
+    expect(found).not.toBeNull();
+    expect(found?.id).toBe(policy.id);
+    expect(found?.name).toBe(policy.name);
+    expect(found?.enabled).toBe(true);
+    expect(found?.rules).toHaveLength(1);
+  });
+
+  it('findByTenant returns policies for the matching tenant only', () => {
+    const p1 = makePolicy({ tenantId: 'team-alpha' });
+    const p2 = makePolicy({ tenantId: 'team-beta' });
+    repo.insert(p1);
+    repo.insert(p2);
+
+    const alphaResults = repo.findByTenant('team-alpha');
+    expect(alphaResults).toHaveLength(1);
+    expect(alphaResults[0]?.tenantId).toBe('team-alpha');
+  });
+
+  it('update modifies an existing policy and returns true', () => {
+    const policy = makePolicy();
+    repo.insert(policy);
+    const updated = { ...policy, name: 'Updated Policy', version: 2, updatedAt: LATER };
+    const result = repo.update(updated);
+    expect(result).toBe(true);
+    const found = repo.findById(policy.id);
+    expect(found?.name).toBe('Updated Policy');
+    expect(found?.version).toBe(2);
+  });
+
+  it('update returns false for a non-existent id', () => {
+    const policy = makePolicy();
+    const result = repo.update(policy);
+    expect(result).toBe(false);
+  });
+
+  it('delete removes the policy and returns true', () => {
+    const policy = makePolicy();
+    repo.insert(policy);
+    const deleted = repo.delete(policy.id);
+    expect(deleted).toBe(true);
+    expect(repo.findById(policy.id)).toBeNull();
+  });
+
+  it('delete returns false for a non-existent id', () => {
+    expect(repo.delete(randomUUID())).toBe(false);
+  });
+
+  it('findByTenant returns multiple policies for the same tenant', () => {
+    const p1 = makePolicy({ tenantId: 'team-alpha', name: 'Policy One' });
+    const p2 = makePolicy({ tenantId: 'team-alpha', name: 'Policy Two' });
+    const p3 = makePolicy({ tenantId: 'team-beta', name: 'Other Policy' });
+    repo.insert(p1);
+    repo.insert(p2);
+    repo.insert(p3);
+
+    const results = repo.findByTenant('team-alpha');
+    expect(results).toHaveLength(2);
+    const names = results.map((p) => p.name);
+    expect(names).toContain('Policy One');
+    expect(names).toContain('Policy Two');
+  });
+});

--- a/packages/store/src/database.ts
+++ b/packages/store/src/database.ts
@@ -1,0 +1,41 @@
+import Database from 'better-sqlite3';
+import { TABLE_DDL } from './schema.js';
+
+/** Options for creating a database connection */
+export interface DatabaseOptions {
+  /** Filesystem path or ':memory:' for an in-process test database */
+  path: string;
+  readonly?: boolean;
+}
+
+/**
+ * Initialize a SQLite database connection with WAL mode enabled and
+ * idempotent schema creation. Tables are created on first call and
+ * left untouched on subsequent calls.
+ */
+export function createDatabase(options: DatabaseOptions): Database.Database {
+  const db = new Database(options.path, {
+    readonly: options.readonly ?? false,
+  });
+
+  if (!(options.readonly ?? false)) {
+    // WAL mode gives better concurrent read performance while still
+    // being safe for single-writer workloads.
+    db.pragma('journal_mode = WAL');
+    db.pragma('foreign_keys = ON');
+
+    for (const ddl of TABLE_DDL) {
+      db.exec(ddl);
+    }
+  }
+
+  return db;
+}
+
+/**
+ * Create an in-memory SQLite database. The database is destroyed when
+ * the connection is closed. Intended for use in tests only.
+ */
+export function createTestDatabase(): Database.Database {
+  return createDatabase({ path: ':memory:' });
+}

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,0 +1,9 @@
+export { createDatabase, createTestDatabase } from './database.js';
+export type { DatabaseOptions } from './database.js';
+export { TABLE_DDL } from './schema.js';
+export { CandidateRepository } from './repositories/candidate-repository.js';
+export { MemoryRepository } from './repositories/memory-repository.js';
+export { PolicyRepository } from './repositories/policy-repository.js';
+export { AuditRepository } from './repositories/audit-repository.js';
+export { ExportStateRepository } from './repositories/export-state-repository.js';
+export type { ExportState } from './repositories/export-state-repository.js';

--- a/packages/store/src/repositories/audit-repository.ts
+++ b/packages/store/src/repositories/audit-repository.ts
@@ -1,0 +1,92 @@
+import type Database from 'better-sqlite3';
+import type { AuditEvent } from '@qmd-team-intent-kb/schema';
+
+/** Raw SQLite row shape for the audit_events table */
+interface AuditRow {
+  id: string;
+  action: string;
+  memory_id: string;
+  tenant_id: string;
+  actor_json: string;
+  reason: string | null;
+  details_json: string;
+  timestamp: string;
+}
+
+function rowToEvent(row: AuditRow): AuditEvent {
+  return {
+    id: row.id,
+    action: row.action as AuditEvent['action'],
+    memoryId: row.memory_id,
+    tenantId: row.tenant_id,
+    actor: JSON.parse(row.actor_json) as AuditEvent['actor'],
+    reason: row.reason ?? undefined,
+    details: JSON.parse(row.details_json) as AuditEvent['details'],
+    timestamp: row.timestamp,
+  };
+}
+
+/**
+ * Append-only repository for immutable audit events.
+ * No update or delete methods are exposed by design.
+ */
+export class AuditRepository {
+  private readonly stmtInsert: Database.Statement;
+  private readonly stmtFindByMemory: Database.Statement;
+  private readonly stmtFindByTenant: Database.Statement;
+  private readonly stmtFindByAction: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.stmtInsert = db.prepare(`
+      INSERT INTO audit_events (
+        id, action, memory_id, tenant_id, actor_json, reason, details_json, timestamp
+      ) VALUES (
+        @id, @action, @memory_id, @tenant_id, @actor_json, @reason, @details_json, @timestamp
+      )
+    `);
+
+    this.stmtFindByMemory = db.prepare(`
+      SELECT * FROM audit_events WHERE memory_id = ? ORDER BY timestamp ASC
+    `);
+
+    this.stmtFindByTenant = db.prepare(`
+      SELECT * FROM audit_events WHERE tenant_id = ? ORDER BY timestamp ASC
+    `);
+
+    this.stmtFindByAction = db.prepare(`
+      SELECT * FROM audit_events WHERE action = ? ORDER BY timestamp ASC
+    `);
+  }
+
+  /** Append a new audit event. This is the only write operation permitted. */
+  insert(event: AuditEvent): void {
+    this.stmtInsert.run({
+      id: event.id,
+      action: event.action,
+      memory_id: event.memoryId,
+      tenant_id: event.tenantId,
+      actor_json: JSON.stringify(event.actor),
+      reason: event.reason ?? null,
+      details_json: JSON.stringify(event.details),
+      timestamp: event.timestamp,
+    });
+  }
+
+  /** Return all events associated with the given memory, in chronological order. */
+  findByMemory(memoryId: string): AuditEvent[] {
+    const rows = this.stmtFindByMemory.all(memoryId) as AuditRow[];
+    return rows.map(rowToEvent);
+  }
+
+  /** Return all events for the given tenant, in chronological order. */
+  findByTenant(tenantId: string): AuditEvent[] {
+    const rows = this.stmtFindByTenant.all(tenantId) as AuditRow[];
+    return rows.map(rowToEvent);
+  }
+
+  /** Return all events of the given action type, in chronological order. */
+  findByAction(action: string): AuditEvent[] {
+    const rows = this.stmtFindByAction.all(action) as AuditRow[];
+    return rows.map(rowToEvent);
+  }
+}

--- a/packages/store/src/repositories/candidate-repository.ts
+++ b/packages/store/src/repositories/candidate-repository.ts
@@ -1,0 +1,126 @@
+import type Database from 'better-sqlite3';
+import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+
+/** Raw SQLite row shape for the candidates table */
+interface CandidateRow {
+  id: string;
+  status: string;
+  source: string;
+  content: string;
+  title: string;
+  category: string;
+  trust_level: string;
+  author_json: string;
+  tenant_id: string;
+  metadata_json: string;
+  pre_policy_flags_json: string;
+  content_hash: string;
+  captured_at: string;
+  created_at: string;
+}
+
+function rowToCandidate(row: CandidateRow): MemoryCandidate {
+  return {
+    id: row.id,
+    status: row.status as MemoryCandidate['status'],
+    source: row.source as MemoryCandidate['source'],
+    content: row.content,
+    title: row.title,
+    category: row.category as MemoryCandidate['category'],
+    trustLevel: row.trust_level as MemoryCandidate['trustLevel'],
+    author: JSON.parse(row.author_json) as MemoryCandidate['author'],
+    tenantId: row.tenant_id,
+    metadata: JSON.parse(row.metadata_json) as MemoryCandidate['metadata'],
+    prePolicyFlags: JSON.parse(row.pre_policy_flags_json) as MemoryCandidate['prePolicyFlags'],
+    capturedAt: row.captured_at,
+  };
+}
+
+/**
+ * Repository for raw memory candidate proposals.
+ * All methods use prepared statements for safety and performance.
+ * Validation is the responsibility of the caller.
+ */
+export class CandidateRepository {
+  private readonly stmtInsert: Database.Statement;
+  private readonly stmtFindById: Database.Statement;
+  private readonly stmtFindByTenant: Database.Statement;
+  private readonly stmtFindByHash: Database.Statement;
+  private readonly stmtCount: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.stmtInsert = db.prepare(`
+      INSERT INTO candidates (
+        id, status, source, content, title, category,
+        trust_level, author_json, tenant_id,
+        metadata_json, pre_policy_flags_json, content_hash, captured_at
+      ) VALUES (
+        @id, @status, @source, @content, @title, @category,
+        @trust_level, @author_json, @tenant_id,
+        @metadata_json, @pre_policy_flags_json, @content_hash, @captured_at
+      )
+    `);
+
+    this.stmtFindById = db.prepare(`
+      SELECT * FROM candidates WHERE id = ?
+    `);
+
+    this.stmtFindByTenant = db.prepare(`
+      SELECT * FROM candidates WHERE tenant_id = ?
+    `);
+
+    this.stmtFindByHash = db.prepare(`
+      SELECT * FROM candidates WHERE content_hash = ? LIMIT 1
+    `);
+
+    this.stmtCount = db.prepare(`
+      SELECT COUNT(*) as cnt FROM candidates
+    `);
+  }
+
+  /** Insert a new candidate. The contentHash must be provided by the caller. */
+  insert(candidate: MemoryCandidate, contentHash: string): void {
+    this.stmtInsert.run({
+      id: candidate.id,
+      status: candidate.status,
+      source: candidate.source,
+      content: candidate.content,
+      title: candidate.title,
+      category: candidate.category,
+      trust_level: candidate.trustLevel,
+      author_json: JSON.stringify(candidate.author),
+      tenant_id: candidate.tenantId,
+      metadata_json: JSON.stringify(candidate.metadata),
+      pre_policy_flags_json: JSON.stringify(candidate.prePolicyFlags),
+      content_hash: contentHash,
+      captured_at: candidate.capturedAt,
+    });
+  }
+
+  /** Find a candidate by its primary key, or return null if not found. */
+  findById(id: string): MemoryCandidate | null {
+    const row = this.stmtFindById.get(id) as CandidateRow | undefined;
+    return row !== undefined ? rowToCandidate(row) : null;
+  }
+
+  /** Return all candidates belonging to the given tenant. */
+  findByTenant(tenantId: string): MemoryCandidate[] {
+    const rows = this.stmtFindByTenant.all(tenantId) as CandidateRow[];
+    return rows.map(rowToCandidate);
+  }
+
+  /**
+   * Return the first candidate with the given content hash, or null.
+   * Useful for duplicate detection before insertion.
+   */
+  findByContentHash(hash: string): MemoryCandidate | null {
+    const row = this.stmtFindByHash.get(hash) as CandidateRow | undefined;
+    return row !== undefined ? rowToCandidate(row) : null;
+  }
+
+  /** Return the total number of candidates in the store. */
+  count(): number {
+    const result = this.stmtCount.get() as { cnt: number };
+    return result.cnt;
+  }
+}

--- a/packages/store/src/repositories/export-state-repository.ts
+++ b/packages/store/src/repositories/export-state-repository.ts
@@ -1,0 +1,65 @@
+import type Database from 'better-sqlite3';
+
+/** The last-export tracking record for a single export target */
+export interface ExportState {
+  targetId: string;
+  lastExportedAt: string;
+  updatedAt: string;
+}
+
+/** Raw SQLite row shape for the export_state table */
+interface ExportStateRow {
+  target_id: string;
+  last_exported_at: string;
+  updated_at: string;
+}
+
+function rowToState(row: ExportStateRow): ExportState {
+  return {
+    targetId: row.target_id,
+    lastExportedAt: row.last_exported_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/**
+ * Repository for tracking the last successful export timestamp per target.
+ * Used by the git-exporter to implement incremental exports.
+ */
+export class ExportStateRepository {
+  private readonly stmtGet: Database.Statement;
+  private readonly stmtUpsert: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.stmtGet = db.prepare(`
+      SELECT * FROM export_state WHERE target_id = ?
+    `);
+
+    // Use INSERT OR REPLACE (a.k.a. UPSERT) to create-or-update in one statement.
+    // updated_at is written explicitly so tests can control the timestamp.
+    this.stmtUpsert = db.prepare(`
+      INSERT INTO export_state (target_id, last_exported_at, updated_at)
+      VALUES (@target_id, @last_exported_at, datetime('now'))
+      ON CONFLICT(target_id) DO UPDATE SET
+        last_exported_at = excluded.last_exported_at,
+        updated_at = datetime('now')
+    `);
+  }
+
+  /** Return the export state for the given target, or null if never exported. */
+  get(targetId: string): ExportState | null {
+    const row = this.stmtGet.get(targetId) as ExportStateRow | undefined;
+    return row !== undefined ? rowToState(row) : null;
+  }
+
+  /**
+   * Create or update the export state for the given target.
+   * updated_at is set to the current wall-clock time by the database.
+   */
+  set(targetId: string, lastExportedAt: string): void {
+    this.stmtUpsert.run({
+      target_id: targetId,
+      last_exported_at: lastExportedAt,
+    });
+  }
+}

--- a/packages/store/src/repositories/memory-repository.ts
+++ b/packages/store/src/repositories/memory-repository.ts
@@ -1,0 +1,245 @@
+import type Database from 'better-sqlite3';
+import type { CuratedMemory, MemoryLifecycleState } from '@qmd-team-intent-kb/schema';
+
+/** Raw SQLite row shape for the curated_memories table */
+interface MemoryRow {
+  id: string;
+  candidate_id: string;
+  source: string;
+  content: string;
+  title: string;
+  category: string;
+  trust_level: string;
+  sensitivity: string;
+  author_json: string;
+  tenant_id: string;
+  metadata_json: string;
+  lifecycle: string;
+  content_hash: string;
+  policy_evaluations_json: string;
+  supersession_json: string | null;
+  promoted_at: string;
+  promoted_by_json: string;
+  updated_at: string;
+  version: number;
+}
+
+function rowToMemory(row: MemoryRow): CuratedMemory {
+  const base = {
+    id: row.id,
+    candidateId: row.candidate_id,
+    source: row.source as CuratedMemory['source'],
+    content: row.content,
+    title: row.title,
+    category: row.category as CuratedMemory['category'],
+    trustLevel: row.trust_level as CuratedMemory['trustLevel'],
+    sensitivity: row.sensitivity as CuratedMemory['sensitivity'],
+    author: JSON.parse(row.author_json) as CuratedMemory['author'],
+    tenantId: row.tenant_id,
+    metadata: JSON.parse(row.metadata_json) as CuratedMemory['metadata'],
+    lifecycle: row.lifecycle as CuratedMemory['lifecycle'],
+    contentHash: row.content_hash,
+    policyEvaluations: JSON.parse(
+      row.policy_evaluations_json,
+    ) as CuratedMemory['policyEvaluations'],
+    supersession:
+      row.supersession_json !== null
+        ? (JSON.parse(row.supersession_json) as CuratedMemory['supersession'])
+        : undefined,
+    promotedAt: row.promoted_at,
+    promotedBy: JSON.parse(row.promoted_by_json) as CuratedMemory['promotedBy'],
+    updatedAt: row.updated_at,
+    version: row.version,
+  };
+
+  return base as CuratedMemory;
+}
+
+/**
+ * Repository for governance-approved curated memories.
+ * All methods use prepared statements. Validation is the caller's responsibility.
+ */
+export class MemoryRepository {
+  private readonly stmtInsert: Database.Statement;
+  private readonly stmtFindById: Database.Statement;
+  private readonly stmtFindByTenant: Database.Statement;
+  private readonly stmtFindByHash: Database.Statement;
+  private readonly stmtFindByLifecycle: Database.Statement;
+  private readonly stmtUpdateLifecycle: Database.Statement;
+  private readonly stmtUpdate: Database.Statement;
+  private readonly stmtCount: Database.Statement;
+  private readonly stmtAllHashes: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.stmtInsert = db.prepare(`
+      INSERT INTO curated_memories (
+        id, candidate_id, source, content, title, category,
+        trust_level, sensitivity, author_json, tenant_id,
+        metadata_json, lifecycle, content_hash,
+        policy_evaluations_json, supersession_json,
+        promoted_at, promoted_by_json, updated_at, version
+      ) VALUES (
+        @id, @candidate_id, @source, @content, @title, @category,
+        @trust_level, @sensitivity, @author_json, @tenant_id,
+        @metadata_json, @lifecycle, @content_hash,
+        @policy_evaluations_json, @supersession_json,
+        @promoted_at, @promoted_by_json, @updated_at, @version
+      )
+    `);
+
+    this.stmtFindById = db.prepare(`
+      SELECT * FROM curated_memories WHERE id = ?
+    `);
+
+    this.stmtFindByTenant = db.prepare(`
+      SELECT * FROM curated_memories WHERE tenant_id = ?
+    `);
+
+    this.stmtFindByHash = db.prepare(`
+      SELECT * FROM curated_memories WHERE content_hash = ? LIMIT 1
+    `);
+
+    this.stmtFindByLifecycle = db.prepare(`
+      SELECT * FROM curated_memories WHERE lifecycle = ?
+    `);
+
+    this.stmtUpdateLifecycle = db.prepare(`
+      UPDATE curated_memories SET lifecycle = @lifecycle, updated_at = @updated_at WHERE id = @id
+    `);
+
+    this.stmtUpdate = db.prepare(`
+      UPDATE curated_memories SET
+        candidate_id = @candidate_id,
+        source = @source,
+        content = @content,
+        title = @title,
+        category = @category,
+        trust_level = @trust_level,
+        sensitivity = @sensitivity,
+        author_json = @author_json,
+        tenant_id = @tenant_id,
+        metadata_json = @metadata_json,
+        lifecycle = @lifecycle,
+        content_hash = @content_hash,
+        policy_evaluations_json = @policy_evaluations_json,
+        supersession_json = @supersession_json,
+        promoted_at = @promoted_at,
+        promoted_by_json = @promoted_by_json,
+        updated_at = @updated_at,
+        version = @version
+      WHERE id = @id
+    `);
+
+    this.stmtCount = db.prepare(`
+      SELECT COUNT(*) as cnt FROM curated_memories
+    `);
+
+    this.stmtAllHashes = db.prepare(`
+      SELECT content_hash FROM curated_memories
+    `);
+  }
+
+  /** Insert a new curated memory. */
+  insert(memory: CuratedMemory): void {
+    this.stmtInsert.run({
+      id: memory.id,
+      candidate_id: memory.candidateId,
+      source: memory.source,
+      content: memory.content,
+      title: memory.title,
+      category: memory.category,
+      trust_level: memory.trustLevel,
+      sensitivity: memory.sensitivity,
+      author_json: JSON.stringify(memory.author),
+      tenant_id: memory.tenantId,
+      metadata_json: JSON.stringify(memory.metadata),
+      lifecycle: memory.lifecycle,
+      content_hash: memory.contentHash,
+      policy_evaluations_json: JSON.stringify(memory.policyEvaluations),
+      supersession_json:
+        memory.supersession !== undefined ? JSON.stringify(memory.supersession) : null,
+      promoted_at: memory.promotedAt,
+      promoted_by_json: JSON.stringify(memory.promotedBy),
+      updated_at: memory.updatedAt,
+      version: memory.version,
+    });
+  }
+
+  /** Find a memory by its primary key, or return null if not found. */
+  findById(id: string): CuratedMemory | null {
+    const row = this.stmtFindById.get(id) as MemoryRow | undefined;
+    return row !== undefined ? rowToMemory(row) : null;
+  }
+
+  /** Return all curated memories belonging to the given tenant. */
+  findByTenant(tenantId: string): CuratedMemory[] {
+    const rows = this.stmtFindByTenant.all(tenantId) as MemoryRow[];
+    return rows.map(rowToMemory);
+  }
+
+  /**
+   * Return the first memory with the given content hash, or null.
+   * Useful for duplicate detection before promotion.
+   */
+  findByContentHash(hash: string): CuratedMemory | null {
+    const row = this.stmtFindByHash.get(hash) as MemoryRow | undefined;
+    return row !== undefined ? rowToMemory(row) : null;
+  }
+
+  /** Return all memories in the given lifecycle state. */
+  findByLifecycle(lifecycle: MemoryLifecycleState): CuratedMemory[] {
+    const rows = this.stmtFindByLifecycle.all(lifecycle) as MemoryRow[];
+    return rows.map(rowToMemory);
+  }
+
+  /**
+   * Update only the lifecycle state and updatedAt timestamp.
+   * Returns true if a row was modified, false if the id was not found.
+   */
+  updateLifecycle(id: string, lifecycle: MemoryLifecycleState, updatedAt: string): boolean {
+    const result = this.stmtUpdateLifecycle.run({ id, lifecycle, updated_at: updatedAt });
+    return result.changes > 0;
+  }
+
+  /**
+   * Perform a full update of a curated memory record.
+   * Returns true if a row was modified, false if the id was not found.
+   */
+  update(memory: CuratedMemory): boolean {
+    const result = this.stmtUpdate.run({
+      id: memory.id,
+      candidate_id: memory.candidateId,
+      source: memory.source,
+      content: memory.content,
+      title: memory.title,
+      category: memory.category,
+      trust_level: memory.trustLevel,
+      sensitivity: memory.sensitivity,
+      author_json: JSON.stringify(memory.author),
+      tenant_id: memory.tenantId,
+      metadata_json: JSON.stringify(memory.metadata),
+      lifecycle: memory.lifecycle,
+      content_hash: memory.contentHash,
+      policy_evaluations_json: JSON.stringify(memory.policyEvaluations),
+      supersession_json:
+        memory.supersession !== undefined ? JSON.stringify(memory.supersession) : null,
+      promoted_at: memory.promotedAt,
+      promoted_by_json: JSON.stringify(memory.promotedBy),
+      updated_at: memory.updatedAt,
+      version: memory.version,
+    });
+    return result.changes > 0;
+  }
+
+  /** Return the total number of curated memories in the store. */
+  count(): number {
+    const result = this.stmtCount.get() as { cnt: number };
+    return result.cnt;
+  }
+
+  /** Return all distinct content hashes present in the store. */
+  getAllContentHashes(): string[] {
+    const rows = this.stmtAllHashes.all() as Array<{ content_hash: string }>;
+    return rows.map((r) => r.content_hash);
+  }
+}

--- a/packages/store/src/repositories/policy-repository.ts
+++ b/packages/store/src/repositories/policy-repository.ts
@@ -1,0 +1,124 @@
+import type Database from 'better-sqlite3';
+import type { GovernancePolicy } from '@qmd-team-intent-kb/schema';
+
+/** Raw SQLite row shape for the governance_policies table */
+interface PolicyRow {
+  id: string;
+  name: string;
+  tenant_id: string;
+  rules_json: string;
+  enabled: number;
+  version: number;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToPolicy(row: PolicyRow): GovernancePolicy {
+  return {
+    id: row.id,
+    name: row.name,
+    tenantId: row.tenant_id,
+    rules: JSON.parse(row.rules_json) as GovernancePolicy['rules'],
+    enabled: row.enabled !== 0,
+    version: row.version,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/**
+ * Repository for governance policy configurations.
+ * All methods use prepared statements. Validation is the caller's responsibility.
+ */
+export class PolicyRepository {
+  private readonly stmtInsert: Database.Statement;
+  private readonly stmtFindById: Database.Statement;
+  private readonly stmtFindByTenant: Database.Statement;
+  private readonly stmtUpdate: Database.Statement;
+  private readonly stmtDelete: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.stmtInsert = db.prepare(`
+      INSERT INTO governance_policies (
+        id, name, tenant_id, rules_json, enabled, version, created_at, updated_at
+      ) VALUES (
+        @id, @name, @tenant_id, @rules_json, @enabled, @version, @created_at, @updated_at
+      )
+    `);
+
+    this.stmtFindById = db.prepare(`
+      SELECT * FROM governance_policies WHERE id = ?
+    `);
+
+    this.stmtFindByTenant = db.prepare(`
+      SELECT * FROM governance_policies WHERE tenant_id = ?
+    `);
+
+    this.stmtUpdate = db.prepare(`
+      UPDATE governance_policies SET
+        name = @name,
+        tenant_id = @tenant_id,
+        rules_json = @rules_json,
+        enabled = @enabled,
+        version = @version,
+        updated_at = @updated_at
+      WHERE id = @id
+    `);
+
+    this.stmtDelete = db.prepare(`
+      DELETE FROM governance_policies WHERE id = ?
+    `);
+  }
+
+  /** Insert a new governance policy. */
+  insert(policy: GovernancePolicy): void {
+    this.stmtInsert.run({
+      id: policy.id,
+      name: policy.name,
+      tenant_id: policy.tenantId,
+      rules_json: JSON.stringify(policy.rules),
+      enabled: policy.enabled ? 1 : 0,
+      version: policy.version,
+      created_at: policy.createdAt,
+      updated_at: policy.updatedAt,
+    });
+  }
+
+  /** Find a policy by its primary key, or return null if not found. */
+  findById(id: string): GovernancePolicy | null {
+    const row = this.stmtFindById.get(id) as PolicyRow | undefined;
+    return row !== undefined ? rowToPolicy(row) : null;
+  }
+
+  /** Return all policies belonging to the given tenant. */
+  findByTenant(tenantId: string): GovernancePolicy[] {
+    const rows = this.stmtFindByTenant.all(tenantId) as PolicyRow[];
+    return rows.map(rowToPolicy);
+  }
+
+  /**
+   * Perform a full update of an existing policy record.
+   * Returns true if a row was modified, false if the id was not found.
+   */
+  update(policy: GovernancePolicy): boolean {
+    const result = this.stmtUpdate.run({
+      id: policy.id,
+      name: policy.name,
+      tenant_id: policy.tenantId,
+      rules_json: JSON.stringify(policy.rules),
+      enabled: policy.enabled ? 1 : 0,
+      version: policy.version,
+      updated_at: policy.updatedAt,
+    });
+    return result.changes > 0;
+  }
+
+  /**
+   * Delete a policy by id.
+   * Returns true if a row was deleted, false if the id was not found.
+   */
+  delete(id: string): boolean {
+    const result = this.stmtDelete.run(id);
+    return result.changes > 0;
+  }
+}

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -1,0 +1,100 @@
+/**
+ * SQL DDL statements for the store package.
+ * Each entry creates one table and its associated indexes idempotently.
+ */
+
+const CANDIDATES_DDL = `
+CREATE TABLE IF NOT EXISTS candidates (
+  id TEXT PRIMARY KEY,
+  status TEXT NOT NULL DEFAULT 'inbox',
+  source TEXT NOT NULL,
+  content TEXT NOT NULL,
+  title TEXT NOT NULL,
+  category TEXT NOT NULL,
+  trust_level TEXT NOT NULL DEFAULT 'medium',
+  author_json TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  pre_policy_flags_json TEXT NOT NULL DEFAULT '{}',
+  content_hash TEXT NOT NULL,
+  captured_at TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_candidates_tenant ON candidates(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_candidates_hash ON candidates(content_hash);
+`.trim();
+
+const CURATED_MEMORIES_DDL = `
+CREATE TABLE IF NOT EXISTS curated_memories (
+  id TEXT PRIMARY KEY,
+  candidate_id TEXT NOT NULL,
+  source TEXT NOT NULL,
+  content TEXT NOT NULL,
+  title TEXT NOT NULL,
+  category TEXT NOT NULL,
+  trust_level TEXT NOT NULL,
+  sensitivity TEXT NOT NULL DEFAULT 'internal',
+  author_json TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  lifecycle TEXT NOT NULL DEFAULT 'active',
+  content_hash TEXT NOT NULL,
+  policy_evaluations_json TEXT NOT NULL DEFAULT '[]',
+  supersession_json TEXT,
+  promoted_at TEXT NOT NULL,
+  promoted_by_json TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  version INTEGER NOT NULL DEFAULT 1
+);
+CREATE INDEX IF NOT EXISTS idx_memories_tenant ON curated_memories(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_memories_hash ON curated_memories(content_hash);
+CREATE INDEX IF NOT EXISTS idx_memories_lifecycle ON curated_memories(lifecycle);
+CREATE INDEX IF NOT EXISTS idx_memories_updated ON curated_memories(updated_at);
+`.trim();
+
+const GOVERNANCE_POLICIES_DDL = `
+CREATE TABLE IF NOT EXISTS governance_policies (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  rules_json TEXT NOT NULL,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  version INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_policies_tenant ON governance_policies(tenant_id);
+`.trim();
+
+const AUDIT_EVENTS_DDL = `
+CREATE TABLE IF NOT EXISTS audit_events (
+  id TEXT PRIMARY KEY,
+  action TEXT NOT NULL,
+  memory_id TEXT NOT NULL,
+  tenant_id TEXT NOT NULL,
+  actor_json TEXT NOT NULL,
+  reason TEXT,
+  details_json TEXT NOT NULL DEFAULT '{}',
+  timestamp TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_audit_memory ON audit_events(memory_id);
+CREATE INDEX IF NOT EXISTS idx_audit_tenant ON audit_events(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_events(action);
+`.trim();
+
+const EXPORT_STATE_DDL = `
+CREATE TABLE IF NOT EXISTS export_state (
+  target_id TEXT PRIMARY KEY,
+  last_exported_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+`.trim();
+
+/** All DDL statements, each including the CREATE TABLE and its indexes as one string. */
+export const TABLE_DDL: string[] = [
+  CANDIDATES_DDL,
+  CURATED_MEMORIES_DDL,
+  GOVERNANCE_POLICIES_DDL,
+  AUDIT_EVENTS_DDL,
+  EXPORT_STATE_DDL,
+];

--- a/packages/store/tsconfig.json
+++ b/packages/store/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "../schema" }, { "path": "../common" }]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,17 @@ importers:
 
   packages/common: {}
 
-  packages/policy-engine: {}
+  packages/policy-engine:
+    dependencies:
+      '@qmd-team-intent-kb/claude-runtime':
+        specifier: workspace:*
+        version: link:../claude-runtime
+      '@qmd-team-intent-kb/common':
+        specifier: workspace:*
+        version: link:../common
+      '@qmd-team-intent-kb/schema':
+        specifier: workspace:*
+        version: link:../schema
 
   packages/qmd-adapter:
     dependencies:
@@ -70,6 +80,22 @@ importers:
       zod:
         specifier: ^3.23.0
         version: 3.25.76
+
+  packages/store:
+    dependencies:
+      '@qmd-team-intent-kb/common':
+        specifier: workspace:*
+        version: link:../common
+      '@qmd-team-intent-kb/schema':
+        specifier: workspace:*
+        version: link:../schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.0
+        version: 7.6.13
 
 packages:
 
@@ -432,6 +458,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -587,12 +616,27 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -613,6 +657,9 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -641,9 +688,17 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -651,6 +706,13 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -713,6 +775,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -757,6 +823,9 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   find-my-way@9.5.0:
     resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
     engines: {node: '>=20'}
@@ -772,10 +841,16 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -788,6 +863,9 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -804,6 +882,12 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ipaddr.js@2.3.0:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
@@ -865,12 +949,22 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -880,12 +974,22 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -939,6 +1043,12 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -954,12 +1064,23 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
@@ -988,6 +1109,9 @@ packages:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-regex2@5.1.0:
     resolution: {integrity: sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==}
@@ -1019,6 +1143,12 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -1036,6 +1166,13 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -1046,6 +1183,13 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
@@ -1083,6 +1227,9 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -1104,6 +1251,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1191,6 +1341,9 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -1438,6 +1591,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.19.15
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -1631,6 +1788,23 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -1639,6 +1813,11 @@ snapshots:
   brace-expansion@5.0.4:
     dependencies:
       balanced-match: 4.0.4
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   cac@6.7.14: {}
 
@@ -1658,6 +1837,8 @@ snapshots:
       supports-color: 7.2.0
 
   check-error@2.1.3: {}
+
+  chownr@1.1.4: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -1679,11 +1860,23 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@5.0.2: {}
+
+  deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
 
   dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   es-module-lexer@1.7.0: {}
 
@@ -1790,6 +1983,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   fast-decode-uri-component@1.0.1: {}
@@ -1845,6 +2040,8 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-uri-to-path@1.0.0: {}
+
   find-my-way@9.5.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -1863,8 +2060,12 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  fs-constants@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
+
+  github-from-package@0.0.0: {}
 
   glob-parent@6.0.2:
     dependencies:
@@ -1873,6 +2074,8 @@ snapshots:
   globals@14.0.0: {}
 
   has-flag@4.0.0: {}
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -1884,6 +2087,10 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   ipaddr.js@2.3.0: {}
 
@@ -1940,6 +2147,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mimic-response@3.1.0: {}
+
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.4
@@ -1948,13 +2157,27 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
   natural-compare@1.4.0: {}
 
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
+
   on-exit-leak-free@2.1.2: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -2015,6 +2238,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   prettier@3.8.1: {}
@@ -2023,9 +2261,27 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   real-require@0.2.0: {}
 
@@ -2070,6 +2326,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  safe-buffer@5.2.1: {}
+
   safe-regex2@5.1.0:
     dependencies:
       ret: 0.5.0
@@ -2090,6 +2348,14 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
@@ -2102,6 +2368,12 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-json-comments@2.0.1: {}
+
   strip-json-comments@3.1.1: {}
 
   strip-literal@3.1.0:
@@ -2111,6 +2383,21 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   thread-stream@4.0.0:
     dependencies:
@@ -2137,6 +2424,10 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -2159,6 +2450,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
 
   vite-node@3.2.4(@types/node@22.19.15):
     dependencies:
@@ -2244,6 +2537,8 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrappy@1.0.2: {}
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,25 @@ importers:
 
   apps/api:
     dependencies:
+      '@qmd-team-intent-kb/common':
+        specifier: workspace:*
+        version: link:../../packages/common
+      '@qmd-team-intent-kb/policy-engine':
+        specifier: workspace:*
+        version: link:../../packages/policy-engine
+      '@qmd-team-intent-kb/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      '@qmd-team-intent-kb/store':
+        specifier: workspace:*
+        version: link:../../packages/store
       fastify:
         specifier: ^5.0.0
         version: 5.8.2
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.0
+        version: 7.6.13
 
   apps/curator: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,27 @@ importers:
         specifier: ^7.6.0
         version: 7.6.13
 
-  apps/curator: {}
+  apps/curator:
+    dependencies:
+      '@qmd-team-intent-kb/claude-runtime':
+        specifier: workspace:*
+        version: link:../../packages/claude-runtime
+      '@qmd-team-intent-kb/common':
+        specifier: workspace:*
+        version: link:../../packages/common
+      '@qmd-team-intent-kb/policy-engine':
+        specifier: workspace:*
+        version: link:../../packages/policy-engine
+      '@qmd-team-intent-kb/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      '@qmd-team-intent-kb/store':
+        specifier: workspace:*
+        version: link:../../packages/store
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.0
+        version: 7.6.13
 
   apps/edge-daemon: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,21 @@ importers:
 
   apps/edge-daemon: {}
 
-  apps/git-exporter: {}
+  apps/git-exporter:
+    dependencies:
+      '@qmd-team-intent-kb/common':
+        specifier: workspace:*
+        version: link:../../packages/common
+      '@qmd-team-intent-kb/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      '@qmd-team-intent-kb/store':
+        specifier: workspace:*
+        version: link:../../packages/store
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.0
+        version: 7.6.13
 
   apps/reporting: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "packages/common" },
     { "path": "packages/schema" },
+    { "path": "packages/store" },
     { "path": "packages/qmd-adapter" },
     { "path": "packages/claude-runtime" },
     { "path": "packages/policy-engine" },


### PR DESCRIPTION
## Summary
- **Phase 4A**: Policy engine (`packages/policy-engine`) — 6 deterministic rule evaluators with short-circuit pipeline (54 tests)
- **Phase 4B**: SQLite store (`packages/store`) — better-sqlite3 with WAL mode, 5 repositories, in-memory testing (38 tests)
- **Phase 4C**: Control plane API (`apps/api`) — Fastify REST API with service layer, lifecycle transitions, audit trail (62 tests)
- **Phase 5**: Curator engine (`apps/curator`) — spool intake, exact-hash dedup, Jaccard supersession, promotion/rejection pipeline (79 tests)
- **Phase 6**: Git exporter (`apps/git-exporter`) — incremental Markdown export, YAML frontmatter, category-based directory mapping (76 tests)

**309 new tests** across 5 packages/apps. Cumulative: **678 tests passing**.

### Architectural decisions
- `packages/store` extracted as shared persistence layer (not inside `apps/api`)
- SQLite via better-sqlite3 for zero-config embedded persistence
- No auth (documented for future hardening)
- String-templated YAML frontmatter (no yaml lib dependency)

## Test plan
- [x] `pnpm validate` passes (format, lint, typecheck, 678 tests)
- [x] All 6 rule evaluators tested independently
- [x] Policy pipeline short-circuit behavior verified
- [x] All 5 repositories tested with in-memory SQLite
- [x] API routes tested via Fastify inject (no HTTP overhead)
- [x] Curator pipeline: dedup, supersession, promotion, rejection, dry-run
- [x] Git exporter: frontmatter, directory mapping, change detection, idempotency

🤖 Generated with [Claude Code](https://claude.com/claude-code)