### PR TITLE
feat: governed team knowledge plugin (v0.3.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "qmd-team-intent-kb",
+  "version": "0.3.0",
+  "description": "Governed team memory — deterministic policy, lifecycle, team sharing via qmd",
+  "author": {
+    "name": "Intent Solutions",
+    "url": "https://github.com/jeremylongshore"
+  },
+  "repository": "https://github.com/jeremylongshore/qmd-team-intent-kb",
+  "license": "UNLICENSED",
+  "keywords": ["memory", "team", "knowledge", "governance", "qmd"]
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "teamkb": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/apps/mcp-server/dist/index.js"],
+      "env": {
+        "TEAMKB_TENANT_ID": "${TEAMKB_TENANT_ID}"
+      }
+    }
+  }
+}

--- a/agents/teamkb-classifier.md
+++ b/agents/teamkb-classifier.md
@@ -1,0 +1,34 @@
+---
+name: teamkb-classifier
+description: |
+  Categorizes a document or text into a MemoryCategory. Used by teamkb_import
+  when heuristic path matching is insufficient. Returns category and confidence.
+---
+
+Classify the provided content into exactly one category:
+
+- **decision** — Architectural or design decisions with rationale
+- **pattern** — Reusable code or design patterns
+- **convention** — Team coding standards, naming, style rules
+- **architecture** — System structure, data flow, component relationships
+- **troubleshooting** — Bug fixes, debugging techniques, error resolution
+- **onboarding** — Getting started, setup, how-to guides
+- **reference** — API docs, config reference, external links
+
+## Response Format
+
+Respond with JSON only:
+
+```json
+{ "category": "<category>", "confidence": <0.0-1.0> }
+```
+
+## Guidelines
+
+- Choose the single best-fitting category
+- Confidence above 0.8 means strong match to the category definition
+- Confidence below 0.5 means the content is ambiguous — use "reference" as fallback
+- Consider the document's primary purpose, not just keywords
+- ADR (Architecture Decision Record) format → always "decision"
+- README/setup instructions → "onboarding"
+- Error logs or stack trace analysis → "troubleshooting"

--- a/agents/teamkb-conflict-checker.md
+++ b/agents/teamkb-conflict-checker.md
@@ -1,0 +1,49 @@
+---
+name: teamkb-conflict-checker
+description: |
+  Compares a proposed memory against existing similar memories to detect
+  semantic conflicts (contradictory decisions, outdated patterns). Called
+  after initial dedup passes but before final promotion.
+---
+
+You are comparing a proposed memory against existing team memories to detect
+semantic conflicts.
+
+## Input
+
+You will receive:
+
+1. The **proposed memory** (title + content)
+2. A list of **existing memories** with similar titles or content
+
+## Analysis
+
+For each existing memory, determine:
+
+- Does the proposed memory **contradict** it? (different conclusion, incompatible approach)
+- Does the proposed memory **supersede** it? (same topic, newer/better information)
+- Are they **compatible**? (different aspects of the same topic, or unrelated)
+
+## Response Format
+
+Respond with one of:
+
+```json
+{ "result": "no_conflict" }
+```
+
+```json
+{ "result": "supersedes", "memoryId": "<id-of-superseded-memory>", "reason": "explanation" }
+```
+
+```json
+{ "result": "conflicts", "memoryId": "<id-of-conflicting-memory>", "reason": "explanation" }
+```
+
+## Guidelines
+
+- **Supersedes** means the new memory covers the same ground with updated information
+- **Conflicts** means both cannot be true simultaneously (flag for human review)
+- **No conflict** is the default — only flag real contradictions
+- Consider that older decisions may have been valid at the time but outdated now
+- When in doubt, prefer "no_conflict" to avoid blocking knowledge capture

--- a/agents/teamkb-curator.md
+++ b/agents/teamkb-curator.md
@@ -1,0 +1,58 @@
+---
+name: teamkb-curator
+description: |
+  Reviews recent session work and proposes team-worthy memories. Invoked
+  at session end or on-demand. Reads recent tool calls, file changes, and
+  decisions. For each insight worth sharing, calls teamkb_propose MCP tool.
+  The governance pipeline (deterministic, not this agent) decides promotion.
+---
+
+You are a knowledge curator for a development team. Your job is to review
+what happened in this session and identify insights worth preserving as
+team memory.
+
+## What to Look For
+
+Scan the session for:
+
+- **Architectural decisions** and their rationale (why X over Y)
+- **Patterns** discovered or established (reusable approaches)
+- **Conventions** agreed upon (naming, structure, style rules)
+- **Non-obvious debugging solutions** (root causes that weren't intuitive)
+- **Important context** about the codebase (data flow, dependencies, gotchas)
+- **Onboarding knowledge** (setup steps, prerequisites, common pitfalls)
+
+## How to Capture
+
+For each insight worth preserving, call the `teamkb_propose` MCP tool:
+
+```json
+{
+  "title": "Clear, descriptive title",
+  "content": "Detailed explanation with context and rationale",
+  "category": "decision|pattern|convention|architecture|troubleshooting|onboarding|reference",
+  "filePaths": ["relevant/file/paths"]
+}
+```
+
+## What NOT to Propose
+
+- Session-specific debugging steps (too ephemeral)
+- Personal preferences (not team knowledge)
+- Content that's already in CLAUDE.md, README, or existing team memories
+- Anything containing secrets, tokens, or credentials
+- Trivial changes that don't carry reusable insight
+
+## Quality Bar
+
+Ask for each candidate: **"Would a new team member benefit from finding this in 30 days?"**
+
+If the answer is no, skip it. Prefer fewer high-quality memories over many low-value ones.
+
+## Process
+
+1. Read recent file changes with `Glob` and `Read`
+2. Identify the key decisions, patterns, or conventions from the session
+3. For each, craft a clear title and detailed content
+4. Call `teamkb_propose` for each insight
+5. Report what you proposed and why

--- a/agents/teamkb-scout.md
+++ b/agents/teamkb-scout.md
@@ -1,0 +1,41 @@
+---
+name: teamkb-scout
+description: |
+  Discovers trending agent tools, MCP servers, and Claude Code plugins
+  that could benefit the team. Proposes findings as reference memories
+  with low trust level. Requires source_trust policy rule to enforce
+  review before promotion.
+---
+
+You are a tool discovery agent for a development team. Your job is to find
+useful tools, MCP servers, and Claude Code plugins that could improve the
+team's workflow.
+
+## Discovery Scope
+
+Search for:
+
+- New MCP servers relevant to the team's tech stack
+- Claude Code plugins that automate common tasks
+- CLI tools that improve developer experience
+- Libraries or frameworks worth evaluating
+
+## How to Report
+
+For each discovery, call `teamkb_propose` with:
+
+```json
+{
+  "title": "Tool: <tool-name> — <one-line description>",
+  "content": "## What it does\n<description>\n\n## Why it matters\n<relevance to team>\n\n## Links\n- <url>\n\n## Evaluation status\nDiscovered by scout — needs team review before adoption.",
+  "category": "reference"
+}
+```
+
+## Quality Bar
+
+- Only propose tools that are **relevant** to the current project's tech stack
+- Include concrete reasons why the team should evaluate it
+- Note any risks (security, maintenance, licensing)
+- Prefer established tools over bleeding-edge experiments
+- Maximum 5 discoveries per session to avoid noise

--- a/apps/api/src/__tests__/api-key-auth.test.ts
+++ b/apps/api/src/__tests__/api-key-auth.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '@qmd-team-intent-kb/store';
+import { buildApp } from '../app.js';
+
+// ---------------------------------------------------------------------------
+// API key auth — security-focused tests
+// ---------------------------------------------------------------------------
+
+describe('API key auth — timing-safe comparison', () => {
+  let db: Database.Database;
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    app = buildApp({ db, silent: true, apiKey: 'correct-key-abc123' });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.close();
+  });
+
+  it('valid key passes timing-safe comparison and returns non-401', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/memories',
+      headers: { Authorization: 'Bearer correct-key-abc123' },
+    });
+    expect(res.statusCode).not.toBe(401);
+  });
+
+  it('wrong token on Bearer scheme is rejected via timing-safe path', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/memories',
+      headers: { Authorization: 'Bearer wrong-key-xyz' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('token with same length as key but different content is rejected', async () => {
+    // Same byte-length as 'correct-key-abc123' to exercise the equal-length
+    // timingSafeEqual branch, not the fast-reject length-mismatch branch
+    const sameLength = 'X'.repeat('correct-key-abc123'.length);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/memories',
+      headers: { Authorization: `Bearer ${sameLength}` },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('token with different length is rejected (constant-time fallback branch)', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/memories',
+      headers: { Authorization: 'Bearer short' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('API key auth — fail-closed in production', () => {
+  it('throws when NODE_ENV=production and no API key is set', async () => {
+    const original = process.env['NODE_ENV'];
+    process.env['NODE_ENV'] = 'production';
+    try {
+      const db = createTestDatabase();
+      try {
+        expect(() => buildApp({ db, silent: true })).toThrow(/must be set in production/i);
+      } finally {
+        db.close();
+      }
+    } finally {
+      process.env['NODE_ENV'] = original;
+    }
+  });
+
+  it('does not throw when NODE_ENV=production and API key is provided', async () => {
+    const original = process.env['NODE_ENV'];
+    process.env['NODE_ENV'] = 'production';
+    let app: FastifyInstance | undefined;
+    const db = createTestDatabase();
+    try {
+      expect(() => {
+        app = buildApp({ db, silent: true, apiKey: 'prod-key-abc' });
+      }).not.toThrow();
+    } finally {
+      process.env['NODE_ENV'] = original;
+      await app?.close();
+      db.close();
+    }
+  });
+});
+
+describe('API key auth — malformed Authorization headers', () => {
+  let db: Database.Database;
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    app = buildApp({ db, silent: true, apiKey: 'test-key-789' });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.close();
+  });
+
+  it('rejects Authorization header with no space separator', async () => {
+    // e.g. "Bearertoken" — no space between scheme and token
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/memories',
+      headers: { Authorization: 'Bearertest-key-789' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects empty Authorization header value', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/memories',
+      headers: { Authorization: '' },
+    });
+    // Empty string header — 401 expected (missing token)
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects non-Bearer scheme even with correct token value', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/memories',
+      headers: { Authorization: 'Token test-key-789' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects Bearer with empty token (Bearer followed by space only)', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/memories',
+      headers: { Authorization: 'Bearer ' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('health endpoint is always exempt regardless of missing auth', async () => {
+    // Health is always exempt — no Authorization required
+    const res = await app.inject({ method: 'GET', url: '/health' });
+    expect(res.statusCode).not.toBe(401);
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -47,7 +47,7 @@ export interface AppDependencies {
  */
 export function buildApp(deps: AppDependencies): FastifyInstance {
   const bodyLimit = deps.maxBodySize ?? 1_048_576;
-  const app = Fastify({ logger: deps.silent !== false ? false : true, bodyLimit });
+  const app = Fastify({ logger: !deps.silent, bodyLimit });
 
   // Middleware (order: rate-limiter → auth → sanitizer → routes)
   registerRateLimiter(app, deps.rateLimitMax ?? 100, deps.rateLimitWindowMs ?? 60000);

--- a/apps/api/src/middleware/api-key-auth.ts
+++ b/apps/api/src/middleware/api-key-auth.ts
@@ -1,12 +1,44 @@
+import { timingSafeEqual } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 
 /**
- * Optional bearer token authentication middleware.
- * If TEAMKB_API_KEY is not set, authentication is skipped (dev mode).
- * The health endpoint is always exempt.
+ * Compare two strings in constant time to prevent timing attacks.
+ * Pads the shorter string to match lengths before comparison.
+ */
+function timingSafeCompare(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, 'utf8');
+  const bufB = Buffer.from(b, 'utf8');
+
+  // timingSafeEqual requires equal-length buffers.
+  // If lengths differ, compare against a dummy buffer (constant-time rejection).
+  if (bufA.length !== bufB.length) {
+    // Still call timingSafeEqual so the timing profile stays constant
+    timingSafeEqual(bufA, Buffer.alloc(bufA.length));
+    return false;
+  }
+
+  return timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * Bearer token authentication middleware.
+ *
+ * Security model:
+ * - **Production (NODE_ENV=production)**: API key is REQUIRED. If not set,
+ *   the server refuses to start (fail-closed).
+ * - **Development**: If TEAMKB_API_KEY is not set, authentication is skipped.
+ * - Token comparison uses `crypto.timingSafeEqual` to prevent timing attacks.
+ * - The health endpoint is always exempt.
  */
 export function registerApiKeyAuth(app: FastifyInstance, apiKey: string | undefined): void {
+  const isProduction = process.env['NODE_ENV'] === 'production';
+
   if (apiKey === undefined || apiKey === '') {
+    if (isProduction) {
+      throw new Error(
+        'TEAMKB_API_KEY must be set in production. Refusing to start without authentication.',
+      );
+    }
     return; // Dev mode — no auth required
   }
 
@@ -23,9 +55,16 @@ export function registerApiKeyAuth(app: FastifyInstance, apiKey: string | undefi
       throw new Error('Missing Authorization header');
     }
 
-    const [scheme, token] = authHeader.split(' ');
+    const spaceIndex = authHeader.indexOf(' ');
+    if (spaceIndex === -1) {
+      reply.status(401);
+      throw new Error('Invalid Authorization header format');
+    }
 
-    if (scheme !== 'Bearer' || token !== apiKey) {
+    const scheme = authHeader.slice(0, spaceIndex);
+    const token = authHeader.slice(spaceIndex + 1);
+
+    if (scheme !== 'Bearer' || !timingSafeCompare(token, apiKey)) {
       reply.status(401);
       throw new Error('Invalid API key');
     }

--- a/apps/curator/src/__tests__/curator.test.ts
+++ b/apps/curator/src/__tests__/curator.test.ts
@@ -342,7 +342,11 @@ describe('Curator.processBatch', () => {
 
   it('dry run mode returns same outcomes but does not persist', () => {
     const curator = new Curator(deps, { tenantId: TENANT, dryRun: true });
-    const candidates = [makeCandidate(), makeCandidate()];
+    // Use distinct content so intra-batch dedup doesn't catch the second
+    const candidates = [
+      makeCandidate({ content: 'First unique candidate with enough content for length check.' }),
+      makeCandidate({ content: 'Second unique candidate with enough content for length check.' }),
+    ];
     const result = curator.processBatch(candidates);
 
     // Outcomes are computed

--- a/apps/curator/src/__tests__/intra-batch-dedup.test.ts
+++ b/apps/curator/src/__tests__/intra-batch-dedup.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createTestDatabase,
+  CandidateRepository,
+  MemoryRepository,
+  PolicyRepository,
+  AuditRepository,
+} from '@qmd-team-intent-kb/store';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type Database from 'better-sqlite3';
+import { Curator } from '../curator.js';
+import type { CuratorDependencies } from '../curator.js';
+import { makeCandidate, TENANT } from './fixtures.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDeps(db: Database.Database): CuratorDependencies {
+  return {
+    candidateRepo: new CandidateRepository(db),
+    memoryRepo: new MemoryRepository(db),
+    policyRepo: new PolicyRepository(db),
+    auditRepo: new AuditRepository(db),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Intra-batch dedup tests
+// ---------------------------------------------------------------------------
+
+describe('Curator.processBatch — intra-batch duplicate detection', () => {
+  let deps: CuratorDependencies;
+
+  beforeEach(() => {
+    const db = createTestDatabase();
+    deps = makeDeps(db);
+  });
+
+  it('second candidate with identical content is detected as intra-batch duplicate', () => {
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const sharedContent = 'Intra-batch dedup test: unique content string here abc123xyz.';
+    const c1 = makeCandidate({ content: sharedContent });
+    const c2 = makeCandidate({ content: sharedContent });
+
+    const result = curator.processBatch([c1, c2]);
+
+    expect(result.promoted).toBe(1);
+    expect(result.duplicates).toBe(1);
+    expect(result.results[0]?.outcome).toBe('promoted');
+    expect(result.results[1]?.outcome).toBe('duplicate');
+  });
+
+  it('intra-batch duplicate reason mentions intra-batch (dry-run mode)', () => {
+    // In dry-run mode, promote() does not insert to the store, so checkDuplicate
+    // (store-based) will NOT find the first candidate. The second candidate is
+    // caught by the intra-batch existingHashes set instead, which does contain
+    // the hash added after the first promotion completes.
+    const curator = new Curator(deps, { tenantId: TENANT, dryRun: true });
+    const content = 'Specific content to verify intra-batch reason message here.';
+    const c1 = makeCandidate({ content });
+    const c2 = makeCandidate({ content });
+
+    const result = curator.processBatch([c1, c2]);
+
+    const dupResult = result.results[1];
+    expect(dupResult?.outcome).toBe('duplicate');
+    expect(dupResult?.reason).toMatch(/intra-batch/i);
+  });
+
+  it('distinct candidates both get promoted (no false dedup)', () => {
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const c1 = makeCandidate({
+      content: 'First distinct content for testing batch promotion candidate A.',
+    });
+    const c2 = makeCandidate({
+      content: 'Second distinct content for testing batch promotion candidate B.',
+    });
+
+    const result = curator.processBatch([c1, c2]);
+
+    expect(result.promoted).toBe(2);
+    expect(result.duplicates).toBe(0);
+    expect(result.results[0]?.outcome).toBe('promoted');
+    expect(result.results[1]?.outcome).toBe('promoted');
+  });
+
+  it('hash set grows after each promotion — third identical candidate is also a duplicate', () => {
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const content = 'Triple duplicate content for intra-batch hash set growth test here.';
+    const c1 = makeCandidate({ content });
+    const c2 = makeCandidate({ content });
+    const c3 = makeCandidate({ content });
+
+    const result = curator.processBatch([c1, c2, c3]);
+
+    expect(result.promoted).toBe(1);
+    expect(result.duplicates).toBe(2);
+    expect(result.results[0]?.outcome).toBe('promoted');
+    expect(result.results[1]?.outcome).toBe('duplicate');
+    expect(result.results[2]?.outcome).toBe('duplicate');
+  });
+
+  it('intra-batch dedup does not affect candidates with different content', () => {
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const contentA = 'Unique content for candidate alpha in dedup test suite here.';
+    const contentB = 'Unique content for candidate beta in dedup test suite here.';
+    const contentC = contentA; // duplicate of A
+
+    const cA = makeCandidate({ content: contentA });
+    const cB = makeCandidate({ content: contentB });
+    const cC = makeCandidate({ content: contentC });
+
+    const result = curator.processBatch([cA, cB, cC]);
+
+    expect(result.promoted).toBe(2); // A and B both promoted
+    expect(result.duplicates).toBe(1); // C is dup of A
+    expect(result.results[0]?.outcome).toBe('promoted'); // A
+    expect(result.results[1]?.outcome).toBe('promoted'); // B
+    expect(result.results[2]?.outcome).toBe('duplicate'); // C
+  });
+
+  it('hash set starts from store — existing memory blocks intra-batch first candidate', () => {
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const content = 'Content already in store before batch runs here for dedup check.';
+
+    // Pre-populate the store with a memory having this hash
+    const existing = makeCandidate({ content });
+    // Use Curator to promote it so the store has the hash
+    curator.processSingle(existing);
+    expect(deps.memoryRepo.count()).toBe(1);
+
+    // Now batch-process a candidate with the same content
+    const batchCandidate = makeCandidate({ content });
+    const result = curator.processBatch([batchCandidate]);
+
+    // Should be detected as a duplicate (cross-session dedup, not intra-batch)
+    expect(result.duplicates).toBe(1);
+    expect(result.promoted).toBe(0);
+  });
+
+  it('hash set is updated correctly — content hash of promoted item matches expected', () => {
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const content = 'Hash set update verification: content used to verify tracking here.';
+    const c1 = makeCandidate({ content });
+    const c2 = makeCandidate({ content }); // same content — should be blocked
+
+    curator.processBatch([c1, c2]);
+
+    // Only one memory in store — dedup prevented the second
+    expect(deps.memoryRepo.count()).toBe(1);
+    const hashes = deps.memoryRepo.getAllContentHashes();
+    expect(hashes).toContain(computeContentHash(content));
+  });
+
+  it('empty batch returns zero duplicates', () => {
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const result = curator.processBatch([]);
+    expect(result.duplicates).toBe(0);
+    expect(result.promoted).toBe(0);
+    expect(result.results).toHaveLength(0);
+  });
+
+  it('single-item batch never produces intra-batch duplicate', () => {
+    const curator = new Curator(deps, { tenantId: TENANT });
+    const c = makeCandidate({
+      content: 'Only one candidate in this batch so no intra-batch dup possible.',
+    });
+    const result = curator.processBatch([c]);
+    expect(result.duplicates).toBe(0);
+    expect(result.promoted).toBe(1);
+  });
+});

--- a/apps/curator/src/curator.ts
+++ b/apps/curator/src/curator.ts
@@ -44,9 +44,11 @@ export class Curator {
   /**
    * Process a single candidate through the full governance pipeline.
    *
+   * @param existingHashes - Pre-loaded set of content hashes (hoisted from batch).
+   *                         When provided, avoids N+1 queries against the store.
    * @returns A CurationResult describing the outcome.
    */
-  processSingle(candidate: MemoryCandidate): CurationResult {
+  processSingle(candidate: MemoryCandidate, existingHashes?: Set<string>): CurationResult {
     // Step 1: Compute content hash
     const contentHash = computeContentHash(candidate.content);
 
@@ -57,6 +59,15 @@ export class Curator {
         candidateId: candidate.id,
         outcome: 'duplicate',
         reason: `Exact duplicate of memory ${dedup.matchedMemoryId}`,
+      };
+    }
+
+    // Intra-batch dedup: check if this hash was already promoted in the current batch
+    if (existingHashes?.has(contentHash)) {
+      return {
+        candidateId: candidate.id,
+        outcome: 'duplicate',
+        reason: 'Intra-batch duplicate (same content already promoted in this batch)',
       };
     }
 
@@ -73,11 +84,11 @@ export class Curator {
       });
     }
 
-    // Step 4: Run policy pipeline
+    // Step 4: Run policy pipeline (uses pre-loaded hashes to avoid N+1)
     const pipeline = new PolicyPipeline(policy);
-    const existingHashes = new Set(this.deps.memoryRepo.getAllContentHashes());
+    const hashSet = existingHashes ?? new Set(this.deps.memoryRepo.getAllContentHashes());
     const pipelineResult = pipeline.evaluate(candidate, {
-      existingHashes,
+      existingHashes: hashSet,
       tenantId: this.config.tenantId,
     });
 
@@ -110,7 +121,9 @@ export class Curator {
   /**
    * Process a batch of candidates through the pipeline.
    *
-   * Candidates are processed in order; each is independent of the others.
+   * Content hashes are loaded once before the loop (not per-candidate) to avoid
+   * N+1 queries. The hash set is updated after each promotion to catch intra-batch
+   * duplicates.
    */
   processBatch(candidates: MemoryCandidate[]): CurationBatchResult {
     const results: CurationResult[] = [];
@@ -119,13 +132,18 @@ export class Curator {
     let flagged = 0;
     let duplicates = 0;
 
+    // Hoist hash loading out of the per-candidate loop
+    const existingHashes = new Set(this.deps.memoryRepo.getAllContentHashes());
+
     for (const candidate of candidates) {
-      const result = this.processSingle(candidate);
+      const result = this.processSingle(candidate, existingHashes);
       results.push(result);
 
       switch (result.outcome) {
         case 'promoted':
           promoted++;
+          // Update intra-batch hash set so subsequent candidates catch duplicates
+          existingHashes.add(computeContentHash(candidate.content));
           break;
         case 'rejected':
           rejected++;

--- a/apps/curator/src/supersession/supersession-detector.ts
+++ b/apps/curator/src/supersession/supersession-detector.ts
@@ -27,8 +27,8 @@ export function detectSupersession(
   threshold: number = 0.6,
 ): SupersessionMatch | null {
   const existingMemories = memoryRepo
-    .findByTenant(candidate.tenantId)
-    .filter((m) => m.lifecycle === 'active' && m.category === candidate.category);
+    .findByTenantAndLifecycle(candidate.tenantId, 'active')
+    .filter((m) => m.category === candidate.category);
 
   let bestMatch: SupersessionMatch | null = null;
 

--- a/apps/edge-daemon/package.json
+++ b/apps/edge-daemon/package.json
@@ -3,6 +3,15 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsx watch src/index.ts",

--- a/apps/edge-daemon/src/__tests__/feedback.test.ts
+++ b/apps/edge-daemon/src/__tests__/feedback.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import type { CurationBatchResult } from '@qmd-team-intent-kb/curator';
+
+// ---------------------------------------------------------------------------
+// Feedback module tests
+//
+// writeFeedback and readRecentFeedback use resolveTeamKbPath internally, which
+// reads TEAMKB_BASE_PATH from the environment. We override that env var to
+// point at a temp directory so tests are fully isolated and self-cleaning.
+// ---------------------------------------------------------------------------
+
+const NOW = '2026-01-15T10:00:00.000Z';
+
+function makeBatchResult(overrides?: Partial<CurationBatchResult>): CurationBatchResult {
+  return {
+    processed: 0,
+    promoted: 0,
+    rejected: 0,
+    flagged: 0,
+    duplicates: 0,
+    results: [],
+    ...overrides,
+  };
+}
+
+describe('writeFeedback', () => {
+  let baseDir: string;
+  let feedbackDir: string;
+  let originalBase: string | undefined;
+
+  beforeEach(() => {
+    baseDir = mkdtempSync(join(tmpdir(), 'feedback-base-'));
+    feedbackDir = join(baseDir, 'feedback');
+    originalBase = process.env['TEAMKB_BASE_PATH'];
+    process.env['TEAMKB_BASE_PATH'] = baseDir;
+  });
+
+  afterEach(() => {
+    if (originalBase === undefined) {
+      delete process.env['TEAMKB_BASE_PATH'];
+    } else {
+      process.env['TEAMKB_BASE_PATH'] = originalBase;
+    }
+    rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  it('creates a JSONL file in the feedback directory for rejected candidates', async () => {
+    const { writeFeedback } = await import('../feedback.js');
+
+    const batchResult = makeBatchResult({
+      processed: 1,
+      rejected: 1,
+      results: [
+        {
+          candidateId: randomUUID(),
+          outcome: 'rejected',
+          reason: 'Contains sensitive data',
+        },
+      ],
+    });
+
+    writeFeedback(batchResult, () => NOW);
+
+    const files = readdirSync(feedbackDir).filter((f) => f.startsWith('feedback-'));
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^feedback-.*\.jsonl$/);
+  });
+
+  it('writes one JSONL line per rejected or flagged candidate', async () => {
+    const { writeFeedback } = await import('../feedback.js');
+    const { readFileSync } = await import('node:fs');
+
+    const batchResult = makeBatchResult({
+      processed: 3,
+      rejected: 2,
+      flagged: 1,
+      results: [
+        { candidateId: randomUUID(), outcome: 'rejected', reason: 'Secret detected' },
+        { candidateId: randomUUID(), outcome: 'flagged', reason: 'Low relevance' },
+        { candidateId: randomUUID(), outcome: 'rejected', reason: 'Content too short' },
+      ],
+    });
+
+    writeFeedback(batchResult, () => NOW);
+
+    const files = readdirSync(feedbackDir).filter((f) => f.startsWith('feedback-'));
+    expect(files).toHaveLength(1);
+
+    const content = readFileSync(join(feedbackDir, files[0]!), 'utf8');
+    const lines = content
+      .trim()
+      .split('\n')
+      .filter((l) => l.length > 0);
+    expect(lines).toHaveLength(3);
+
+    for (const line of lines) {
+      const entry = JSON.parse(line) as {
+        candidateId: string;
+        outcome: string;
+        reason: string;
+        timestamp: string;
+      };
+      expect(entry.timestamp).toBe(NOW);
+      expect(['rejected', 'flagged']).toContain(entry.outcome);
+    }
+  });
+
+  it('does not create a file when all candidates are promoted (no rejections)', async () => {
+    const { writeFeedback } = await import('../feedback.js');
+
+    const batchResult = makeBatchResult({
+      processed: 2,
+      promoted: 2,
+      results: [
+        { candidateId: randomUUID(), outcome: 'promoted', reason: 'Passed all rules' },
+        { candidateId: randomUUID(), outcome: 'promoted', reason: 'Passed all rules' },
+      ],
+    });
+
+    writeFeedback(batchResult, () => NOW);
+
+    // Feedback dir may not even exist — no file should be created
+    let files: string[] = [];
+    try {
+      files = readdirSync(feedbackDir).filter((f) => f.startsWith('feedback-'));
+    } catch {
+      // Directory does not exist — that is also correct
+    }
+    expect(files).toHaveLength(0);
+  });
+
+  it('uses the timestamp from nowFn for each entry in the file', async () => {
+    const { writeFeedback } = await import('../feedback.js');
+    const { readFileSync } = await import('node:fs');
+
+    const customNow = '2026-03-19T12:00:00.000Z';
+    const batchResult = makeBatchResult({
+      processed: 1,
+      rejected: 1,
+      results: [{ candidateId: randomUUID(), outcome: 'rejected', reason: 'Test' }],
+    });
+
+    writeFeedback(batchResult, () => customNow);
+
+    const files = readdirSync(feedbackDir).filter((f) => f.startsWith('feedback-'));
+    const content = readFileSync(join(feedbackDir, files[0]!), 'utf8');
+    const entry = JSON.parse(content.trim().split('\n')[0]!) as { timestamp: string };
+    expect(entry.timestamp).toBe(customNow);
+  });
+});
+
+describe('readRecentFeedback', () => {
+  let baseDir: string;
+  let feedbackDir: string;
+  let originalBase: string | undefined;
+
+  beforeEach(() => {
+    baseDir = mkdtempSync(join(tmpdir(), 'feedback-read-'));
+    feedbackDir = join(baseDir, 'feedback');
+    mkdirSync(feedbackDir, { recursive: true });
+    originalBase = process.env['TEAMKB_BASE_PATH'];
+    process.env['TEAMKB_BASE_PATH'] = baseDir;
+  });
+
+  afterEach(() => {
+    if (originalBase === undefined) {
+      delete process.env['TEAMKB_BASE_PATH'];
+    } else {
+      process.env['TEAMKB_BASE_PATH'] = originalBase;
+    }
+    rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  it('returns empty array when no feedback files exist', async () => {
+    const { readRecentFeedback } = await import('../feedback.js');
+    // feedbackDir exists but is empty
+    const entries = readRecentFeedback();
+    expect(entries).toHaveLength(0);
+  });
+
+  it('returns empty array when feedback directory does not exist', async () => {
+    const { readRecentFeedback } = await import('../feedback.js');
+    // Point base at a nonexistent path
+    process.env['TEAMKB_BASE_PATH'] = join(baseDir, 'nonexistent');
+    const entries = readRecentFeedback();
+    expect(entries).toHaveLength(0);
+  });
+
+  it('returns entries from feedback files, most recent first', async () => {
+    const { readRecentFeedback } = await import('../feedback.js');
+
+    // Write two files with timestamps that sort differently
+    const older = '2026-01-01T10:00:00.000Z';
+    const newer = '2026-03-01T10:00:00.000Z';
+
+    const olderFilename = `feedback-2026-01-01T10-00-00-000Z.jsonl`;
+    const newerFilename = `feedback-2026-03-01T10-00-00-000Z.jsonl`;
+
+    writeFileSync(
+      join(feedbackDir, olderFilename),
+      JSON.stringify({
+        candidateId: 'c-old',
+        outcome: 'rejected',
+        reason: 'old',
+        timestamp: older,
+      }) + '\n',
+      'utf8',
+    );
+    writeFileSync(
+      join(feedbackDir, newerFilename),
+      JSON.stringify({
+        candidateId: 'c-new',
+        outcome: 'flagged',
+        reason: 'new',
+        timestamp: newer,
+      }) + '\n',
+      'utf8',
+    );
+
+    const entries = readRecentFeedback(10);
+
+    // Files are sorted in reverse — newer file read first
+    expect(entries.length).toBeGreaterThanOrEqual(2);
+    // First entry should come from the newer file (sorted alphabetically, reversed)
+    const candidateIds = entries.map((e) => e.candidateId);
+    expect(candidateIds).toContain('c-new');
+    expect(candidateIds).toContain('c-old');
+    // Newer should appear before older because files are sorted DESC
+    expect(candidateIds.indexOf('c-new')).toBeLessThan(candidateIds.indexOf('c-old'));
+  });
+
+  it('respects the limit parameter and returns at most limit entries', async () => {
+    const { readRecentFeedback } = await import('../feedback.js');
+
+    // Write a file with 5 entries
+    const lines =
+      Array.from({ length: 5 }, (_, i) =>
+        JSON.stringify({
+          candidateId: `cand-${i}`,
+          outcome: 'rejected',
+          reason: `Reason ${i}`,
+          timestamp: NOW,
+        }),
+      ).join('\n') + '\n';
+
+    writeFileSync(join(feedbackDir, 'feedback-2026-01-15T10-00-00-000Z.jsonl'), lines, 'utf8');
+
+    const entries = readRecentFeedback(3);
+    expect(entries).toHaveLength(3);
+  });
+});
+
+describe('writeFeedback — file pruning', () => {
+  let baseDir: string;
+  let feedbackDir: string;
+  let originalBase: string | undefined;
+
+  beforeEach(() => {
+    baseDir = mkdtempSync(join(tmpdir(), 'feedback-prune-'));
+    feedbackDir = join(baseDir, 'feedback');
+    mkdirSync(feedbackDir, { recursive: true, mode: 0o700 });
+    originalBase = process.env['TEAMKB_BASE_PATH'];
+    process.env['TEAMKB_BASE_PATH'] = baseDir;
+  });
+
+  afterEach(() => {
+    if (originalBase === undefined) {
+      delete process.env['TEAMKB_BASE_PATH'];
+    } else {
+      process.env['TEAMKB_BASE_PATH'] = originalBase;
+    }
+    rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  it('prunes oldest files when total exceeds MAX_FEEDBACK_FILES (50)', async () => {
+    const { writeFeedback } = await import('../feedback.js');
+
+    // Pre-populate with 50 existing feedback files (at the limit)
+    for (let i = 0; i < 50; i++) {
+      const ts = `2025-${String(i + 1).padStart(2, '0')}-01T00-00-00-000Z`;
+      const filename = `feedback-${ts}.jsonl`;
+      writeFileSync(
+        join(feedbackDir, filename),
+        JSON.stringify({
+          candidateId: `cand-existing-${i}`,
+          outcome: 'rejected',
+          reason: 'old',
+          timestamp: NOW,
+        }) + '\n',
+        'utf8',
+      );
+    }
+
+    // Verify we have exactly 50 files
+    const before = readdirSync(feedbackDir).filter((f) => f.startsWith('feedback-'));
+    expect(before).toHaveLength(50);
+
+    // Write one more — should trigger pruning of the oldest
+    const batchResult = makeBatchResult({
+      processed: 1,
+      rejected: 1,
+      results: [{ candidateId: randomUUID(), outcome: 'rejected', reason: 'New rejection' }],
+    });
+
+    // Use a timestamp that will sort AFTER the existing ones
+    writeFeedback(batchResult, () => '2026-01-15T10:00:00.000Z');
+
+    const after = readdirSync(feedbackDir).filter((f) => f.startsWith('feedback-'));
+    // Should still be at most 50 files after pruning
+    expect(after.length).toBeLessThanOrEqual(50);
+  });
+});

--- a/apps/edge-daemon/src/cycle.ts
+++ b/apps/edge-daemon/src/cycle.ts
@@ -6,6 +6,7 @@ import { runExport } from '@qmd-team-intent-kb/git-exporter';
 import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
 import type { DaemonConfig, DaemonDependencies, CycleResult, DaemonLogger } from './types.js';
 import { runStalenessSweep } from './staleness.js';
+import { writeFeedback } from './feedback.js';
 
 /**
  * Check if enterprise managed settings disable memory capture.
@@ -101,6 +102,16 @@ export async function runCycle(
       logger.info(
         `Curation: ${result.curation.promoted} promoted, ${result.curation.rejected} rejected, ${result.curation.duplicates} duplicates`,
       );
+
+      // Write rejection feedback for MCP status visibility
+      if (result.curation.rejected > 0 || result.curation.flagged > 0) {
+        try {
+          writeFeedback(result.curation, nowFn);
+        } catch (feedbackErr) {
+          const msg = feedbackErr instanceof Error ? feedbackErr.message : String(feedbackErr);
+          logger.warn(`Feedback write failed: ${msg}`);
+        }
+      }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       logger.error(`Curation error: ${msg}`);

--- a/apps/edge-daemon/src/feedback.ts
+++ b/apps/edge-daemon/src/feedback.ts
@@ -1,0 +1,107 @@
+import { writeFileSync, mkdirSync, readdirSync, readFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { resolveTeamKbPath } from '@qmd-team-intent-kb/common';
+import type { CurationBatchResult } from '@qmd-team-intent-kb/curator';
+
+const FEEDBACK_DIR = 'feedback';
+const MAX_FEEDBACK_FILES = 50;
+
+/** Feedback entry written for rejected/flagged candidates */
+export interface FeedbackEntry {
+  candidateId: string;
+  outcome: string;
+  reason: string;
+  timestamp: string;
+}
+
+/** Get the absolute feedback directory path */
+export function getFeedbackPath(): string {
+  return resolveTeamKbPath(FEEDBACK_DIR);
+}
+
+/**
+ * Write rejection/flagging feedback to the feedback directory.
+ *
+ * Each curation cycle that produces rejections writes a single JSONL file.
+ * The MCP `teamkb_status` tool reads these to show recent rejections.
+ *
+ * Old feedback files are pruned to keep the directory bounded.
+ */
+export function writeFeedback(
+  batchResult: CurationBatchResult,
+  nowFn: () => string = () => new Date().toISOString(),
+): void {
+  const entries: FeedbackEntry[] = [];
+  const now = nowFn();
+
+  for (const result of batchResult.results) {
+    if (result.outcome === 'rejected' || result.outcome === 'flagged') {
+      entries.push({
+        candidateId: result.candidateId,
+        outcome: result.outcome,
+        reason: result.reason ?? 'No reason provided',
+        timestamp: now,
+      });
+    }
+  }
+
+  if (entries.length === 0) return;
+
+  const dir = getFeedbackPath();
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+
+  const filename = `feedback-${now.replace(/[:.]/g, '-')}.jsonl`;
+  const content = entries.map((e) => JSON.stringify(e)).join('\n') + '\n';
+  writeFileSync(join(dir, filename), content, { encoding: 'utf8', mode: 0o600 });
+
+  // Prune old feedback files
+  pruneFeedbackFiles(dir);
+}
+
+/**
+ * Read recent feedback entries (most recent first).
+ * Returns at most `limit` entries.
+ */
+export function readRecentFeedback(limit: number = 10): FeedbackEntry[] {
+  const dir = getFeedbackPath();
+  let files: string[];
+  try {
+    files = readdirSync(dir)
+      .filter((f) => f.startsWith('feedback-'))
+      .sort()
+      .reverse();
+  } catch {
+    return []; // Feedback dir doesn't exist yet
+  }
+
+  const entries: FeedbackEntry[] = [];
+  for (const file of files) {
+    if (entries.length >= limit) break;
+    try {
+      const content = readFileSync(join(dir, file), 'utf8');
+      for (const line of content.trim().split('\n')) {
+        if (line && entries.length < limit) {
+          entries.push(JSON.parse(line) as FeedbackEntry);
+        }
+      }
+    } catch {
+      // Skip corrupt files
+    }
+  }
+  return entries;
+}
+
+/** Keep only the most recent MAX_FEEDBACK_FILES files */
+function pruneFeedbackFiles(dir: string): void {
+  try {
+    const files = readdirSync(dir)
+      .filter((f) => f.startsWith('feedback-'))
+      .sort();
+    while (files.length > MAX_FEEDBACK_FILES) {
+      const oldest = files.shift()!;
+      unlinkSync(join(dir, oldest));
+    }
+  } catch {
+    // Best-effort pruning
+  }
+}

--- a/apps/edge-daemon/src/index.ts
+++ b/apps/edge-daemon/src/index.ts
@@ -15,3 +15,5 @@ export { ConsoleDaemonLogger, NullLogger } from './health.js';
 export { runCycle } from './cycle.js';
 export { runStalenessSweep } from './staleness.js';
 export { EdgeDaemon } from './daemon.js';
+export { writeFeedback, readRecentFeedback, getFeedbackPath } from './feedback.js';
+export type { FeedbackEntry } from './feedback.js';

--- a/apps/git-exporter/src/__tests__/file-writer-security.test.ts
+++ b/apps/git-exporter/src/__tests__/file-writer-security.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { writeFile, archiveFile, removeFile } from '../writer/file-writer.js';
+
+// ---------------------------------------------------------------------------
+// writeFile — path traversal guard
+// ---------------------------------------------------------------------------
+
+describe('writeFile — path traversal rejection', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'exporter-write-sec-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('rejects path containing ".." segments when exportRoot is provided', () => {
+    const safePath = join(dir, 'curated', '..', '..', 'etc', 'passwd');
+    expect(() => writeFile(safePath, 'evil', dir)).toThrow(/traversal|unsafe/i);
+  });
+
+  it('rejects path containing null byte when exportRoot is provided', () => {
+    const evilPath = join(dir, `file\0.md`);
+    expect(() => writeFile(evilPath, 'evil', dir)).toThrow(/null byte|unsafe/i);
+  });
+
+  it('rejects ".." in path even without an explicit exportRoot', () => {
+    // Use string concatenation to keep ".." as a literal path segment — node:path
+    // join() would resolve ".." away before the check can see it.
+    const evilPath = dir + '/../escape.md';
+    expect(() => writeFile(evilPath, 'content')).toThrow(/traversal|unsafe/i);
+  });
+
+  it('rejects null byte in path even without an explicit exportRoot', () => {
+    // Use string concatenation — join() strips null bytes on some platforms
+    const evilPath = dir + '/mem\0ory.md';
+    expect(() => writeFile(evilPath, 'content')).toThrow(/null byte|unsafe/i);
+  });
+
+  it('accepts a valid path that stays within exportRoot', () => {
+    const validPath = join(dir, 'curated', 'memory.md');
+    expect(() => writeFile(validPath, 'safe content', dir)).not.toThrow();
+    expect(existsSync(validPath)).toBe(true);
+  });
+
+  it('rejects path that resolves outside exportRoot even without explicit ".."', () => {
+    // A symlink or absolute path outside the root — use absolute path outside dir
+    const outsidePath = join(tmpdir(), 'outside-export.md');
+    expect(() => writeFile(outsidePath, 'evil', dir)).toThrow(/traversal|outside/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// archiveFile — path traversal guard for both from and to paths
+// ---------------------------------------------------------------------------
+
+describe('archiveFile — path traversal rejection', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'exporter-archive-sec-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('rejects toPath containing ".." when exportRoot is provided', () => {
+    const fromPath = join(dir, 'curated', 'mem.md');
+    const toPath = join(dir, '..', '..', 'etc', 'evil.md');
+    expect(() => archiveFile(fromPath, toPath, 'content', dir)).toThrow(/traversal|unsafe/i);
+  });
+
+  it('rejects toPath containing null byte when exportRoot is provided', () => {
+    const fromPath = join(dir, 'curated', 'mem.md');
+    const toPath = join(dir, `archive\0.md`);
+    expect(() => archiveFile(fromPath, toPath, 'content', dir)).toThrow(/null byte|unsafe/i);
+  });
+
+  it('rejects fromPath containing ".." when exportRoot is provided', () => {
+    const fromPath = join(dir, '..', '..', 'etc', 'source.md');
+    const toPath = join(dir, 'archive', 'mem.md');
+    expect(() => archiveFile(fromPath, toPath, 'content', dir)).toThrow(/traversal|unsafe/i);
+  });
+
+  it('rejects fromPath containing null byte when exportRoot is provided', () => {
+    const fromPath = join(dir, `source\0.md`);
+    const toPath = join(dir, 'archive', 'dest.md');
+    expect(() => archiveFile(fromPath, toPath, 'content', dir)).toThrow(/null byte|unsafe/i);
+  });
+
+  it('does not validate fromPath when no exportRoot is given', () => {
+    // Without exportRoot, fromPath is not validated (only toPath always checked).
+    // Provide a non-existent fromPath with a ".." — should not throw on path check.
+    // Note: ".." in toPath is always blocked regardless of exportRoot.
+    const fromPath = join(dir, 'nonexistent.md');
+    const toPath = join(dir, 'valid-dest.md');
+    expect(() => archiveFile(fromPath, toPath, 'content')).not.toThrow();
+    expect(existsSync(toPath)).toBe(true);
+  });
+
+  it('accepts valid from and to paths within exportRoot', () => {
+    const fromPath = join(dir, 'curated', 'mem.md');
+    const toPath = join(dir, 'archive', 'mem.md');
+    mkdirSync(join(dir, 'curated'), { recursive: true });
+    writeFileSync(fromPath, 'old content', 'utf8');
+
+    expect(() => archiveFile(fromPath, toPath, 'new content', dir)).not.toThrow();
+    expect(existsSync(toPath)).toBe(true);
+    expect(existsSync(fromPath)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeFile — path traversal guard when exportRoot is provided
+// ---------------------------------------------------------------------------
+
+describe('removeFile — path traversal rejection', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'exporter-remove-sec-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('rejects path with ".." when exportRoot is provided', () => {
+    const evilPath = join(dir, '..', '..', 'etc', 'passwd');
+    expect(() => removeFile(evilPath, dir)).toThrow(/traversal|unsafe/i);
+  });
+
+  it('rejects path with null byte when exportRoot is provided', () => {
+    const evilPath = join(dir, `file\0.md`);
+    expect(() => removeFile(evilPath, dir)).toThrow(/null byte|unsafe/i);
+  });
+
+  it('accepts valid path within exportRoot', () => {
+    const filePath = join(dir, 'valid.md');
+    writeFileSync(filePath, 'content', 'utf8');
+    expect(() => removeFile(filePath, dir)).not.toThrow();
+    expect(existsSync(filePath)).toBe(false);
+  });
+
+  it('does not validate path when no exportRoot is given', () => {
+    // Without exportRoot, path validation is skipped — only existence matters
+    const filePath = join(dir, 'removable.md');
+    writeFileSync(filePath, 'content', 'utf8');
+    const result = removeFile(filePath);
+    expect(result).toBe(true);
+  });
+});

--- a/apps/git-exporter/src/writer/file-writer.ts
+++ b/apps/git-exporter/src/writer/file-writer.ts
@@ -1,10 +1,46 @@
 import { writeFileSync, mkdirSync, unlinkSync, existsSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { dirname, resolve } from 'node:path';
+
+/**
+ * Validate that a file path is safe for writing.
+ *
+ * When `allowedRoot` is provided, the resolved path must be under it.
+ * Always rejects paths containing `..` segments or null bytes.
+ *
+ * @param filePath - The path to validate
+ * @param allowedRoot - If provided, absolute paths must be under this root
+ * @throws Error if the path is unsafe
+ */
+function assertPathSafe(filePath: string, allowedRoot?: string): void {
+  // Always reject null bytes and traversal segments
+  if (filePath.includes('\0')) {
+    throw new Error('Unsafe file path: Path contains null byte');
+  }
+  const segments = filePath.split(/[/\\]/);
+  if (segments.includes('..')) {
+    throw new Error('Unsafe file path: Path contains directory traversal (..)');
+  }
+
+  // When an allowed root is given, verify the resolved path stays inside it
+  if (allowedRoot !== undefined) {
+    const resolved = resolve(filePath);
+    const resolvedRoot = resolve(allowedRoot);
+    if (!resolved.startsWith(resolvedRoot + '/') && resolved !== resolvedRoot) {
+      throw new Error(`Path traversal rejected: ${filePath} is outside ${allowedRoot}`);
+    }
+  }
+}
 
 /**
  * Write content to a file, creating all parent directories as needed.
+ * Path traversal is validated before writing.
+ *
+ * @param filePath - Must be an absolute path under the export root
+ * @param content - The file content to write
+ * @param exportRoot - Optional export root for path validation
  */
-export function writeFile(filePath: string, content: string): void {
+export function writeFile(filePath: string, content: string, exportRoot?: string): void {
+  assertPathSafe(filePath, exportRoot);
   mkdirSync(dirname(filePath), { recursive: true });
   writeFileSync(filePath, content, 'utf8');
 }
@@ -14,8 +50,18 @@ export function writeFile(filePath: string, content: string): void {
  * and writing updated content to `toPath`.
  *
  * If the source file does not exist, writes directly to the destination.
+ * Path traversal is validated for both paths.
  */
-export function archiveFile(fromPath: string, toPath: string, content: string): void {
+export function archiveFile(
+  fromPath: string,
+  toPath: string,
+  content: string,
+  exportRoot?: string,
+): void {
+  assertPathSafe(toPath, exportRoot);
+  if (exportRoot !== undefined) {
+    assertPathSafe(fromPath, exportRoot);
+  }
   mkdirSync(dirname(toPath), { recursive: true });
 
   if (existsSync(fromPath)) {
@@ -30,7 +76,10 @@ export function archiveFile(fromPath: string, toPath: string, content: string): 
  *
  * @returns `true` if the file was deleted, `false` if it did not exist.
  */
-export function removeFile(filePath: string): boolean {
+export function removeFile(filePath: string, exportRoot?: string): boolean {
+  if (exportRoot !== undefined) {
+    assertPathSafe(filePath, exportRoot);
+  }
   if (existsSync(filePath)) {
     unlinkSync(filePath);
     return true;

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -24,11 +24,12 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@qmd-team-intent-kb/schema": "workspace:*",
-    "@qmd-team-intent-kb/common": "workspace:*",
-    "@qmd-team-intent-kb/store": "workspace:*",
     "@qmd-team-intent-kb/claude-runtime": "workspace:*",
-    "@qmd-team-intent-kb/edge-daemon": "workspace:*"
+    "@qmd-team-intent-kb/common": "workspace:*",
+    "@qmd-team-intent-kb/edge-daemon": "workspace:*",
+    "@qmd-team-intent-kb/schema": "workspace:*",
+    "@qmd-team-intent-kb/store": "workspace:*",
+    "fast-glob": "^3.3.3"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0"

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@qmd-team-intent-kb/mcp-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "bin": {
+    "teamkb-mcp": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@qmd-team-intent-kb/schema": "workspace:*",
+    "@qmd-team-intent-kb/common": "workspace:*",
+    "@qmd-team-intent-kb/store": "workspace:*",
+    "@qmd-team-intent-kb/claude-runtime": "workspace:*",
+    "@qmd-team-intent-kb/edge-daemon": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0"
+  }
+}

--- a/apps/mcp-server/src/__tests__/categorize.test.ts
+++ b/apps/mcp-server/src/__tests__/categorize.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { categorizeFromPath } from '../categorize.js';
+
+describe('categorizeFromPath', () => {
+  it('maps decisions/ segment to "decision"', () => {
+    expect(categorizeFromPath('decisions/adr-001.md')).toBe('decision');
+  });
+
+  it('maps adr/ segment to "decision"', () => {
+    expect(categorizeFromPath('docs/adr/0001-use-sqlite.md')).toBe('decision');
+  });
+
+  it('maps patterns/ segment to "pattern"', () => {
+    expect(categorizeFromPath('patterns/repository-pattern.md')).toBe('pattern');
+  });
+
+  it('maps architecture/ segment to "pattern"', () => {
+    expect(categorizeFromPath('docs/architecture/overview.md')).toBe('pattern');
+  });
+
+  it('maps conventions/ segment to "convention"', () => {
+    expect(categorizeFromPath('conventions/naming.md')).toBe('convention');
+  });
+
+  it('maps standards/ segment to "convention"', () => {
+    expect(categorizeFromPath('standards/code-style.md')).toBe('convention');
+  });
+
+  it('maps troubleshooting/ segment to "troubleshooting"', () => {
+    expect(categorizeFromPath('troubleshooting/connection-errors.md')).toBe('troubleshooting');
+  });
+
+  it('maps debug/ segment to "troubleshooting"', () => {
+    expect(categorizeFromPath('debug/memory-leak.md')).toBe('troubleshooting');
+  });
+
+  it('maps onboarding/ segment to "onboarding"', () => {
+    expect(categorizeFromPath('onboarding/new-engineer.md')).toBe('onboarding');
+  });
+
+  it('maps setup/ segment to "onboarding"', () => {
+    expect(categorizeFromPath('setup/local-dev.md')).toBe('onboarding');
+  });
+
+  it('maps getting-started/ segment to "onboarding"', () => {
+    expect(categorizeFromPath('docs/getting-started/quickstart.md')).toBe('onboarding');
+  });
+
+  it('maps reference/ segment to "reference"', () => {
+    expect(categorizeFromPath('reference/api-endpoints.md')).toBe('reference');
+  });
+
+  it('maps api/ segment to "reference"', () => {
+    expect(categorizeFromPath('api/rest-guide.md')).toBe('reference');
+  });
+
+  it('defaults to "reference" for unrecognised paths', () => {
+    expect(categorizeFromPath('random/notes.md')).toBe('reference');
+    expect(categorizeFromPath('misc/something.txt')).toBe('reference');
+    expect(categorizeFromPath('README.md')).toBe('reference');
+  });
+
+  it('is case-insensitive — uppercase segment matches', () => {
+    expect(categorizeFromPath('Decisions/my-adr.md')).toBe('decision');
+    expect(categorizeFromPath('PATTERNS/service-pattern.md')).toBe('pattern');
+  });
+
+  it('matches nested paths correctly', () => {
+    expect(categorizeFromPath('docs/team/decisions/big-choice.md')).toBe('decision');
+    expect(categorizeFromPath('src/lib/troubleshooting/guide.md')).toBe('troubleshooting');
+  });
+
+  it('handles Windows-style backslash paths', () => {
+    expect(categorizeFromPath('decisions\\adr-001.md')).toBe('decision');
+    expect(categorizeFromPath('patterns\\repository.md')).toBe('pattern');
+  });
+});

--- a/apps/mcp-server/src/__tests__/import.test.ts
+++ b/apps/mcp-server/src/__tests__/import.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { McpServerConfig } from '../config.js';
+import { importFiles } from '../tools/import.js';
+
+const FIXED_NOW = '2026-01-15T10:00:00.000Z';
+const nowFn = () => FIXED_NOW;
+
+function makeConfig(spoolPath: string): McpServerConfig {
+  return {
+    tenantId: 'test-tenant',
+    basePath: spoolPath,
+    spoolPath,
+    dbPath: join(spoolPath, 'teamkb.db'),
+    feedbackPath: join(spoolPath, 'feedback'),
+  };
+}
+
+describe('importFiles()', () => {
+  let spoolDir: string;
+  let srcDir: string;
+  let config: McpServerConfig;
+
+  beforeEach(() => {
+    spoolDir = mkdtempSync(join(tmpdir(), 'teamkb-import-spool-'));
+    srcDir = mkdtempSync(join(tmpdir(), 'teamkb-import-src-'));
+    config = makeConfig(spoolDir);
+  });
+
+  afterEach(() => {
+    rmSync(spoolDir, { recursive: true, force: true });
+    rmSync(srcDir, { recursive: true, force: true });
+  });
+
+  it('returns queued=0 and failed=0 when no files match', async () => {
+    const result = await importFiles({ glob: '**/*.md', basePath: srcDir }, config, nowFn);
+    expect(result.queued).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.outcomes).toHaveLength(0);
+  });
+
+  it('queues one candidate per matching file', async () => {
+    writeFileSync(join(srcDir, 'a.md'), 'Content of A');
+    writeFileSync(join(srcDir, 'b.md'), 'Content of B');
+
+    const result = await importFiles({ glob: '*.md', basePath: srcDir }, config, nowFn);
+
+    expect(result.queued).toBe(2);
+    expect(result.failed).toBe(0);
+    expect(result.outcomes).toHaveLength(2);
+    expect(result.outcomes.every((o) => o.ok)).toBe(true);
+  });
+
+  it('writes candidates to the spool', async () => {
+    writeFileSync(join(srcDir, 'note.md'), 'Important note content');
+
+    await importFiles({ glob: '*.md', basePath: srcDir }, config, nowFn);
+
+    const files = readdirSync(spoolDir).filter((f) => f.endsWith('.jsonl'));
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('uses heuristic category from directory name', async () => {
+    const decisionDir = join(srcDir, 'decisions');
+    mkdirSync(decisionDir);
+    writeFileSync(join(decisionDir, 'adr-001.md'), 'We decided to use SQLite.');
+
+    await importFiles({ glob: 'decisions/*.md', basePath: srcDir }, config, nowFn);
+
+    const files = readdirSync(spoolDir).filter((f) => f.endsWith('.jsonl'));
+    const line = readFileSync(join(spoolDir, files[0]!), 'utf8').trim();
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+    expect(parsed['category']).toBe('decision');
+  });
+
+  it('derives title from filename without extension', async () => {
+    writeFileSync(join(srcDir, 'use-result-type.md'), 'Always use Result<T,E>.');
+
+    await importFiles({ glob: '*.md', basePath: srcDir }, config, nowFn);
+
+    const files = readdirSync(spoolDir).filter((f) => f.endsWith('.jsonl'));
+    const parsed = JSON.parse(readFileSync(join(spoolDir, files[0]!), 'utf8').trim()) as Record<
+      string,
+      unknown
+    >;
+    expect(parsed['title']).toBe('Use Result Type');
+  });
+
+  it('reports failed outcome for empty file', async () => {
+    writeFileSync(join(srcDir, 'empty.md'), '');
+
+    const result = await importFiles({ glob: '*.md', basePath: srcDir }, config, nowFn);
+
+    expect(result.failed).toBe(1);
+    expect(result.queued).toBe(0);
+    const outcome = result.outcomes[0];
+    expect(outcome?.ok).toBe(false);
+    expect(outcome?.error).toMatch(/empty/i);
+  });
+
+  it('continues importing remaining files after one failure', async () => {
+    writeFileSync(join(srcDir, 'empty.md'), '');
+    writeFileSync(join(srcDir, 'good.md'), 'Valid content here');
+
+    const result = await importFiles({ glob: '*.md', basePath: srcDir }, config, nowFn);
+
+    expect(result.queued).toBe(1);
+    expect(result.failed).toBe(1);
+  });
+
+  it('sets source to "import" on each candidate', async () => {
+    writeFileSync(join(srcDir, 'x.md'), 'Some content');
+
+    await importFiles({ glob: '*.md', basePath: srcDir }, config, nowFn);
+
+    const files = readdirSync(spoolDir).filter((f) => f.endsWith('.jsonl'));
+    const parsed = JSON.parse(readFileSync(join(spoolDir, files[0]!), 'utf8').trim()) as Record<
+      string,
+      unknown
+    >;
+    expect(parsed['source']).toBe('import');
+  });
+
+  it('stores the absolute file path in metadata.filePaths', async () => {
+    writeFileSync(join(srcDir, 'guide.md'), 'Guide content');
+
+    await importFiles({ glob: '*.md', basePath: srcDir }, config, nowFn);
+
+    const files = readdirSync(spoolDir).filter((f) => f.endsWith('.jsonl'));
+    const parsed = JSON.parse(readFileSync(join(spoolDir, files[0]!), 'utf8').trim()) as {
+      metadata: { filePaths: string[] };
+    };
+    expect(parsed.metadata.filePaths).toHaveLength(1);
+    expect(parsed.metadata.filePaths[0]).toContain('guide.md');
+  });
+
+  it('defaults basePath to process.cwd() when omitted', async () => {
+    // With no matching files from cwd this should just return 0 queued
+    const result = await importFiles(
+      { glob: 'nonexistent-glob-pattern-xyz-abc/*.md' },
+      config,
+      nowFn,
+    );
+    expect(result.queued).toBe(0);
+  });
+});

--- a/apps/mcp-server/src/__tests__/propose.test.ts
+++ b/apps/mcp-server/src/__tests__/propose.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { McpServerConfig } from '../config.js';
+import { propose } from '../tools/propose.js';
+
+const FIXED_NOW = '2026-01-15T10:00:00.000Z';
+const nowFn = () => FIXED_NOW;
+
+function makeConfig(spoolPath: string): McpServerConfig {
+  return {
+    tenantId: 'test-tenant',
+    basePath: spoolPath,
+    spoolPath,
+    dbPath: join(spoolPath, 'teamkb.db'),
+    feedbackPath: join(spoolPath, 'feedback'),
+  };
+}
+
+describe('propose()', () => {
+  let tmpDir: string;
+  let config: McpServerConfig;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'teamkb-propose-'));
+    config = makeConfig(tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns a valid UUID candidate ID', async () => {
+    const result = await propose(
+      { title: 'Use Result<T,E> for errors', content: 'Never throw, always return.' },
+      config,
+      nowFn,
+    );
+    expect(result.candidateId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it('returns a success message containing the candidate ID', async () => {
+    const result = await propose(
+      { title: 'Prefer named exports', content: 'Always use named exports.' },
+      config,
+      nowFn,
+    );
+    expect(result.message).toContain(result.candidateId);
+  });
+
+  it('writes a JSONL file to the spool directory', async () => {
+    await propose({ title: 'Test entry', content: 'Content goes here.' }, config, nowFn);
+    const files = readdirSync(tmpDir);
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('writes a valid JSON candidate to the spool file', async () => {
+    const result = await propose({ title: 'My Title', content: 'My content.' }, config, nowFn);
+
+    const files = readdirSync(tmpDir).filter((f) => f.endsWith('.jsonl'));
+    expect(files.length).toBeGreaterThan(0);
+
+    const line = readFileSync(join(tmpDir, files[0]!), 'utf8').trim();
+    const parsed = JSON.parse(line) as Record<string, unknown>;
+
+    expect(parsed['id']).toBe(result.candidateId);
+    expect(parsed['status']).toBe('inbox');
+    expect(parsed['source']).toBe('mcp');
+    expect(parsed['title']).toBe('My Title');
+    expect(parsed['content']).toBe('My content.');
+    expect(parsed['tenantId']).toBe('test-tenant');
+    expect(parsed['capturedAt']).toBe(FIXED_NOW);
+  });
+
+  it('defaults category to "reference" when not supplied', async () => {
+    await propose({ title: 'T', content: 'C' }, config, nowFn);
+    const files = readdirSync(tmpDir).filter((f) => f.endsWith('.jsonl'));
+    const parsed = JSON.parse(readFileSync(join(tmpDir, files[0]!), 'utf8').trim()) as Record<
+      string,
+      unknown
+    >;
+    expect(parsed['category']).toBe('reference');
+  });
+
+  it('uses the supplied category', async () => {
+    await propose({ title: 'T', content: 'C', category: 'decision' }, config, nowFn);
+    const files = readdirSync(tmpDir).filter((f) => f.endsWith('.jsonl'));
+    const parsed = JSON.parse(readFileSync(join(tmpDir, files[0]!), 'utf8').trim()) as Record<
+      string,
+      unknown
+    >;
+    expect(parsed['category']).toBe('decision');
+  });
+
+  it('writes filePaths to candidate metadata', async () => {
+    await propose(
+      { title: 'T', content: 'C', filePaths: ['src/api.ts', 'src/auth.ts'] },
+      config,
+      nowFn,
+    );
+    const files = readdirSync(tmpDir).filter((f) => f.endsWith('.jsonl'));
+    const parsed = JSON.parse(readFileSync(join(tmpDir, files[0]!), 'utf8').trim()) as {
+      metadata: { filePaths: string[] };
+    };
+    expect(parsed.metadata.filePaths).toEqual(['src/api.ts', 'src/auth.ts']);
+  });
+
+  it('each call generates a different candidate ID', async () => {
+    const a = await propose({ title: 'T', content: 'C' }, config, nowFn);
+    const b = await propose({ title: 'T', content: 'C' }, config, nowFn);
+    expect(a.candidateId).not.toBe(b.candidateId);
+  });
+
+  it('appends multiple candidates to the same spool file', async () => {
+    await propose({ title: 'First', content: 'First content.' }, config, nowFn);
+    await propose({ title: 'Second', content: 'Second content.' }, config, nowFn);
+
+    const files = readdirSync(tmpDir).filter((f) => f.endsWith('.jsonl'));
+    const content = readFileSync(join(tmpDir, files[0]!), 'utf8').trim();
+    const lines = content.split('\n').filter(Boolean);
+    expect(lines.length).toBe(2);
+  });
+});

--- a/apps/mcp-server/src/__tests__/server.test.ts
+++ b/apps/mcp-server/src/__tests__/server.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { createServer } from '../server.js';
+import type { McpServerConfig } from '../config.js';
+
+function makeConfig(base: string): McpServerConfig {
+  return {
+    tenantId: 'test-tenant',
+    basePath: base,
+    spoolPath: join(base, 'spool'),
+    dbPath: join(base, 'teamkb.db'),
+    feedbackPath: join(base, 'feedback'),
+  };
+}
+
+describe('createServer()', () => {
+  let tmpDir: string;
+  let config: McpServerConfig;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'teamkb-server-'));
+    config = makeConfig(tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns an McpServer instance', () => {
+    const server = createServer(config);
+    expect(server).toBeInstanceOf(McpServer);
+  });
+
+  it('creates server without sync tool by default', () => {
+    // createServer({ withSync: false }) — just verify no throw
+    const server = createServer(config, { withSync: false });
+    expect(server).toBeInstanceOf(McpServer);
+  });
+
+  it('creates server with sync tool when withSync is true', () => {
+    const server = createServer(config, { withSync: true });
+    expect(server).toBeInstanceOf(McpServer);
+  });
+
+  it('creates a new distinct server per call', () => {
+    const a = createServer(config);
+    const b = createServer(config);
+    expect(a).not.toBe(b);
+  });
+});

--- a/apps/mcp-server/src/__tests__/status.test.ts
+++ b/apps/mcp-server/src/__tests__/status.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { createDatabase, createTestDatabase, MemoryRepository } from '@qmd-team-intent-kb/store';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
+import { getStatus } from '../tools/status.js';
+import type { McpServerConfig } from '../config.js';
+
+const NOW = '2026-01-15T10:00:00.000Z';
+
+function makeMemory(overrides?: Partial<CuratedMemory>): CuratedMemory {
+  const content = 'Use Result<T,E> for fallible operations';
+  return {
+    id: randomUUID(),
+    candidateId: randomUUID(),
+    source: 'mcp',
+    content,
+    title: 'Error handling convention',
+    category: 'convention',
+    trustLevel: 'high',
+    sensitivity: 'internal',
+    author: { type: 'ai', id: 'mcp-server' },
+    tenantId: 'test-tenant',
+    metadata: { filePaths: [], tags: [] },
+    lifecycle: 'active',
+    contentHash: computeContentHash(content),
+    policyEvaluations: [],
+    promotedAt: NOW,
+    promotedBy: { type: 'human', id: 'user-1', name: 'Test User' },
+    updatedAt: NOW,
+    version: 1,
+    ...overrides,
+  } as CuratedMemory;
+}
+
+describe('getStatus() — empty DB', () => {
+  let tmpDir: string;
+  let config: McpServerConfig;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'teamkb-status-empty-'));
+    config = {
+      tenantId: 'test-tenant',
+      basePath: tmpDir,
+      spoolPath: join(tmpDir, 'spool'),
+      // Point to a non-existent DB to test graceful handling
+      dbPath: join(tmpDir, 'nonexistent.db'),
+      feedbackPath: join(tmpDir, 'feedback'),
+    };
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns zero total when DB does not exist', () => {
+    const result = getStatus(config);
+    expect(result.counts.total).toBe(0);
+  });
+
+  it('returns empty byLifecycle when DB does not exist', () => {
+    const result = getStatus(config);
+    expect(result.counts.byLifecycle).toEqual({});
+  });
+
+  it('returns empty recentFeedback when feedback dir does not exist', () => {
+    const result = getStatus(config);
+    expect(result.recentFeedback).toEqual([]);
+  });
+
+  it('returns the configured dbPath', () => {
+    const result = getStatus(config);
+    expect(result.dbPath).toBe(config.dbPath);
+  });
+});
+
+describe('getStatus() — populated DB', () => {
+  // Write data via a read-write connection, then call getStatus which opens
+  // a separate read-only connection. SQLite WAL mode supports concurrent readers.
+  let tmpDir: string;
+  let dbPath: string;
+  let config: McpServerConfig;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'teamkb-status-pop-'));
+    dbPath = join(tmpDir, 'teamkb.db');
+    config = {
+      tenantId: 'test-tenant',
+      basePath: tmpDir,
+      spoolPath: join(tmpDir, 'spool'),
+      dbPath,
+      feedbackPath: join(tmpDir, 'feedback'),
+    };
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns correct total count', () => {
+    const db = createDatabase({ path: dbPath });
+    const repo = new MemoryRepository(db);
+    repo.insert(makeMemory());
+    repo.insert(makeMemory({ lifecycle: 'deprecated' }));
+    db.close();
+
+    const result = getStatus(config);
+    expect(result.counts.total).toBe(2);
+  });
+
+  it('groups counts by lifecycle state', () => {
+    const db = createDatabase({ path: dbPath });
+    const repo = new MemoryRepository(db);
+    repo.insert(makeMemory({ lifecycle: 'active' }));
+    repo.insert(makeMemory({ lifecycle: 'active', id: randomUUID(), candidateId: randomUUID() }));
+    repo.insert(makeMemory({ lifecycle: 'archived', id: randomUUID(), candidateId: randomUUID() }));
+    db.close();
+
+    const result = getStatus(config);
+    expect(result.counts.byLifecycle['active']).toBe(2);
+    expect(result.counts.byLifecycle['archived']).toBe(1);
+  });
+
+  it('groups counts by category', () => {
+    const db = createDatabase({ path: dbPath });
+    const repo = new MemoryRepository(db);
+    repo.insert(makeMemory({ category: 'decision' }));
+    repo.insert(
+      makeMemory({ category: 'convention', id: randomUUID(), candidateId: randomUUID() }),
+    );
+    db.close();
+
+    const result = getStatus(config);
+    expect(result.counts.byCategory['decision']).toBe(1);
+    expect(result.counts.byCategory['convention']).toBe(1);
+  });
+});
+
+describe('getStatus() — in-memory DB via createTestDatabase', () => {
+  it('returns zero total for a fresh in-memory database', () => {
+    // We cannot pass an in-memory DB path to getStatus (it would open a separate
+    // connection), so we verify the repository directly here.
+    const db = createTestDatabase();
+    const repo = new MemoryRepository(db);
+    expect(repo.count()).toBe(0);
+    db.close();
+  });
+});

--- a/apps/mcp-server/src/__tests__/transition.test.ts
+++ b/apps/mcp-server/src/__tests__/transition.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { createDatabase } from '@qmd-team-intent-kb/store';
+import { MemoryRepository } from '@qmd-team-intent-kb/store';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
+import { applyTransition } from '../tools/transition.js';
+import type { McpServerConfig } from '../config.js';
+
+const FIXED_NOW = '2026-01-15T10:00:00.000Z';
+const nowFn = () => FIXED_NOW;
+
+function makeMemory(overrides?: Partial<CuratedMemory>): CuratedMemory {
+  const content = 'Always validate inputs with Zod schemas';
+  return {
+    id: randomUUID(),
+    candidateId: randomUUID(),
+    source: 'mcp',
+    content,
+    title: 'Input validation pattern',
+    category: 'pattern',
+    trustLevel: 'high',
+    sensitivity: 'internal',
+    author: { type: 'ai', id: 'mcp-server' },
+    tenantId: 'test-tenant',
+    metadata: { filePaths: [], tags: [] },
+    lifecycle: 'active',
+    contentHash: computeContentHash(content),
+    policyEvaluations: [],
+    promotedAt: FIXED_NOW,
+    promotedBy: { type: 'human', id: 'user-1', name: 'Test User' },
+    updatedAt: FIXED_NOW,
+    version: 1,
+    ...overrides,
+  } as CuratedMemory;
+}
+
+describe('applyTransition()', () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let config: McpServerConfig;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'teamkb-transition-'));
+    dbPath = join(tmpDir, 'teamkb.db');
+    config = {
+      tenantId: 'test-tenant',
+      basePath: tmpDir,
+      spoolPath: join(tmpDir, 'spool'),
+      dbPath,
+      feedbackPath: join(tmpDir, 'feedback'),
+    };
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function seedMemory(memory: CuratedMemory): void {
+    const db = createDatabase({ path: dbPath });
+    const repo = new MemoryRepository(db);
+    repo.insert(memory);
+    db.close();
+  }
+
+  it('transitions active → deprecated successfully', () => {
+    const memory = makeMemory({ lifecycle: 'active' });
+    seedMemory(memory);
+
+    const result = applyTransition(
+      {
+        memoryId: memory.id,
+        to: 'deprecated',
+        reason: 'Superseded by new convention',
+        actor: 'user-1',
+      },
+      config,
+      nowFn,
+    );
+
+    expect(result.memoryId).toBe(memory.id);
+    expect(result.from).toBe('active');
+    expect(result.to).toBe('deprecated');
+    expect(result.message).toContain('deprecated');
+  });
+
+  it('transitions active → archived successfully', () => {
+    const memory = makeMemory({ lifecycle: 'active' });
+    seedMemory(memory);
+
+    const result = applyTransition(
+      { memoryId: memory.id, to: 'archived', reason: 'Permanently retiring this.', actor: 'admin' },
+      config,
+      nowFn,
+    );
+
+    expect(result.from).toBe('active');
+    expect(result.to).toBe('archived');
+  });
+
+  it('returns a valid UUID for auditEventId', () => {
+    const memory = makeMemory();
+    seedMemory(memory);
+
+    const result = applyTransition(
+      { memoryId: memory.id, to: 'deprecated', reason: 'Old.', actor: 'user-2' },
+      config,
+      nowFn,
+    );
+
+    expect(result.auditEventId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it('persists the new lifecycle state to the DB', () => {
+    const memory = makeMemory({ lifecycle: 'active' });
+    seedMemory(memory);
+
+    applyTransition(
+      { memoryId: memory.id, to: 'deprecated', reason: 'No longer needed.', actor: 'user-1' },
+      config,
+      nowFn,
+    );
+
+    const db = createDatabase({ path: dbPath, readonly: true });
+    const repo = new MemoryRepository(db);
+    const updated = repo.findById(memory.id);
+    db.close();
+
+    expect(updated?.lifecycle).toBe('deprecated');
+  });
+
+  it('throws for an invalid lifecycle transition (archived → active)', () => {
+    const memory = makeMemory({ lifecycle: 'archived' });
+    seedMemory(memory);
+
+    expect(() =>
+      applyTransition(
+        { memoryId: memory.id, to: 'active', reason: 'Trying to revive.', actor: 'user-1' },
+        config,
+        nowFn,
+      ),
+    ).toThrow(/not allowed/i);
+  });
+
+  it('throws when memoryId does not exist', () => {
+    const db = createDatabase({ path: dbPath });
+    db.close(); // Ensure DB file exists with schema
+
+    expect(() =>
+      applyTransition(
+        { memoryId: randomUUID(), to: 'deprecated', reason: 'Ghost.', actor: 'user-1' },
+        config,
+        nowFn,
+      ),
+    ).toThrow(/not found/i);
+  });
+
+  it('throws for invalid UUID format', () => {
+    expect(() =>
+      applyTransition(
+        { memoryId: 'not-a-uuid', to: 'deprecated', reason: 'Bad ID.', actor: 'user-1' },
+        config,
+        nowFn,
+      ),
+    ).toThrow();
+  });
+});

--- a/apps/mcp-server/src/categorize.ts
+++ b/apps/mcp-server/src/categorize.ts
@@ -1,0 +1,37 @@
+import type { MemoryCategory } from '@qmd-team-intent-kb/schema';
+
+/**
+ * Heuristic path-to-category mapping for bulk import.
+ *
+ * Matches against path segments so 'decisions/adr-001.md' resolves
+ * to 'decision' regardless of nesting depth.
+ */
+const SEGMENT_RULES: Array<{ segments: string[]; category: MemoryCategory }> = [
+  { segments: ['decisions', 'adr', 'adrs'], category: 'decision' },
+  { segments: ['patterns', 'architecture'], category: 'pattern' },
+  { segments: ['conventions', 'standards'], category: 'convention' },
+  { segments: ['troubleshooting', 'debug', 'debugging'], category: 'troubleshooting' },
+  { segments: ['onboarding', 'setup', 'getting-started'], category: 'onboarding' },
+  { segments: ['reference', 'api', 'apis'], category: 'reference' },
+];
+
+/**
+ * Derive a MemoryCategory from a file path using directory name heuristics.
+ *
+ * Checks each path segment against the rule table in order. Returns the
+ * first match, or 'reference' if no segment matches.
+ */
+export function categorizeFromPath(filePath: string): MemoryCategory {
+  // Normalise: lower-case, split on both / and \ for cross-platform safety
+  const segments = filePath.toLowerCase().split(/[/\\]/);
+
+  for (const segment of segments) {
+    for (const rule of SEGMENT_RULES) {
+      if (rule.segments.includes(segment)) {
+        return rule.category;
+      }
+    }
+  }
+
+  return 'reference';
+}

--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -1,5 +1,6 @@
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
+import { isPathSafe } from '@qmd-team-intent-kb/common';
 
 /** Resolved configuration for the MCP server */
 export interface McpServerConfig {
@@ -30,7 +31,15 @@ export function resolveConfig(): McpServerConfig {
     throw new Error('TEAMKB_TENANT_ID environment variable is required');
   }
 
-  const basePath = process.env['TEAMKB_BASE_PATH'] ?? join(homedir(), '.teamkb');
+  const rawBasePath = process.env['TEAMKB_BASE_PATH'] ?? join(homedir(), '.teamkb');
+  const basePath = resolve(rawBasePath);
+
+  // Validate TEAMKB_BASE_PATH against path traversal (must be under home directory)
+  const home = homedir();
+  const pathCheck = isPathSafe(basePath, [home]);
+  if (!pathCheck.safe) {
+    throw new Error(`TEAMKB_BASE_PATH is invalid: ${pathCheck.reason}`);
+  }
 
   return {
     tenantId: tenantId.trim(),

--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -1,0 +1,42 @@
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+/** Resolved configuration for the MCP server */
+export interface McpServerConfig {
+  /** Tenant identifier — scopes all operations */
+  tenantId: string;
+  /** Absolute path to the TeamKB base directory */
+  basePath: string;
+  /** Absolute path to the spool directory */
+  spoolPath: string;
+  /** Absolute path to the SQLite database file */
+  dbPath: string;
+  /** Absolute path to the feedback directory */
+  feedbackPath: string;
+}
+
+/**
+ * Resolve MCP server configuration from environment variables.
+ *
+ * Required:
+ *   TEAMKB_TENANT_ID — tenant identifier
+ *
+ * Optional:
+ *   TEAMKB_BASE_PATH — defaults to ~/.teamkb
+ */
+export function resolveConfig(): McpServerConfig {
+  const tenantId = process.env['TEAMKB_TENANT_ID'];
+  if (!tenantId || tenantId.trim() === '') {
+    throw new Error('TEAMKB_TENANT_ID environment variable is required');
+  }
+
+  const basePath = process.env['TEAMKB_BASE_PATH'] ?? join(homedir(), '.teamkb');
+
+  return {
+    tenantId: tenantId.trim(),
+    basePath,
+    spoolPath: join(basePath, 'spool'),
+    dbPath: join(basePath, 'teamkb.db'),
+    feedbackPath: join(basePath, 'feedback'),
+  };
+}

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -22,8 +22,11 @@ async function main(): Promise<void> {
     process.stderr.write(`[teamkb-mcp] Received ${signal}, shutting down\n`);
     try {
       await server.close();
-    } finally {
       process.exit(0);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[teamkb-mcp] Error during shutdown: ${msg}\n`);
+      process.exit(1);
     }
   };
 

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * TeamKB MCP Server entry point.
+ *
+ * Reads configuration from environment variables, creates the McpServer,
+ * connects via StdioServerTransport, and handles graceful shutdown on
+ * SIGINT / SIGTERM.
+ */
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { resolveConfig } from './config.js';
+import { createServer, isQmdAvailable } from './server.js';
+
+async function main(): Promise<void> {
+  const config = resolveConfig();
+  const withSync = await isQmdAvailable();
+
+  const server = createServer(config, { withSync });
+  const transport = new StdioServerTransport();
+
+  // Graceful shutdown — close the transport cleanly before exiting
+  const shutdown = async (signal: string): Promise<void> => {
+    process.stderr.write(`[teamkb-mcp] Received ${signal}, shutting down\n`);
+    try {
+      await server.close();
+    } finally {
+      process.exit(0);
+    }
+  };
+
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+
+  await server.connect(transport);
+  process.stderr.write(`[teamkb-mcp] Started — tenant=${config.tenantId} sync=${withSync}\n`);
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`[teamkb-mcp] Fatal: ${msg}\n`);
+  process.exit(1);
+});

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -1,0 +1,199 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { McpServerConfig } from './config.js';
+import { propose } from './tools/propose.js';
+import { importFiles } from './tools/import.js';
+import { getStatus } from './tools/status.js';
+import { applyTransition } from './tools/transition.js';
+import { runSync, isQmdAvailable } from './tools/sync.js';
+
+const VERSION = '0.1.0';
+
+// ---------------------------------------------------------------------------
+// Inline enum definitions for tool parameter schemas.
+//
+// Intentionally NOT imported from @qmd-team-intent-kb/schema: that package
+// resolves against zod@3 while the MCP SDK (and the root workspace) uses
+// zod@4. Passing v3 schema objects to server.tool() triggers "Mixed Zod
+// versions detected" at runtime. The enum values here mirror enums.ts exactly.
+// ---------------------------------------------------------------------------
+
+const MEMORY_CATEGORY_VALUES = [
+  'decision',
+  'pattern',
+  'convention',
+  'architecture',
+  'troubleshooting',
+  'onboarding',
+  'reference',
+] as const;
+
+const LIFECYCLE_STATE_VALUES = ['active', 'deprecated', 'superseded', 'archived'] as const;
+
+/**
+ * Create a configured McpServer with all team-kb tools registered.
+ *
+ * All tool parameter schemas use the zod instance from the root workspace
+ * (zod@4), which is the same instance the MCP SDK was resolved against.
+ *
+ * Call `isQmdAvailable()` before calling this function if you want to
+ * conditionally register the sync tool.
+ */
+export function createServer(
+  config: McpServerConfig,
+  options: { withSync?: boolean } = {},
+): McpServer {
+  const server = new McpServer({ name: 'teamkb', version: VERSION });
+
+  // -------------------------------------------------------------------------
+  // teamkb_propose — queue a memory candidate for governance review
+  // -------------------------------------------------------------------------
+  server.tool(
+    'teamkb_propose',
+    'Queue a new memory candidate for governance review. Writes to the spool only — the curator promotes it after policy checks pass.',
+    {
+      title: z.string().min(1).describe('Short descriptive title for the memory'),
+      content: z.string().min(1).describe('Full content of the memory'),
+      category: z
+        .enum(MEMORY_CATEGORY_VALUES)
+        .optional()
+        .describe(
+          'Memory category: decision, pattern, convention, architecture, troubleshooting, onboarding, reference',
+        ),
+      filePaths: z
+        .array(z.string())
+        .optional()
+        .describe('Source file paths this memory relates to'),
+    },
+    async (params) => {
+      const result = await propose(
+        {
+          title: params.title,
+          content: params.content,
+          // Narrow to MemoryCategory via runtime validation in propose()
+          category: params.category as Parameters<typeof propose>[0]['category'],
+          filePaths: params.filePaths,
+        },
+        config,
+      );
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // teamkb_import — bulk import files matching a glob pattern
+  // -------------------------------------------------------------------------
+  server.tool(
+    'teamkb_import',
+    'Bulk import files matching a glob pattern as memory candidates. Each file becomes one candidate queued for governance review.',
+    {
+      glob: z.string().min(1).describe('Glob pattern relative to basePath (e.g. "docs/**/*.md")'),
+      basePath: z
+        .string()
+        .optional()
+        .describe('Base directory for glob resolution. Defaults to process.cwd()'),
+    },
+    async (params) => {
+      const result = await importFiles({ glob: params.glob, basePath: params.basePath }, config);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // teamkb_status — read database counts and recent feedback
+  // -------------------------------------------------------------------------
+  server.tool(
+    'teamkb_status',
+    'Return memory counts by lifecycle state, category, and tenant, plus recent governance feedback entries.',
+    {},
+    async () => {
+      const result = getStatus(config);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // teamkb_transition — user-initiated lifecycle transitions
+  // -------------------------------------------------------------------------
+  server.tool(
+    'teamkb_transition',
+    'Apply a lifecycle transition to a curated memory. Validates against the state machine and writes an audit event.',
+    {
+      memoryId: z.string().uuid().describe('UUID of the curated memory to transition'),
+      to: z.enum(LIFECYCLE_STATE_VALUES).describe('Target lifecycle state'),
+      reason: z.string().min(1).describe('Human-readable reason for the transition'),
+      actor: z
+        .string()
+        .min(1)
+        .describe('Identifier of the person or system initiating the transition'),
+    },
+    async (params) => {
+      const result = applyTransition(
+        {
+          memoryId: params.memoryId,
+          // Narrow to MemoryLifecycleState via runtime validation in applyTransition()
+          to: params.to as Parameters<typeof applyTransition>[0]['to'],
+          reason: params.reason,
+          actor: params.actor,
+        },
+        config,
+      );
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // teamkb_sync — rebuild qmd vector index (registered only if qmd is present)
+  // -------------------------------------------------------------------------
+  if (options.withSync === true) {
+    server.tool(
+      'teamkb_sync',
+      'Rebuild the local qmd vector index by running `qmd embed`. May take up to 2 minutes on large corpora.',
+      {},
+      async () => {
+        const result = await runSync();
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      },
+    );
+  }
+
+  return server;
+}
+
+// Re-export for convenience
+export { isQmdAvailable };

--- a/apps/mcp-server/src/tools/import.ts
+++ b/apps/mcp-server/src/tools/import.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { join, basename, extname } from 'node:path';
-import { glob } from 'node:fs/promises';
+import fg from 'fast-glob';
 import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
 import { writeToSpool } from '@qmd-team-intent-kb/claude-runtime';
 import { categorizeFromPath } from '../categorize.js';
@@ -57,11 +57,8 @@ export async function importFiles(
 
   let matchedFiles: string[];
   try {
-    const iter = glob(pattern);
-    matchedFiles = [];
-    for await (const file of iter) {
-      matchedFiles.push(file);
-    }
+    // Use fast-glob which works in Node 20+ (node:fs/promises glob requires Node 22)
+    matchedFiles = await fg(pattern, { onlyFiles: true, absolute: true });
   } catch {
     matchedFiles = [];
   }

--- a/apps/mcp-server/src/tools/import.ts
+++ b/apps/mcp-server/src/tools/import.ts
@@ -1,0 +1,130 @@
+import { randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { join, basename, extname } from 'node:path';
+import { glob } from 'node:fs/promises';
+import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import { writeToSpool } from '@qmd-team-intent-kb/claude-runtime';
+import { categorizeFromPath } from '../categorize.js';
+import type { McpServerConfig } from '../config.js';
+
+/** Input for teamkb_import */
+export interface ImportInput {
+  glob: string;
+  basePath?: string;
+}
+
+/** Per-file import outcome */
+export interface FileImportOutcome {
+  file: string;
+  candidateId: string;
+  ok: boolean;
+  error?: string;
+}
+
+/** Aggregate result for teamkb_import */
+export interface ImportResult {
+  queued: number;
+  failed: number;
+  outcomes: FileImportOutcome[];
+}
+
+/**
+ * Derive a human-readable title from a file path.
+ * Strips extension, replaces hyphens/underscores with spaces, title-cases.
+ */
+function titleFromPath(filePath: string): string {
+  const name = basename(filePath, extname(filePath));
+  return name.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
+ * Import matching files from the filesystem as memory candidates.
+ *
+ * One candidate is written to the spool per matching file. Files that cannot
+ * be read (permissions, binary, etc.) are reported as failures without
+ * halting the rest of the import.
+ *
+ * Uses node:fs/promises glob (Node 22+). Falls back gracefully when no files
+ * match.
+ */
+export async function importFiles(
+  input: ImportInput,
+  config: McpServerConfig,
+  nowFn: () => string = () => new Date().toISOString(),
+): Promise<ImportResult> {
+  const base = input.basePath ?? process.cwd();
+  const pattern = join(base, input.glob);
+
+  let matchedFiles: string[];
+  try {
+    const iter = glob(pattern);
+    matchedFiles = [];
+    for await (const file of iter) {
+      matchedFiles.push(file);
+    }
+  } catch {
+    matchedFiles = [];
+  }
+
+  const outcomes: FileImportOutcome[] = [];
+  let queued = 0;
+  let failed = 0;
+
+  for (const file of matchedFiles) {
+    const candidateId = randomUUID();
+    let content: string;
+
+    try {
+      content = await readFile(file, 'utf8');
+    } catch (e) {
+      outcomes.push({
+        file,
+        candidateId,
+        ok: false,
+        error: e instanceof Error ? e.message : String(e),
+      });
+      failed++;
+      continue;
+    }
+
+    if (!content.trim()) {
+      outcomes.push({ file, candidateId, ok: false, error: 'File is empty' });
+      failed++;
+      continue;
+    }
+
+    const candidate: MemoryCandidate = {
+      id: candidateId,
+      status: 'inbox',
+      source: 'import',
+      content: content.trim(),
+      title: titleFromPath(file),
+      category: categorizeFromPath(file),
+      trustLevel: 'medium',
+      author: { type: 'ai', id: 'mcp-import' },
+      tenantId: config.tenantId,
+      metadata: {
+        filePaths: [file],
+        tags: [],
+      },
+      prePolicyFlags: {
+        potentialSecret: false,
+        lowConfidence: false,
+        duplicateSuspect: false,
+      },
+      capturedAt: nowFn(),
+    };
+
+    const writeResult = await writeToSpool(candidate, config.spoolPath);
+
+    if (writeResult.ok) {
+      outcomes.push({ file, candidateId, ok: true });
+      queued++;
+    } else {
+      outcomes.push({ file, candidateId, ok: false, error: writeResult.error });
+      failed++;
+    }
+  }
+
+  return { queued, failed, outcomes };
+}

--- a/apps/mcp-server/src/tools/propose.ts
+++ b/apps/mcp-server/src/tools/propose.ts
@@ -1,0 +1,65 @@
+import { randomUUID } from 'node:crypto';
+import type { MemoryCandidate, MemoryCategory } from '@qmd-team-intent-kb/schema';
+import { writeToSpool } from '@qmd-team-intent-kb/claude-runtime';
+import type { McpServerConfig } from '../config.js';
+
+/** Input for teamkb_propose */
+export interface ProposeInput {
+  title: string;
+  content: string;
+  category?: MemoryCategory;
+  filePaths?: string[];
+}
+
+/** Result shape returned to the MCP caller */
+export interface ProposeResult {
+  candidateId: string;
+  message: string;
+}
+
+/**
+ * Propose a new memory candidate and write it to the spool.
+ *
+ * Does NOT touch SQLite. The curator reads from the spool on its next cycle
+ * and applies governance policy before promotion.
+ */
+export async function propose(
+  input: ProposeInput,
+  config: McpServerConfig,
+  nowFn: () => string = () => new Date().toISOString(),
+): Promise<ProposeResult> {
+  const candidateId = randomUUID();
+
+  const candidate: MemoryCandidate = {
+    id: candidateId,
+    status: 'inbox',
+    source: 'mcp',
+    content: input.content,
+    title: input.title,
+    category: input.category ?? 'reference',
+    trustLevel: 'medium',
+    author: { type: 'ai', id: 'mcp-server' },
+    tenantId: config.tenantId,
+    metadata: {
+      filePaths: input.filePaths ?? [],
+      tags: [],
+    },
+    prePolicyFlags: {
+      potentialSecret: false,
+      lowConfidence: false,
+      duplicateSuspect: false,
+    },
+    capturedAt: nowFn(),
+  };
+
+  const result = await writeToSpool(candidate, config.spoolPath);
+
+  if (!result.ok) {
+    throw new Error(`Failed to write candidate to spool: ${result.error}`);
+  }
+
+  return {
+    candidateId,
+    message: `Candidate ${candidateId} queued for governance review`,
+  };
+}

--- a/apps/mcp-server/src/tools/status.ts
+++ b/apps/mcp-server/src/tools/status.ts
@@ -1,0 +1,86 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createDatabase, MemoryRepository } from '@qmd-team-intent-kb/store';
+import type { FeedbackEntry } from '@qmd-team-intent-kb/edge-daemon';
+import type { McpServerConfig } from '../config.js';
+
+/** Database-derived counts */
+export interface MemoryCounts {
+  byLifecycle: Record<string, number>;
+  byCategory: Record<string, number>;
+  byTenant: Record<string, number>;
+  total: number;
+}
+
+/** Aggregate status response */
+export interface StatusResult {
+  counts: MemoryCounts;
+  recentFeedback: FeedbackEntry[];
+  dbPath: string;
+}
+
+/**
+ * Read recent feedback entries from the feedback directory.
+ *
+ * Inlined from edge-daemon's readRecentFeedback to accept an explicit path
+ * rather than reading from the global TEAMKB_BASE_PATH env var. This keeps
+ * status.ts testable without env mutation.
+ */
+function readFeedback(feedbackPath: string, limit: number = 10): FeedbackEntry[] {
+  let files: string[];
+  try {
+    files = readdirSync(feedbackPath)
+      .filter((f) => f.startsWith('feedback-'))
+      .sort()
+      .reverse();
+  } catch {
+    return []; // Feedback dir doesn't exist yet
+  }
+
+  const entries: FeedbackEntry[] = [];
+  for (const file of files) {
+    if (entries.length >= limit) break;
+    try {
+      const content = readFileSync(join(feedbackPath, file), 'utf8');
+      for (const line of content.trim().split('\n')) {
+        if (line && entries.length < limit) {
+          entries.push(JSON.parse(line) as FeedbackEntry);
+        }
+      }
+    } catch {
+      // Skip corrupt files
+    }
+  }
+  return entries;
+}
+
+/**
+ * Read memory counts from SQLite in read-only mode and return recent feedback.
+ *
+ * Opens a short-lived read-only connection — does not hold the DB open between
+ * calls, so the write path is never blocked.
+ */
+export function getStatus(config: McpServerConfig): StatusResult {
+  let counts: MemoryCounts;
+
+  try {
+    const db = createDatabase({ path: config.dbPath, readonly: true });
+    try {
+      const repo = new MemoryRepository(db);
+      const byLifecycle = repo.countByLifecycle();
+      const byCategory = repo.countByCategory();
+      const byTenant = repo.countByTenant();
+      const total = repo.count();
+      counts = { byLifecycle, byCategory, byTenant, total };
+    } finally {
+      db.close();
+    }
+  } catch {
+    // DB doesn't exist yet or is inaccessible — return empty counts
+    counts = { byLifecycle: {}, byCategory: {}, byTenant: {}, total: 0 };
+  }
+
+  const recentFeedback = readFeedback(config.feedbackPath);
+
+  return { counts, recentFeedback, dbPath: config.dbPath };
+}

--- a/apps/mcp-server/src/tools/sync.ts
+++ b/apps/mcp-server/src/tools/sync.ts
@@ -1,0 +1,47 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/** Result returned after running qmd embed */
+export interface SyncResult {
+  stdout: string;
+  stderr: string;
+  message: string;
+}
+
+/**
+ * Run `qmd embed` to rebuild the local vector index.
+ *
+ * Only registered as a tool when the qmd binary is available (checked at
+ * server startup via `isQmdAvailable()`).
+ */
+export async function runSync(qmdBinary: string = 'qmd'): Promise<SyncResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync(qmdBinary, ['embed'], {
+      timeout: 120_000, // 2 minutes — embedding can be slow
+    });
+
+    return {
+      stdout: stdout.trim(),
+      stderr: stderr.trim(),
+      message: 'qmd embed completed successfully',
+    };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`qmd embed failed: ${msg}`);
+  }
+}
+
+/**
+ * Check if the qmd binary is available on PATH.
+ * Used to conditionally register the sync tool at startup.
+ */
+export async function isQmdAvailable(qmdBinary: string = 'qmd'): Promise<boolean> {
+  try {
+    await execFileAsync(qmdBinary, ['--version'], { timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/mcp-server/src/tools/transition.ts
+++ b/apps/mcp-server/src/tools/transition.ts
@@ -1,0 +1,101 @@
+import { randomUUID } from 'node:crypto';
+import type { MemoryLifecycleState } from '@qmd-team-intent-kb/schema';
+import { validateTransition } from '@qmd-team-intent-kb/schema';
+import { createDatabase, MemoryRepository, AuditRepository } from '@qmd-team-intent-kb/store';
+import type { McpServerConfig } from '../config.js';
+
+/** Input for teamkb_transition */
+export interface TransitionInput {
+  memoryId: string;
+  to: MemoryLifecycleState;
+  reason: string;
+  actor: string;
+}
+
+/** Result returned after a successful transition */
+export interface TransitionResult {
+  memoryId: string;
+  from: string;
+  to: string;
+  auditEventId: string;
+  message: string;
+}
+
+/**
+ * Apply a lifecycle transition to a curated memory.
+ *
+ * Opens a short-lived read-write connection, validates the transition against
+ * the state machine, updates the lifecycle column, and writes an audit event —
+ * all inside the same synchronous SQLite transaction.
+ *
+ * Only called for low-frequency user-initiated actions (deprecation, archival,
+ * etc.), so the overhead of opening a connection per call is acceptable.
+ */
+export function applyTransition(
+  input: TransitionInput,
+  config: McpServerConfig,
+  nowFn: () => string = () => new Date().toISOString(),
+): TransitionResult {
+  // Validate UUID format before opening the DB connection
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  if (!uuidPattern.test(input.memoryId)) {
+    throw new Error(`Invalid memoryId: "${input.memoryId}" is not a valid UUID`);
+  }
+
+  const db = createDatabase({ path: config.dbPath });
+  try {
+    const memoryRepo = new MemoryRepository(db);
+    const auditRepo = new AuditRepository(db);
+
+    const memory = memoryRepo.findById(input.memoryId);
+    if (memory === null) {
+      throw new Error(`Memory not found: ${input.memoryId}`);
+    }
+
+    const transitionRequest = {
+      reason: input.reason,
+      actor: { type: 'human' as const, id: input.actor },
+    };
+
+    const validation = validateTransition(memory.lifecycle, input.to, transitionRequest);
+    if (!validation.valid) {
+      throw new Error(validation.error);
+    }
+
+    const now = nowFn();
+    const auditEventId = randomUUID();
+    const fromState = memory.lifecycle;
+
+    // Apply both writes in a single transaction for atomicity
+    const applyFn = db.transaction(() => {
+      memoryRepo.updateLifecycle(input.memoryId, input.to, now);
+      auditRepo.insert({
+        id: auditEventId,
+        action:
+          input.to === 'archived'
+            ? 'archived'
+            : input.to === 'superseded'
+              ? 'superseded'
+              : 'demoted',
+        memoryId: input.memoryId,
+        tenantId: memory.tenantId,
+        actor: { type: 'human', id: input.actor },
+        reason: input.reason,
+        details: { from: fromState, to: input.to },
+        timestamp: now,
+      });
+    });
+
+    applyFn();
+
+    return {
+      memoryId: input.memoryId,
+      from: fromState,
+      to: input.to,
+      auditEventId,
+      message: `Memory transitioned from "${fromState}" to "${input.to}"`,
+    };
+  } finally {
+    db.close();
+  }
+}

--- a/apps/mcp-server/tsconfig.json
+++ b/apps/mcp-server/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../../packages/schema" },
+    { "path": "../../packages/common" },
+    { "path": "../../packages/store" },
+    { "path": "../../packages/claude-runtime" },
+    { "path": "../edge-daemon" }
+  ]
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,30 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.sh",
+            "timeout": 30,
+            "statusMessage": "Initializing team knowledge base..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/flush-spool.sh",
+            "timeout": 60,
+            "statusMessage": "Flushing knowledge spool..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/claude-runtime/src/__tests__/spool-writer-security.test.ts
+++ b/packages/claude-runtime/src/__tests__/spool-writer-security.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { writeToSpool } from '../spool/spool-writer.js';
+import { buildCandidate } from '../capture/candidate-builder.js';
+import type { RawCaptureEvent, GitContext } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeEvent = (overrides?: Partial<RawCaptureEvent>): RawCaptureEvent => ({
+  content: 'Security test memory candidate content for spool',
+  title: 'Security test candidate',
+  source: 'claude_session',
+  category: 'convention',
+  sessionId: 'sess-security',
+  ...overrides,
+});
+
+const gitCtx: GitContext = {
+  repoUrl: 'https://github.com/org/repo.git',
+  branch: 'main',
+  userName: 'tester',
+  tenantId: 'org-repo',
+};
+
+function buildValidCandidate() {
+  const result = buildCandidate(makeEvent(), gitCtx);
+  if (!result.ok) throw new Error(`buildCandidate failed: ${result.error}`);
+  return result.value.candidate;
+}
+
+// ---------------------------------------------------------------------------
+// Path traversal tests
+// ---------------------------------------------------------------------------
+
+describe('writeToSpool — path traversal rejection', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'spool-security-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('rejects agentId containing ".." to prevent directory traversal', async () => {
+    const candidate = buildValidCandidate();
+    // agentId with ".." would produce filename "spool-../../etc/passwd.jsonl"
+    const result = await writeToSpool(candidate, tmpDir, '../../../etc/passwd');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/traversal|unsafe/i);
+    }
+  });
+
+  it('rejects agentId containing null byte', async () => {
+    const candidate = buildValidCandidate();
+    const result = await writeToSpool(candidate, tmpDir, 'agent\0id');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/unsafe|null|traversal/i);
+    }
+  });
+
+  it('rejects agentId with absolute path segment that escapes spool dir', async () => {
+    const candidate = buildValidCandidate();
+    // Attempt to write outside the spool dir via a crafted relative path
+    const result = await writeToSpool(candidate, tmpDir, '../../outside');
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-agent spool filename pattern
+// ---------------------------------------------------------------------------
+
+describe('writeToSpool — per-agent spool file naming', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'spool-agent-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('uses spool-{agentId}.jsonl filename when agentId is provided', async () => {
+    const candidate = buildValidCandidate();
+    const agentId = 'agent-abc123';
+    const result = await writeToSpool(candidate, tmpDir, agentId);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const filename = result.value.split('/').pop();
+      expect(filename).toBe(`spool-${agentId}.jsonl`);
+    }
+  });
+
+  it('different agentIds write to separate files', async () => {
+    const c1 = buildValidCandidate();
+    const c2 = buildValidCandidate();
+
+    const r1 = await writeToSpool(c1, tmpDir, 'agent-001');
+    const r2 = await writeToSpool(c2, tmpDir, 'agent-002');
+
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    if (r1.ok && r2.ok) {
+      expect(r1.value).not.toBe(r2.value);
+    }
+  });
+
+  it('same agentId appends to the same file on subsequent writes', async () => {
+    const c1 = buildValidCandidate();
+    const c2 = buildCandidate({ ...makeEvent(), title: 'Second event' }, gitCtx);
+    expect(c2.ok).toBe(true);
+    if (!c2.ok) return;
+
+    const r1 = await writeToSpool(c1, tmpDir, 'agent-shared');
+    const r2 = await writeToSpool(c2.value.candidate, tmpDir, 'agent-shared');
+
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    if (r1.ok && r2.ok) {
+      // Both writes should resolve to the same path
+      expect(r1.value).toBe(r2.value);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Daily spool filename (no agentId)
+// ---------------------------------------------------------------------------
+
+describe('writeToSpool — daily spool file (no agentId)', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'spool-daily-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('without agentId, filename matches spool-YYYY-MM-DD.jsonl pattern', async () => {
+    const candidate = buildValidCandidate();
+    const result = await writeToSpool(candidate, tmpDir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const filename = result.value.split('/').pop();
+      expect(filename).toMatch(/^spool-\d{4}-\d{2}-\d{2}\.jsonl$/);
+    }
+  });
+
+  it('without agentId, file is written inside the provided spool directory', async () => {
+    const candidate = buildValidCandidate();
+    const result = await writeToSpool(candidate, tmpDir);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.startsWith(tmpDir)).toBe(true);
+    }
+  });
+});

--- a/packages/claude-runtime/src/spool/spool-writer.ts
+++ b/packages/claude-runtime/src/spool/spool-writer.ts
@@ -1,22 +1,49 @@
-import { mkdir, appendFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdir, appendFile, chmod } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import type { Result } from '@qmd-team-intent-kb/common';
+import { isPathSafe } from '@qmd-team-intent-kb/common';
 import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
 import { getSpoolPath, getSpoolFilename } from '../config.js';
 
-/** Append a memory candidate to the daily JSONL spool file */
+/**
+ * Append a memory candidate to a JSONL spool file.
+ *
+ * When `agentId` is provided, each agent gets its own spool file to prevent
+ * interleaved writes from concurrent sessions.
+ *
+ * Path traversal: the resolved filepath is validated against the spool
+ * directory to prevent writes outside the allowed root.
+ */
 export async function writeToSpool(
   candidate: MemoryCandidate,
   spoolDir?: string,
+  agentId?: string,
 ): Promise<Result<string, string>> {
   const dir = spoolDir ?? getSpoolPath();
-  const filename = getSpoolFilename();
-  const filepath = join(dir, filename);
+  const filename = agentId ? `spool-${agentId}.jsonl` : getSpoolFilename();
+  const filepath = resolve(dir, filename);
+
+  // Path traversal guard: ensure resolved path stays within the spool directory
+  const resolvedDir = resolve(dir);
+  if (!filepath.startsWith(resolvedDir + '/') && filepath !== resolvedDir) {
+    return { ok: false, error: `Path traversal rejected: ${filename}` };
+  }
+
+  const safety = isPathSafe(filename);
+  if (!safety.safe) {
+    return { ok: false, error: `Unsafe spool filename: ${safety.reason}` };
+  }
 
   try {
-    await mkdir(dir, { recursive: true });
+    await mkdir(dir, { recursive: true, mode: 0o700 });
     const line = JSON.stringify(candidate) + '\n';
     await appendFile(filepath, line, 'utf8');
+    // Best-effort file permissions
+    try {
+      await chmod(filepath, 0o600);
+    } catch {
+      // Ignore permission errors on platforms that don't support chmod
+    }
     return { ok: true, value: filepath };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/packages/qmd-adapter/src/__tests__/real-executor.test.ts
+++ b/packages/qmd-adapter/src/__tests__/real-executor.test.ts
@@ -26,17 +26,17 @@ describe('RealQmdExecutor', () => {
     it('detects qmd availability', async () => {
       const available = await executor.isAvailable();
       expect(available).toBe(true);
-    });
+    }, 15000);
 
     it('gets qmd version', async () => {
       const result = await executor.execute(['--version']);
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('qmd');
-    });
+    }, 15000);
 
     it('handles invalid commands gracefully', async () => {
       const result = await executor.execute(['invalid-command-that-does-not-exist']);
       expect(result.exitCode).not.toBe(0);
-    });
+    }, 15000);
   });
 });

--- a/packages/qmd-adapter/src/search/search-client.ts
+++ b/packages/qmd-adapter/src/search/search-client.ts
@@ -15,9 +15,9 @@ export class SearchClient {
   ): Promise<Result<QmdSearchResult[], QmdError>> {
     const collections = this.resolveCollections(scope);
 
-    const args = ['search', query];
-    // qmd search doesn't have a --collection flag per se,
-    // but we filter results by collection post-query for scope enforcement
+    // Use '--' to terminate option parsing so query strings like '--version'
+    // are not interpreted as CLI flags
+    const args = ['search', '--', query];
     const result = await this.executor.execute(args);
 
     if (result.exitCode !== 0) {

--- a/packages/store/src/__tests__/memory-repository-search.test.ts
+++ b/packages/store/src/__tests__/memory-repository-search.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import Database from 'better-sqlite3';
+import type DatabaseType from 'better-sqlite3';
+import { createTestDatabase } from '../database.js';
+import { TABLE_DDL } from '../schema.js';
+import { MemoryRepository } from '../repositories/memory-repository.js';
+import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
+import { makeMemory } from './fixtures.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a unique 64-char hex string suitable for contentHash */
+function uniqueHash(): string {
+  return randomUUID().replace(/-/g, '') + randomUUID().replace(/-/g, '');
+}
+
+/**
+ * Build an in-memory DB with the base DDL only (no migrations) so that
+ * the FTS5 virtual table does NOT exist. This forces MemoryRepository
+ * into the LIKE-based search fallback path.
+ */
+function createLikeOnlyDatabase(): DatabaseType.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  for (const ddl of TABLE_DDL) {
+    db.exec(ddl);
+  }
+  // Deliberately skip runMigrations — no FTS5 virtual table
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// LIKE-escape tests
+//
+// Use a database WITHOUT the FTS5 migration so searchByLike is exercised.
+// ---------------------------------------------------------------------------
+
+describe('MemoryRepository.searchByText — LIKE wildcard escaping (no-FTS5 path)', () => {
+  let db: DatabaseType.Database;
+  let repo: MemoryRepository;
+
+  beforeEach(() => {
+    db = createLikeOnlyDatabase();
+    repo = new MemoryRepository(db);
+  });
+
+  it('percent sign in query does not break LIKE search and returns only exact matches', () => {
+    repo.insert(
+      makeMemory({
+        title: '100% coverage requirement',
+        content: 'All files must meet 100% coverage',
+        contentHash: uniqueHash(),
+      }),
+    );
+    repo.insert(
+      makeMemory({
+        title: 'Unrelated pattern',
+        content: 'Nothing about coverage here',
+        contentHash: uniqueHash(),
+      }),
+    );
+
+    // Capture the result — if % is unescaped SQLite LIKE would treat it as wildcard
+    // and potentially match everything. Escaped, only the row with literal "100%" matches.
+    let results: CuratedMemory[] = [];
+    expect(() => {
+      results = repo.searchByText('100%');
+    }).not.toThrow();
+    expect(results).toHaveLength(1);
+    expect(results[0]?.title).toBe('100% coverage requirement');
+  });
+
+  it('underscore in query does not act as a single-character wildcard', () => {
+    repo.insert(
+      makeMemory({
+        title: 'snake_case naming convention',
+        content: 'Use snake_case for all variable names in Python code',
+        contentHash: uniqueHash(),
+      }),
+    );
+    repo.insert(
+      makeMemory({
+        title: 'camelCase naming',
+        content: 'Use camelCase in JavaScript and TypeScript sources',
+        contentHash: uniqueHash(),
+      }),
+    );
+
+    // If _ were unescaped it would be a LIKE single-char wildcard — potentially
+    // matching "camelCase" etc. Escaped, it only matches the literal "snake_case".
+    let results: CuratedMemory[] = [];
+    expect(() => {
+      results = repo.searchByText('snake_case');
+    }).not.toThrow();
+    for (const r of results) {
+      expect((r.title + ' ' + r.content).toLowerCase()).toContain('snake_case');
+    }
+    expect(results).toHaveLength(1);
+  });
+
+  it('backslash in query does not break the ESCAPE clause', () => {
+    repo.insert(
+      makeMemory({
+        title: 'Windows path convention',
+        content: 'Use C:\\Users\\app for Windows installs',
+        contentHash: uniqueHash(),
+      }),
+    );
+
+    expect(() => {
+      repo.searchByText('C:\\Users');
+    }).not.toThrow();
+  });
+
+  it('query with both percent and underscore is handled safely', () => {
+    repo.insert(
+      makeMemory({ title: 'x_y%z pattern', content: 'mixed wildcards', contentHash: uniqueHash() }),
+    );
+
+    expect(() => {
+      repo.searchByText('x_y%z');
+    }).not.toThrow();
+  });
+
+  it('empty query returns an array without throwing', () => {
+    repo.insert(makeMemory({ contentHash: uniqueHash() }));
+
+    let results: CuratedMemory[] = [];
+    expect(() => {
+      results = repo.searchByText('');
+    }).not.toThrow();
+    expect(Array.isArray(results)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FTS5 search tests — createTestDatabase includes migration v2 (FTS5 table)
+// ---------------------------------------------------------------------------
+
+describe('MemoryRepository.searchByText — FTS5 path', () => {
+  let db: DatabaseType.Database;
+  let repo: MemoryRepository;
+  let hasFts5: boolean;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    // Check FTS5 availability
+    try {
+      db.prepare(
+        "SELECT 1 FROM curated_memories_fts WHERE curated_memories_fts MATCH 'test' LIMIT 0",
+      ).run();
+      hasFts5 = true;
+    } catch {
+      hasFts5 = false;
+    }
+    repo = new MemoryRepository(db);
+  });
+
+  it('FTS5 virtual table exists after createTestDatabase migrations', () => {
+    if (!hasFts5) return;
+    const row = db
+      .prepare(`SELECT name FROM sqlite_master WHERE name = 'curated_memories_fts'`)
+      .get() as { name: string } | undefined;
+    expect(row).toBeDefined();
+    expect(row?.name).toBe('curated_memories_fts');
+  });
+
+  it('inserted memory is searchable via FTS5', () => {
+    if (!hasFts5) return;
+    repo.insert(
+      makeMemory({
+        title: 'Observability tracing convention',
+        content: 'Add distributed tracing spans to every service boundary call',
+        contentHash: uniqueHash(),
+      }),
+    );
+    repo.insert(
+      makeMemory({
+        title: 'Deployment guide',
+        content: 'Run database migrations before rolling the application',
+        contentHash: uniqueHash(),
+      }),
+    );
+
+    const results = repo.searchByText('tracing');
+    expect(results).toHaveLength(1);
+    expect(results[0]?.title).toBe('Observability tracing convention');
+  });
+
+  it('FTS5 empty query returns empty array (early-return guard)', () => {
+    if (!hasFts5) return;
+    repo.insert(makeMemory({ contentHash: uniqueHash() }));
+
+    const results = repo.searchByText('');
+    expect(Array.isArray(results)).toBe(true);
+    // FTS5 path strips empty query → immediate return of []
+    expect(results).toHaveLength(0);
+  });
+
+  it('FTS5 asterisk special char is stripped safely — does not throw', () => {
+    if (!hasFts5) return;
+    repo.insert(
+      makeMemory({
+        title: 'Glob pattern advice',
+        content: 'Use glob for recursive matching in scripts',
+        contentHash: uniqueHash(),
+      }),
+    );
+
+    // '*' is an FTS5 operator — it is stripped, leaving empty string → early return
+    let results: CuratedMemory[] = [];
+    expect(() => {
+      results = repo.searchByText('*');
+    }).not.toThrow();
+    // After stripping *, query is empty → early return []
+    expect(results).toHaveLength(0);
+  });
+
+  it('FTS5 double-quote char is stripped and remaining text matches', () => {
+    if (!hasFts5) return;
+    repo.insert(
+      makeMemory({
+        title: 'Phrase search guide',
+        content: 'Use phrase search for exact term matching in production queries',
+        contentHash: uniqueHash(),
+      }),
+    );
+
+    // '"phrase"' — quotes stripped → 'phrase'
+    let results: CuratedMemory[] = [];
+    expect(() => {
+      results = repo.searchByText('"phrase"');
+    }).not.toThrow();
+    expect(results.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('FTS5 curly brace special char is stripped without error', () => {
+    if (!hasFts5) return;
+    expect(() => {
+      repo.searchByText('{nearQuery}');
+    }).not.toThrow();
+  });
+
+  it('only active memories are returned by FTS5 search', () => {
+    if (!hasFts5) return;
+    const sharedKeyword = 'deploymentxyz99';
+    repo.insert(
+      makeMemory({
+        lifecycle: 'active',
+        title: `Active ${sharedKeyword}`,
+        content: `Content about ${sharedKeyword}`,
+        contentHash: uniqueHash(),
+      }),
+    );
+    repo.insert(
+      makeMemory({
+        lifecycle: 'deprecated',
+        title: `Deprecated ${sharedKeyword}`,
+        content: `Old content about ${sharedKeyword}`,
+        contentHash: uniqueHash(),
+      }),
+    );
+
+    const results = repo.searchByText(sharedKeyword);
+    expect(results.every((r) => r.lifecycle === 'active')).toBe(true);
+    expect(results).toHaveLength(1);
+  });
+});

--- a/packages/store/src/__tests__/migrations.test.ts
+++ b/packages/store/src/__tests__/migrations.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from 'vitest';
+import { createDatabase, createTestDatabase } from '../database.js';
+import { MIGRATIONS } from '../schema.js';
+
+// ---------------------------------------------------------------------------
+// Schema migrations tests
+// ---------------------------------------------------------------------------
+
+describe('schema_migrations table', () => {
+  it('schema_migrations table exists on a fresh database', () => {
+    const db = createTestDatabase();
+    try {
+      const row = db
+        .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations'`)
+        .get() as { name: string } | undefined;
+      expect(row).toBeDefined();
+      expect(row?.name).toBe('schema_migrations');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('all defined migrations are recorded in schema_migrations on fresh DB', () => {
+    const db = createTestDatabase();
+    try {
+      const rows = db
+        .prepare('SELECT version FROM schema_migrations ORDER BY version')
+        .all() as Array<{ version: number }>;
+      const versions = rows.map((r) => r.version);
+      for (const migration of MIGRATIONS) {
+        expect(versions).toContain(migration.version);
+      }
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe('migrations run in order', () => {
+  it('versions in schema_migrations are strictly ascending', () => {
+    const db = createTestDatabase();
+    try {
+      const rows = db
+        .prepare('SELECT version FROM schema_migrations ORDER BY version')
+        .all() as Array<{ version: number }>;
+      const versions = rows.map((r) => r.version);
+      for (let i = 1; i < versions.length; i++) {
+        expect(versions[i]!).toBeGreaterThan(versions[i - 1]!);
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  it('migration versions match the MIGRATIONS array order', () => {
+    const db = createTestDatabase();
+    try {
+      const rows = db
+        .prepare('SELECT version, name FROM schema_migrations ORDER BY version')
+        .all() as Array<{ version: number; name: string }>;
+
+      const sortedMigrations = [...MIGRATIONS].sort((a, b) => a.version - b.version);
+      expect(rows).toHaveLength(sortedMigrations.length);
+
+      for (let i = 0; i < sortedMigrations.length; i++) {
+        expect(rows[i]?.version).toBe(sortedMigrations[i]?.version);
+        expect(rows[i]?.name).toBe(sortedMigrations[i]?.name);
+      }
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe('migrations are idempotent', () => {
+  it('calling createDatabase twice on separate in-memory connections does not throw', () => {
+    expect(() => {
+      const db1 = createDatabase({ path: ':memory:' });
+      db1.close();
+      const db2 = createDatabase({ path: ':memory:' });
+      db2.close();
+    }).not.toThrow();
+  });
+
+  it('migration records are not duplicated on a second createDatabase call', () => {
+    // Each :memory: DB is independent, so we verify a single DB has no duplicates
+    const db = createTestDatabase();
+    try {
+      const rows = db
+        .prepare('SELECT version, COUNT(*) as cnt FROM schema_migrations GROUP BY version')
+        .all() as Array<{ version: number; cnt: number }>;
+      for (const row of rows) {
+        expect(row.cnt).toBe(1);
+      }
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe('FTS5 virtual table after migrations', () => {
+  it('curated_memories_fts virtual table exists', () => {
+    const db = createTestDatabase();
+    try {
+      // SQLite represents virtual tables with type='table' in sqlite_master
+      const row = db
+        .prepare(`SELECT name FROM sqlite_master WHERE name = 'curated_memories_fts'`)
+        .get() as { name: string } | undefined;
+      expect(row).toBeDefined();
+      expect(row?.name).toBe('curated_memories_fts');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('FTS5 table is queryable without error', () => {
+    const db = createTestDatabase();
+    try {
+      expect(() => {
+        db.prepare(
+          `SELECT rowid FROM curated_memories_fts WHERE curated_memories_fts MATCH 'test' LIMIT 0`,
+        ).all();
+      }).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('insert trigger keeps FTS index in sync', () => {
+    const db = createTestDatabase();
+    try {
+      // Manually insert a row so we can verify the trigger fired
+      db.prepare(
+        `
+        INSERT INTO curated_memories (
+          id, candidate_id, source, content, title, category,
+          trust_level, sensitivity, author_json, tenant_id,
+          metadata_json, lifecycle, content_hash,
+          policy_evaluations_json, supersession_json,
+          promoted_at, promoted_by_json, updated_at, version
+        ) VALUES (
+          'test-id-1', 'cand-1', 'claude_session',
+          'Unique phrase synccheck inserted here', 'FTS sync test',
+          'pattern', 'high', 'internal', '{"type":"ai","id":"c1"}', 'team-a',
+          '{}', 'active', '${'a'.repeat(64)}',
+          '[]', NULL, datetime('now'), '{"type":"system","id":"s1"}',
+          datetime('now'), 1
+        )
+      `,
+      ).run();
+
+      const rows = db
+        .prepare(
+          `SELECT rowid FROM curated_memories_fts WHERE curated_memories_fts MATCH 'synccheck'`,
+        )
+        .all();
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe('compound indexes after migrations', () => {
+  it('idx_memories_tenant_lifecycle index exists', () => {
+    const db = createTestDatabase();
+    try {
+      const row = db
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type='index' AND name='idx_memories_tenant_lifecycle'`,
+        )
+        .get() as { name: string } | undefined;
+      expect(row).toBeDefined();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('idx_memories_lifecycle_updated index exists', () => {
+    const db = createTestDatabase();
+    try {
+      const row = db
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type='index' AND name='idx_memories_lifecycle_updated'`,
+        )
+        .get() as { name: string } | undefined;
+      expect(row).toBeDefined();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('idx_audit_timestamp index exists', () => {
+    const db = createTestDatabase();
+    try {
+      const row = db
+        .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_audit_timestamp'`)
+        .get() as { name: string } | undefined;
+      expect(row).toBeDefined();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('idx_memories_tenant_category index exists', () => {
+    const db = createTestDatabase();
+    try {
+      const row = db
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type='index' AND name='idx_memories_tenant_category'`,
+        )
+        .get() as { name: string } | undefined;
+      expect(row).toBeDefined();
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/store/src/database.ts
+++ b/packages/store/src/database.ts
@@ -1,5 +1,7 @@
+import { chmodSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
 import Database from 'better-sqlite3';
-import { TABLE_DDL } from './schema.js';
+import { TABLE_DDL, MIGRATIONS } from './schema.js';
 
 /** Options for creating a database connection */
 export interface DatabaseOptions {
@@ -9,11 +11,44 @@ export interface DatabaseOptions {
 }
 
 /**
+ * Ensure the parent directory of a database file exists with restricted
+ * permissions (0700). The database file itself is set to 0600 after creation.
+ * Skipped for in-memory databases.
+ */
+function ensureSecureDirectory(dbPath: string): void {
+  if (dbPath === ':memory:') return;
+
+  const dir = dirname(dbPath);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+}
+
+/**
+ * Apply restrictive file permissions (0600) to a database file.
+ * Silently ignores failures (e.g., on Windows or in-memory DBs).
+ */
+function secureDbFile(dbPath: string): void {
+  if (dbPath === ':memory:') return;
+
+  try {
+    chmodSync(dbPath, 0o600);
+  } catch {
+    // Best-effort: permissions may not be supported on all platforms
+  }
+}
+
+/**
  * Initialize a SQLite database connection with WAL mode enabled and
  * idempotent schema creation. Tables are created on first call and
  * left untouched on subsequent calls.
+ *
+ * Security: Parent directory is created with 0700, DB file set to 0600.
+ * Performance: WAL mode + busy_timeout + synchronous=NORMAL.
  */
 export function createDatabase(options: DatabaseOptions): Database.Database {
+  if (!(options.readonly ?? false)) {
+    ensureSecureDirectory(options.path);
+  }
+
   const db = new Database(options.path, {
     readonly: options.readonly ?? false,
   });
@@ -23,13 +58,51 @@ export function createDatabase(options: DatabaseOptions): Database.Database {
     // being safe for single-writer workloads.
     db.pragma('journal_mode = WAL');
     db.pragma('foreign_keys = ON');
+    db.pragma('busy_timeout = 5000');
+    db.pragma('synchronous = NORMAL');
 
     for (const ddl of TABLE_DDL) {
       db.exec(ddl);
     }
+
+    // Run incremental migrations
+    runMigrations(db);
+
+    secureDbFile(options.path);
   }
 
   return db;
+}
+
+/**
+ * Run all pending schema migrations in a transaction.
+ *
+ * Each migration is tracked in the `schema_migrations` table by version number.
+ * Only migrations with versions greater than the current max are applied.
+ * Runs inside a transaction so partial migration failures roll back cleanly.
+ */
+function runMigrations(db: Database.Database): void {
+  const currentVersion = db
+    .prepare('SELECT COALESCE(MAX(version), 0) as v FROM schema_migrations')
+    .get() as { v: number };
+
+  const pending = MIGRATIONS.filter((m) => m.version > currentVersion.v).sort(
+    (a, b) => a.version - b.version,
+  );
+
+  if (pending.length === 0) return;
+
+  const applyAll = db.transaction(() => {
+    for (const migration of pending) {
+      db.exec(migration.sql);
+      db.prepare('INSERT INTO schema_migrations (version, name) VALUES (?, ?)').run(
+        migration.version,
+        migration.name,
+      );
+    }
+  });
+
+  applyAll();
 }
 
 /**

--- a/packages/store/src/repositories/memory-repository.ts
+++ b/packages/store/src/repositories/memory-repository.ts
@@ -61,6 +61,7 @@ function rowToMemory(row: MemoryRow): CuratedMemory {
  */
 export class MemoryRepository {
   private readonly db: Database.Database;
+  private readonly hasFts5: boolean;
   private readonly stmtInsert: Database.Statement;
   private readonly stmtFindById: Database.Statement;
   private readonly stmtFindByTenant: Database.Statement;
@@ -78,6 +79,16 @@ export class MemoryRepository {
 
   constructor(db: Database.Database) {
     this.db = db;
+
+    // Detect FTS5 availability — the virtual table may not exist on older DBs
+    try {
+      db.prepare(
+        "SELECT 1 FROM curated_memories_fts WHERE curated_memories_fts MATCH 'test' LIMIT 0",
+      ).run();
+      this.hasFts5 = true;
+    } catch {
+      this.hasFts5 = false;
+    }
 
     this.stmtInsert = db.prepare(`
       INSERT INTO curated_memories (
@@ -315,12 +326,60 @@ export class MemoryRepository {
 
   /**
    * Search active curated memories by text match on title and content.
-   * Uses SQL LIKE for lightweight search — no FTS5 dependency.
+   *
+   * Uses FTS5 MATCH when the virtual table is available (faster, ranked).
+   * Falls back to LIKE search with escaped wildcards when FTS5 is not present.
    * Results capped at 100 rows.
    */
   searchByText(query: string, tenantId?: string, categories?: string[]): CuratedMemory[] {
-    const conditions = ["lifecycle = 'active'", '(title LIKE @pattern OR content LIKE @pattern)'];
-    const params: Record<string, string> = { pattern: `%${query}%` };
+    if (this.hasFts5) {
+      return this.searchByFts5(query, tenantId, categories);
+    }
+    return this.searchByLike(query, tenantId, categories);
+  }
+
+  /** FTS5-based search using MATCH for ranked full-text results */
+  private searchByFts5(query: string, tenantId?: string, categories?: string[]): CuratedMemory[] {
+    // Escape FTS5 special characters: " * ^ ( ) { } : -> NOT AND OR NEAR
+    const ftsQuery = query.replace(/[*"^(){}:]/g, '').trim();
+    if (ftsQuery.length === 0) return [];
+
+    const conditions = ["cm.lifecycle = 'active'"];
+    const params: Record<string, string> = { query: ftsQuery };
+
+    if (tenantId !== undefined) {
+      conditions.push('cm.tenant_id = @tenantId');
+      params['tenantId'] = tenantId;
+    }
+
+    if (categories !== undefined && categories.length > 0) {
+      const placeholders = categories.map((_, i) => `@cat${i}`);
+      conditions.push(`cm.category IN (${placeholders.join(', ')})`);
+      categories.forEach((cat, i) => {
+        params[`cat${i}`] = cat;
+      });
+    }
+
+    const sql = `
+      SELECT cm.* FROM curated_memories cm
+      JOIN curated_memories_fts fts ON cm.rowid = fts.rowid
+      WHERE curated_memories_fts MATCH @query
+        AND ${conditions.join(' AND ')}
+      ORDER BY rank
+      LIMIT 100
+    `;
+    const rows = this.db.prepare(sql).all(params) as MemoryRow[];
+    return rows.map(rowToMemory);
+  }
+
+  /** LIKE-based fallback search with escaped wildcards */
+  private searchByLike(query: string, tenantId?: string, categories?: string[]): CuratedMemory[] {
+    const escapedQuery = query.replace(/[%_\\]/g, '\\$&');
+    const conditions = [
+      "lifecycle = 'active'",
+      "(title LIKE @pattern ESCAPE '\\' OR content LIKE @pattern ESCAPE '\\')",
+    ];
+    const params: Record<string, string> = { pattern: `%${escapedQuery}%` };
 
     if (tenantId !== undefined) {
       conditions.push('tenant_id = @tenantId');

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -90,6 +90,14 @@ CREATE TABLE IF NOT EXISTS export_state (
 );
 `.trim();
 
+const SCHEMA_MIGRATIONS_DDL = `
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  version INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+`.trim();
+
 /** All DDL statements, each including the CREATE TABLE and its indexes as one string. */
 export const TABLE_DDL: string[] = [
   CANDIDATES_DDL,
@@ -97,4 +105,67 @@ export const TABLE_DDL: string[] = [
   GOVERNANCE_POLICIES_DDL,
   AUDIT_EVENTS_DDL,
   EXPORT_STATE_DDL,
+  SCHEMA_MIGRATIONS_DDL,
+];
+
+/**
+ * Numbered migrations applied incrementally after initial schema creation.
+ * Each migration runs exactly once, tracked by the schema_migrations table.
+ *
+ * IMPORTANT: Never modify existing migrations — only append new ones.
+ */
+export interface Migration {
+  version: number;
+  name: string;
+  sql: string;
+}
+
+export const MIGRATIONS: Migration[] = [
+  {
+    version: 1,
+    name: 'add_compound_indexes',
+    sql: `
+CREATE INDEX IF NOT EXISTS idx_memories_tenant_lifecycle ON curated_memories(tenant_id, lifecycle);
+CREATE INDEX IF NOT EXISTS idx_memories_lifecycle_updated ON curated_memories(lifecycle, updated_at);
+CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_memories_tenant_category ON curated_memories(tenant_id, category);
+    `.trim(),
+  },
+  {
+    version: 2,
+    name: 'add_fts5_search',
+    sql: `
+CREATE VIRTUAL TABLE IF NOT EXISTS curated_memories_fts USING fts5(
+  title,
+  content,
+  content='curated_memories',
+  content_rowid='rowid'
+);
+
+-- Populate FTS from existing data
+INSERT OR IGNORE INTO curated_memories_fts(rowid, title, content)
+  SELECT rowid, title, content FROM curated_memories;
+
+-- Triggers to keep FTS in sync with curated_memories
+CREATE TRIGGER IF NOT EXISTS curated_memories_fts_insert
+AFTER INSERT ON curated_memories BEGIN
+  INSERT INTO curated_memories_fts(rowid, title, content)
+  VALUES (new.rowid, new.title, new.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS curated_memories_fts_delete
+AFTER DELETE ON curated_memories BEGIN
+  INSERT INTO curated_memories_fts(curated_memories_fts, rowid, title, content)
+  VALUES ('delete', old.rowid, old.title, old.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS curated_memories_fts_update
+AFTER UPDATE ON curated_memories BEGIN
+  INSERT INTO curated_memories_fts(curated_memories_fts, rowid, title, content)
+  VALUES ('delete', old.rowid, old.title, old.content);
+  INSERT INTO curated_memories_fts(rowid, title, content)
+  VALUES (new.rowid, new.title, new.content);
+END;
+    `.trim(),
+  },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       '@qmd-team-intent-kb/store':
         specifier: workspace:*
         version: link:../../packages/store
+      fast-glob:
+        specifier: ^3.3.3
+        version: 3.3.3
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.0
@@ -460,6 +463,18 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
@@ -769,6 +784,10 @@ packages:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
@@ -976,6 +995,10 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -1012,6 +1035,10 @@ packages:
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -1061,6 +1088,10 @@ packages:
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -1131,6 +1162,10 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -1186,6 +1221,14 @@ packages:
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
 
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
@@ -1286,6 +1329,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
@@ -1344,6 +1391,9 @@ packages:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
@@ -1390,6 +1440,9 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -1513,6 +1566,10 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
 
   toad-cache@3.7.0:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
@@ -1850,6 +1907,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
   '@pinojs/redact@0.4.0': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
@@ -2163,6 +2232,10 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
@@ -2404,6 +2477,14 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-json-stringify@6.3.0:
@@ -2454,6 +2535,10 @@ snapshots:
       flat-cache: 4.0.1
 
   file-uri-to-path@1.0.0: {}
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
 
   finalhandler@2.1.1:
     dependencies:
@@ -2515,6 +2600,10 @@ snapshots:
 
   github-from-package@0.0.0: {}
 
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -2565,6 +2654,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-number@7.0.0: {}
+
   is-promise@4.0.0: {}
 
   isexe@2.0.0: {}
@@ -2613,6 +2704,13 @@ snapshots:
   media-typer@1.1.0: {}
 
   merge-descriptors@2.0.0: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
 
   mime-db@1.54.0: {}
 
@@ -2689,6 +2787,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.1: {}
+
   picomatch@4.0.3: {}
 
   pino-abstract-transport@3.0.0:
@@ -2757,6 +2857,8 @@ snapshots:
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
+
+  queue-microtask@1.2.3: {}
 
   quick-format-unescaped@4.0.4: {}
 
@@ -2832,6 +2934,10 @@ snapshots:
       path-to-regexp: 8.3.0
     transitivePeerDependencies:
       - supports-color
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
   safe-buffer@5.2.1: {}
 
@@ -2969,6 +3075,10 @@ snapshots:
       picomatch: 4.0.3
 
   tinyrainbow@3.1.0: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
 
   toad-cache@3.7.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,31 @@ importers:
         specifier: ^7.6.0
         version: 7.6.13
 
+  apps/mcp-server:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.27.1
+        version: 1.27.1(zod@4.3.6)
+      '@qmd-team-intent-kb/claude-runtime':
+        specifier: workspace:*
+        version: link:../../packages/claude-runtime
+      '@qmd-team-intent-kb/common':
+        specifier: workspace:*
+        version: link:../../packages/common
+      '@qmd-team-intent-kb/edge-daemon':
+        specifier: workspace:*
+        version: link:../edge-daemon
+      '@qmd-team-intent-kb/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      '@qmd-team-intent-kb/store':
+        specifier: workspace:*
+        version: link:../../packages/store
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.0
+        version: 7.6.13
+
   apps/reporting:
     dependencies:
       '@qmd-team-intent-kb/common':
@@ -400,6 +425,12 @@ packages:
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
 
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -418,6 +449,16 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -665,6 +706,10 @@ packages:
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -716,12 +761,28 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -730,12 +791,32 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -761,6 +842,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -769,16 +854,42 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -829,6 +940,18 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -836,6 +959,16 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.3.1:
+    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -880,6 +1013,10 @@ packages:
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way@9.5.0:
     resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
     engines: {node: '>=20'}
@@ -895,6 +1032,14 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -903,12 +1048,47 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.8:
+    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -931,6 +1111,14 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   ipaddr.js@2.3.0:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
     engines: {node: '>= 10'}
@@ -943,8 +1131,14 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -957,6 +1151,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -977,6 +1174,26 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -1006,9 +1223,21 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -1016,6 +1245,10 @@ packages:
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1032,6 +1265,10 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1039,6 +1276,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1059,6 +1299,10 @@ packages:
   pino@10.3.1:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -1085,6 +1329,10 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -1092,8 +1340,20 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -1127,6 +1387,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -1138,6 +1402,9 @@ packages:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
@@ -1146,8 +1413,19 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1156,6 +1434,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1179,6 +1473,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
@@ -1220,6 +1518,10 @@ packages:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -1232,6 +1534,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typescript-eslint@8.57.1:
     resolution: {integrity: sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==}
@@ -1251,11 +1557,19 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -1352,6 +1666,11 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -1492,6 +1811,10 @@ snapshots:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.3.0
 
+  '@hono/node-server@1.19.11(hono@4.12.8)':
+    dependencies:
+      hono: 4.12.8
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -1504,6 +1827,28 @@ snapshots:
   '@humanwhocodes/retry@0.4.3': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.11(hono@4.12.8)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
+      hono: 4.12.8
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@pinojs/redact@0.4.0': {}
 
@@ -1743,6 +2088,11 @@ snapshots:
 
   abstract-logging@2.0.1: {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -1795,6 +2145,20 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@5.0.4:
     dependencies:
       balanced-match: 4.0.4
@@ -1804,13 +2168,38 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   chai@6.2.2: {}
 
   chownr@1.1.4: {}
 
+  content-disposition@1.0.1: {}
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
   cookie@1.1.1: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1830,15 +2219,35 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -1868,6 +2277,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.4
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -1939,9 +2350,55 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.3.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-decode-uri-component@1.0.1: {}
 
@@ -1998,6 +2455,17 @@ snapshots:
 
   file-uri-to-path@1.0.0: {}
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way@9.5.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -2016,16 +2484,62 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   github-from-package@0.0.0: {}
 
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.8: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -2039,6 +2553,10 @@ snapshots:
 
   ini@1.3.8: {}
 
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   ipaddr.js@2.3.0: {}
 
   is-extglob@2.1.1: {}
@@ -2047,7 +2565,11 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-promise@4.0.0: {}
+
   isexe@2.0.0: {}
+
+  jose@6.2.2: {}
 
   json-buffer@3.0.1: {}
 
@@ -2058,6 +2580,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -2084,6 +2608,18 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mimic-response@3.1.0: {}
 
   minimatch@10.2.4:
@@ -2102,13 +2638,23 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
 
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
 
   on-exit-leak-free@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -2131,9 +2677,13 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@8.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -2160,6 +2710,8 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
+
+  pkce-challenge@5.0.1: {}
 
   postcss@8.5.8:
     dependencies:
@@ -2190,6 +2742,11 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -2197,7 +2754,20 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+
   quick-format-unescaped@4.0.4: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -2253,6 +2823,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.2.1: {}
 
   safe-regex2@5.1.0:
@@ -2261,17 +2841,74 @@ snapshots:
 
   safe-stable-stringify@2.5.0: {}
 
+  safer-buffer@2.1.2: {}
+
   secure-json-parse@4.1.0: {}
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@2.7.2: {}
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -2292,6 +2929,8 @@ snapshots:
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.0.0: {}
 
@@ -2333,6 +2972,8 @@ snapshots:
 
   toad-cache@3.7.0: {}
 
+  toidentifier@1.0.1: {}
+
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -2344,6 +2985,12 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typescript-eslint@8.57.1(eslint@10.0.3)(typescript@5.9.3):
     dependencies:
@@ -2362,11 +3009,15 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  unpipe@1.0.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2: {}
 
   vite@7.3.1(@types/node@25.5.0):
     dependencies:
@@ -2421,6 +3072,10 @@ snapshots:
   wrappy@1.0.2: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.1(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@3.25.76: {}
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -20,13 +20,13 @@ else
 fi
 
 if [ -f "$INIT_SCRIPT" ]; then
-  TEAMKB_DB_PATH="$DB_PATH" node "$INIT_SCRIPT" 2>/dev/null || true
+  TEAMKB_DB_PATH="$DB_PATH" node "$INIT_SCRIPT" || true
 fi
 
 # 3. If qmd is installed, ensure governed collections exist
 if command -v qmd &>/dev/null; then
   for collection in kb-curated kb-decisions kb-guides; do
-    qmd collection create "$collection" 2>/dev/null || true
+    qmd collection create "$collection" || true
   done
 fi
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -16,7 +16,7 @@ chmod 700 "$TEAMKB_DIR" "$SPOOL_DIR" "$FEEDBACK_DIR"
 if [ -n "${CLAUDE_PLUGIN_DATA:-}" ]; then
   INIT_SCRIPT="$CLAUDE_PLUGIN_DATA/init-db.js"
 else
-  INIT_SCRIPT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$(dirname "$0")")}/apps/mcp-server/dist/init-db.js"
+  INIT_SCRIPT="${CLAUDE_PLUGIN_ROOT:-.}/apps/mcp-server/dist/init-db.js"
 fi
 
 if [ -f "$INIT_SCRIPT" ]; then
@@ -31,4 +31,8 @@ if command -v qmd &>/dev/null; then
 fi
 
 # 4. Output status as JSON for Claude Code
-echo "{\"status\":\"ok\",\"db\":\"$DB_PATH\",\"qmd\":$(command -v qmd &>/dev/null && echo true || echo false)}"
+QMD_AVAILABLE=false
+if command -v qmd &>/dev/null; then
+  QMD_AVAILABLE=true
+fi
+echo "{\"status\":\"ok\",\"db\":\"$DB_PATH\",\"qmd\":$QMD_AVAILABLE}"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# bootstrap.sh — SessionStart hook for qmd-team-intent-kb plugin
+# Creates ~/.teamkb/ with secure permissions, initializes DB, seeds default policy.
+set -euo pipefail
+
+TEAMKB_DIR="${TEAMKB_BASE_PATH:-$HOME/.teamkb}"
+DB_PATH="$TEAMKB_DIR/teamkb.db"
+SPOOL_DIR="$TEAMKB_DIR/spool"
+FEEDBACK_DIR="$TEAMKB_DIR/feedback"
+
+# 1. Create directories with restricted permissions
+mkdir -p "$TEAMKB_DIR" "$SPOOL_DIR" "$FEEDBACK_DIR"
+chmod 700 "$TEAMKB_DIR" "$SPOOL_DIR" "$FEEDBACK_DIR"
+
+# 2. Initialize database (idempotent — schema + migrations)
+if [ -n "${CLAUDE_PLUGIN_DATA:-}" ]; then
+  INIT_SCRIPT="$CLAUDE_PLUGIN_DATA/init-db.js"
+else
+  INIT_SCRIPT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$(dirname "$0")")}/apps/mcp-server/dist/init-db.js"
+fi
+
+if [ -f "$INIT_SCRIPT" ]; then
+  TEAMKB_DB_PATH="$DB_PATH" node "$INIT_SCRIPT" 2>/dev/null || true
+fi
+
+# 3. If qmd is installed, ensure governed collections exist
+if command -v qmd &>/dev/null; then
+  for collection in kb-curated kb-decisions kb-guides; do
+    qmd collection create "$collection" 2>/dev/null || true
+  done
+fi
+
+# 4. Output status as JSON for Claude Code
+echo "{\"status\":\"ok\",\"db\":\"$DB_PATH\",\"qmd\":$(command -v qmd &>/dev/null && echo true || echo false)}"

--- a/scripts/flush-spool.sh
+++ b/scripts/flush-spool.sh
@@ -7,10 +7,17 @@ set -euo pipefail
 TEAMKB_DIR="${TEAMKB_BASE_PATH:-$HOME/.teamkb}"
 SPOOL_DIR="$TEAMKB_DIR/spool"
 DB_PATH="$TEAMKB_DIR/teamkb.db"
-EXPORT_DIR="${TEAMKB_EXPORT_DIR:-$(pwd)/kb-export}"
+EXPORT_DIR="${TEAMKB_EXPORT_DIR:-./kb-export}"
 
-# Exit early if no spool files
-if [ ! -d "$SPOOL_DIR" ] || [ -z "$(ls -A "$SPOOL_DIR" 2>/dev/null)" ]; then
+# Exit early if no spool files (use glob to avoid command substitution)
+if [ ! -d "$SPOOL_DIR" ]; then
+  echo '{"status":"ok","message":"No spool files to process"}'
+  exit 0
+fi
+shopt -s nullglob
+SPOOL_FILES=("$SPOOL_DIR"/*)
+shopt -u nullglob
+if [ ${#SPOOL_FILES[@]} -eq 0 ]; then
   echo '{"status":"ok","message":"No spool files to process"}'
   exit 0
 fi
@@ -19,7 +26,7 @@ fi
 if [ -n "${CLAUDE_PLUGIN_DATA:-}" ]; then
   CURATOR_SCRIPT="$CLAUDE_PLUGIN_DATA/flush.js"
 else
-  CURATOR_SCRIPT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$(dirname "$0")")}/apps/mcp-server/dist/flush.js"
+  CURATOR_SCRIPT="${CLAUDE_PLUGIN_ROOT:-.}/apps/mcp-server/dist/flush.js"
 fi
 
 # Run inline curation if script exists

--- a/scripts/flush-spool.sh
+++ b/scripts/flush-spool.sh
@@ -34,7 +34,7 @@ if [ -f "$CURATOR_SCRIPT" ]; then
   TEAMKB_DB_PATH="$DB_PATH" \
   TEAMKB_SPOOL_DIR="$SPOOL_DIR" \
   TEAMKB_EXPORT_DIR="$EXPORT_DIR" \
-  node "$CURATOR_SCRIPT" 2>/dev/null || {
+  node "$CURATOR_SCRIPT" || {
     echo '{"status":"error","message":"Curation failed"}'
     exit 0  # Don't block session exit
   }
@@ -42,7 +42,7 @@ fi
 
 # Trigger qmd embed if available
 if command -v qmd &>/dev/null && [ -d "$EXPORT_DIR" ]; then
-  qmd embed 2>/dev/null || true
+  qmd embed || true
 fi
 
 echo '{"status":"ok","message":"Spool flushed"}'

--- a/scripts/flush-spool.sh
+++ b/scripts/flush-spool.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# flush-spool.sh — Stop hook for qmd-team-intent-kb plugin
+# Drains the spool directory: curate → export → qmd embed.
+# Single-writer: only runs when the session is ending (no daemon conflict).
+set -euo pipefail
+
+TEAMKB_DIR="${TEAMKB_BASE_PATH:-$HOME/.teamkb}"
+SPOOL_DIR="$TEAMKB_DIR/spool"
+DB_PATH="$TEAMKB_DIR/teamkb.db"
+EXPORT_DIR="${TEAMKB_EXPORT_DIR:-$(pwd)/kb-export}"
+
+# Exit early if no spool files
+if [ ! -d "$SPOOL_DIR" ] || [ -z "$(ls -A "$SPOOL_DIR" 2>/dev/null)" ]; then
+  echo '{"status":"ok","message":"No spool files to process"}'
+  exit 0
+fi
+
+# Determine curator script location
+if [ -n "${CLAUDE_PLUGIN_DATA:-}" ]; then
+  CURATOR_SCRIPT="$CLAUDE_PLUGIN_DATA/flush.js"
+else
+  CURATOR_SCRIPT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$(dirname "$0")")}/apps/mcp-server/dist/flush.js"
+fi
+
+# Run inline curation if script exists
+if [ -f "$CURATOR_SCRIPT" ]; then
+  TEAMKB_DB_PATH="$DB_PATH" \
+  TEAMKB_SPOOL_DIR="$SPOOL_DIR" \
+  TEAMKB_EXPORT_DIR="$EXPORT_DIR" \
+  node "$CURATOR_SCRIPT" 2>/dev/null || {
+    echo '{"status":"error","message":"Curation failed"}'
+    exit 0  # Don't block session exit
+  }
+fi
+
+# Trigger qmd embed if available
+if command -v qmd &>/dev/null && [ -d "$EXPORT_DIR" ]; then
+  qmd embed 2>/dev/null || true
+fi
+
+echo '{"status":"ok","message":"Spool flushed"}'

--- a/skills/teamkb/SKILL.md
+++ b/skills/teamkb/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: teamkb
+description: |
+  Team knowledge governance for Claude Code. Captures architectural decisions,
+  patterns, conventions, and insights during sessions. Shares governed
+  knowledge across the team via qmd. Use when making team-relevant
+  discoveries or importing existing docs.
+allowed-tools: 'Read, Glob, Grep, Bash, Agent'
+user-invocable: true
+argument-hint: '[capture|import|status|review]'
+---
+
+You are assisting with **governed team knowledge management**. This plugin ensures
+that team memory is captured, validated through deterministic governance policies,
+and shared reliably.
+
+## Available MCP Tools
+
+When the teamkb MCP server is running, you have these tools:
+
+- **teamkb_propose** — Capture a single insight as a memory candidate
+  - Input: `{ title, content, category?, filePaths? }`
+  - Categories: decision, pattern, convention, architecture, troubleshooting, onboarding, reference
+  - Writes to spool (not directly to DB). Governance pipeline decides promotion.
+
+- **teamkb_import** — Bulk import files as memory candidates
+  - Input: `{ glob, basePath? }`
+  - Each file becomes a separate candidate in the spool.
+
+- **teamkb_status** — Check team knowledge health
+  - Shows counts by lifecycle state, category, and recent rejection feedback.
+
+- **teamkb_transition** — Change a memory's lifecycle state
+  - Input: `{ memoryId, to, reason, actor }`
+  - Valid transitions: active→deprecated, active→superseded, active→archived, deprecated→active, deprecated→archived, superseded→archived
+
+- **teamkb_sync** — Trigger qmd embedding (only if qmd installed)
+
+## When to Capture
+
+Recognize these capturable moments during sessions:
+
+1. **Decisions made** — "Let's use X instead of Y because..." → category: decision
+2. **Patterns discovered** — "This pattern works well for..." → category: pattern
+3. **Conventions agreed** — "We should always..." → category: convention
+4. **Architecture documented** — "The data flows from..." → category: architecture
+5. **Bugs solved** — "The root cause was..." → category: troubleshooting
+6. **Setup documented** — "To get this running..." → category: onboarding
+
+## Quality Bar
+
+Before proposing, ask: **"Would a new team member benefit from finding this in 30 days?"**
+
+Do NOT propose:
+
+- Session-specific debugging steps (too ephemeral)
+- Personal preferences (not team knowledge)
+- Content already in CLAUDE.md or README
+- Anything containing secrets, tokens, or credentials
+
+## Subagents
+
+- **@teamkb-curator** — End-of-session capture sweep. Reviews what happened and proposes insights.
+- **@teamkb-classifier** — Categorizes ambiguous content into a MemoryCategory.
+- **@teamkb-conflict-checker** — Compares proposed memory against existing ones for conflicts.
+
+## Usage Examples
+
+```
+/teamkb capture
+→ Invokes @teamkb-curator to review session and propose memories
+
+/teamkb import docs/**/*.md
+→ Bulk imports matching files as memory candidates
+
+/teamkb status
+→ Shows team knowledge health dashboard
+
+/teamkb review
+→ Reviews recent rejections and suggests improvements
+```

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     { "path": "apps/curator" },
     { "path": "apps/edge-daemon" },
     { "path": "apps/git-exporter" },
-    { "path": "apps/reporting" }
+    { "path": "apps/reporting" },
+    { "path": "apps/mcp-server" }
   ]
 }


### PR DESCRIPTION
## Summary

- **Phase 1 — Security + Data Hardening**: 15 P0 fixes across 8 existing files (timing-safe auth, LIKE escape, file permissions, path traversal, FTS5, schema migrations, compound indexes, intra-batch dedup, per-agent spool, rejection feedback)
- **Phase 2 — MCP Server**: New `apps/mcp-server` with 5 tools (propose, import, status, transition, sync) following single-writer invariant
- **Phase 3 — Plugin Packaging**: `.claude-plugin/plugin.json`, hooks (SessionStart bootstrap, Stop flush), `.mcp.json` for auto-start MCP server, shell scripts
- **Phase 4 — Intelligence Layer**: teamkb skill + 4 subagent definitions (curator, classifier, conflict-checker, scout)

### Numbers
- **867 → 1000 tests** (+133 new, all passing)
- **`pnpm validate` green** (format ✓ lint ✓ typecheck ✓ test ✓)
- **6 structured commits** following conventional commit style

### Architecture
```
Claude Code session
  ├─ teamkb MCP server (session-lifetime subprocess)
  │  ├─ teamkb_propose → spool (NOT SQLite)
  │  ├─ teamkb_import  → spool (one per file)
  │  ├─ teamkb_status  → SQLite read-only + feedback
  │  ├─ teamkb_transition → SQLite (low-frequency, user-initiated)
  │  └─ teamkb_sync    → qmd embed (conditional)
  ├─ SessionStart hook → bootstrap.sh (init DB, dirs, qmd collections)
  └─ Stop hook → flush-spool.sh (curate → export → embed)
```

### Security fixes
- `crypto.timingSafeEqual` for API key auth
- Fail-closed in production (no key = refuse to start)
- LIKE wildcard escape prevents pattern injection
- Path traversal validation in spool-writer + git-exporter
- File permissions 0700/0600 on data directories/files
- `busy_timeout=5000` prevents locked-database errors
- `--` separator prevents CLI flag injection in qmd search

### Data fixes
- Schema migration framework (`schema_migrations` table)
- FTS5 virtual table with sync triggers for ranked text search
- Compound indexes for common query patterns

## Test plan
- [x] `pnpm validate` passes (1000 tests)
- [x] Security fixes verified with targeted tests
- [x] FTS5 search returns results, LIKE fallback works
- [x] Schema migrations run on fresh DB
- [x] MCP server typechecks, all 5 tools tested
- [x] Intra-batch dedup catches same-content candidates
- [x] Plugin structure follows Claude Code plugin spec
- [ ] Manual: MCP server starts via stdio
- [ ] Manual: Plugin installs via `claude plugin install`
- [ ] Manual: Graceful degradation without qmd

🤖 Generated with [Claude Code](https://claude.com/claude-code)