### PR TITLE
feat(repo-resolver): monorepo detection (pnpm/npm/nx/turbo/lerna)

### DIFF
--- a/packages/repo-resolver/src/__tests__/fixtures.ts
+++ b/packages/repo-resolver/src/__tests__/fixtures.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execSync } from 'node:child_process';
@@ -72,4 +72,20 @@ export function makeRepoDetached(): Fixture {
 /** Directory that is not a git repo at all. */
 export function makeNonGitDir(): Fixture {
   return makeTmp('repo-resolver-nongit-');
+}
+
+/**
+ * Plain git repo whose root is also a pnpm workspace, with a single inner
+ * workspace package at packages/inner with name `@scope/inner`.
+ */
+export function makeRepoWithPnpmWorkspace(): Fixture & { innerDir: string } {
+  const fx = makeTmp('repo-resolver-pnpm-');
+  exec(fx.dir, 'git init -q -b main');
+  exec(fx.dir, 'git commit -q --allow-empty -m init');
+  writeFileSync(join(fx.dir, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n');
+  writeFileSync(join(fx.dir, 'package.json'), JSON.stringify({ name: 'root' }));
+  const innerDir = join(fx.dir, 'packages', 'inner');
+  mkdirSync(innerDir, { recursive: true });
+  writeFileSync(join(innerDir, 'package.json'), JSON.stringify({ name: '@scope/inner' }));
+  return { ...fx, innerDir };
 }

--- a/packages/repo-resolver/src/__tests__/monorepo.test.ts
+++ b/packages/repo-resolver/src/__tests__/monorepo.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { detectMonorepo } from '../monorepo.js';
+
+interface Workspace {
+  root: string;
+  cleanup: () => void;
+}
+
+const dirs: string[] = [];
+
+function tmp(prefix: string): string {
+  const d = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+  dirs.push(d);
+  return d;
+}
+
+function writeJson(path: string, body: unknown): void {
+  writeFileSync(path, JSON.stringify(body, null, 2));
+}
+
+function writeFile(path: string, body: string): void {
+  writeFileSync(path, body);
+}
+
+function makeMonorepo(
+  manifest: 'pnpm' | 'npm' | 'nx' | 'turbo' | 'lerna',
+  withPackage = true,
+): Workspace {
+  const root = tmp(`mr-${manifest}-`);
+  switch (manifest) {
+    case 'pnpm':
+      writeFile(join(root, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n');
+      writeJson(join(root, 'package.json'), { name: 'root' });
+      break;
+    case 'npm':
+      writeJson(join(root, 'package.json'), {
+        name: 'root',
+        workspaces: ['packages/*'],
+      });
+      break;
+    case 'nx':
+      writeJson(join(root, 'nx.json'), {});
+      writeJson(join(root, 'package.json'), { name: 'root' });
+      break;
+    case 'turbo':
+      writeJson(join(root, 'turbo.json'), {});
+      writeJson(join(root, 'package.json'), { name: 'root' });
+      break;
+    case 'lerna':
+      writeJson(join(root, 'lerna.json'), {});
+      writeJson(join(root, 'package.json'), { name: 'root' });
+      break;
+  }
+  if (withPackage) {
+    const pkgDir = join(root, 'packages', 'inner');
+    mkdirSync(pkgDir, { recursive: true });
+    writeJson(join(pkgDir, 'package.json'), { name: '@scope/inner' });
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+afterEach(() => {
+  while (dirs.length > 0) {
+    const d = dirs.pop();
+    if (d) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe('detectMonorepo manifest precedence', () => {
+  it.each(['pnpm', 'npm', 'nx', 'turbo', 'lerna'] as const)(
+    'detects %s workspace from inner package',
+    (kind) => {
+      const ws = makeMonorepo(kind);
+      const inner = join(ws.root, 'packages', 'inner');
+      const info = detectMonorepo(inner, ws.root);
+      expect(info.isMonorepo).toBe(true);
+      expect(info.workspaceRoot).toBe(ws.root);
+      expect(info.workspacePackage).toBe('@scope/inner');
+    },
+  );
+
+  it('pnpm beats nx when both present in same dir', () => {
+    const root = tmp('mr-precedence-');
+    writeFile(join(root, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n');
+    writeJson(join(root, 'nx.json'), {});
+    const info = detectMonorepo(root, root);
+    expect(info.workspaceRoot).toBe(root);
+  });
+});
+
+describe('detectMonorepo cwd handling', () => {
+  it('returns null workspacePackage when cwd is at the workspace root', () => {
+    const ws = makeMonorepo('pnpm', false);
+    const info = detectMonorepo(ws.root, ws.root);
+    expect(info.isMonorepo).toBe(true);
+    expect(info.workspacePackage).toBeNull();
+  });
+
+  it('returns null workspacePackage when no package.json exists between cwd and root', () => {
+    const ws = makeMonorepo('pnpm', false);
+    const inner = join(ws.root, 'packages', 'inner');
+    mkdirSync(inner, { recursive: true });
+    const info = detectMonorepo(inner, ws.root);
+    expect(info.isMonorepo).toBe(true);
+    expect(info.workspacePackage).toBeNull();
+  });
+
+  it('returns null workspacePackage when nearest package.json has no name', () => {
+    const ws = makeMonorepo('pnpm', false);
+    const inner = join(ws.root, 'packages', 'unnamed');
+    mkdirSync(inner, { recursive: true });
+    writeJson(join(inner, 'package.json'), { version: '0.0.0' });
+    const info = detectMonorepo(inner, ws.root);
+    expect(info.workspacePackage).toBeNull();
+  });
+
+  it('walks upward through nested subdirectories to find the manifest', () => {
+    const ws = makeMonorepo('pnpm');
+    const deep = join(ws.root, 'packages', 'inner', 'src', 'lib', 'utils');
+    mkdirSync(deep, { recursive: true });
+    const info = detectMonorepo(deep, ws.root);
+    expect(info.workspaceRoot).toBe(ws.root);
+    expect(info.workspacePackage).toBe('@scope/inner');
+  });
+});
+
+describe('detectMonorepo negative cases', () => {
+  it('returns non-monorepo when no manifest exists', () => {
+    const root = tmp('mr-plain-');
+    writeJson(join(root, 'package.json'), { name: 'plain' });
+    const info = detectMonorepo(root, root);
+    expect(info.isMonorepo).toBe(false);
+    expect(info.workspaceRoot).toBeNull();
+    expect(info.workspacePackage).toBeNull();
+  });
+
+  it('treats package.json without workspaces field as non-monorepo', () => {
+    const root = tmp('mr-no-workspaces-');
+    writeJson(join(root, 'package.json'), { name: 'plain' });
+    const info = detectMonorepo(root, root);
+    expect(info.isMonorepo).toBe(false);
+  });
+
+  it('treats workspaces:[] as non-monorepo', () => {
+    const root = tmp('mr-empty-workspaces-');
+    writeJson(join(root, 'package.json'), { name: 'plain', workspaces: [] });
+    const info = detectMonorepo(root, root);
+    expect(info.isMonorepo).toBe(false);
+  });
+
+  it('handles object-form workspaces ({packages: []})', () => {
+    const root = tmp('mr-obj-workspaces-');
+    writeJson(join(root, 'package.json'), {
+      name: 'plain',
+      workspaces: { packages: ['packages/*'] },
+    });
+    const info = detectMonorepo(root, root);
+    expect(info.isMonorepo).toBe(true);
+  });
+
+  it('returns non-monorepo when cwd is outside repoRoot', () => {
+    const repo = tmp('mr-outside-');
+    const outside = tmp('mr-outside-other-');
+    writeFile(join(repo, 'pnpm-workspace.yaml'), 'packages:\n  - "*"\n');
+    const info = detectMonorepo(outside, repo);
+    expect(info.isMonorepo).toBe(false);
+  });
+
+  it('skips malformed package.json without throwing', () => {
+    const root = tmp('mr-bad-json-');
+    writeFile(join(root, 'package.json'), '{ this is not json');
+    const info = detectMonorepo(root, root);
+    expect(info.isMonorepo).toBe(false);
+  });
+});

--- a/packages/repo-resolver/src/__tests__/resolver.test.ts
+++ b/packages/repo-resolver/src/__tests__/resolver.test.ts
@@ -8,6 +8,7 @@ import {
   makeRepoDetached,
   makeRepoNoCommits,
   makeRepoNoRemote,
+  makeRepoWithPnpmWorkspace,
   makeRepoWithRemote,
   type Fixture,
 } from './fixtures.js';
@@ -15,7 +16,7 @@ import {
 describe('resolveRepoContext', () => {
   const fixtures: Fixture[] = [];
 
-  function track(fx: Fixture): Fixture {
+  function track<T extends Fixture>(fx: T): T {
     fixtures.push(fx);
     return fx;
   }
@@ -106,5 +107,26 @@ describe('resolveRepoContext', () => {
     if (!result.ok) return;
     // On macOS /tmp is a symlink; realpath must have resolved it.
     expect(result.value.repoRoot).toBe(realpathSync(fx.dir));
+  });
+
+  it('populates monorepo fields when cwd is inside a pnpm workspace package', async () => {
+    const fx = track(makeRepoWithPnpmWorkspace());
+    const result = await resolveRepoContext(fx.innerDir);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.isMonorepo).toBe(true);
+    expect(result.value.workspaceRoot).toBe(realpathSync(fx.dir));
+    expect(result.value.workspacePackage).toBe('@scope/inner');
+  });
+
+  it('populates workspaceRoot but null workspacePackage when cwd is at repo root', async () => {
+    const fx = track(makeRepoWithPnpmWorkspace());
+    const result = await resolveRepoContext(fx.dir);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.isMonorepo).toBe(true);
+    expect(result.value.workspaceRoot).toBe(realpathSync(fx.dir));
+    // Root package.json has name='root' but cwd === workspaceRoot, so null.
+    expect(result.value.workspacePackage).toBeNull();
   });
 });

--- a/packages/repo-resolver/src/index.ts
+++ b/packages/repo-resolver/src/index.ts
@@ -1,4 +1,4 @@
-export type { RepoContext, ResolverError } from './types.js';
+export { RepoContext, ResolverError } from './types.js';
 export { resolveRepoContext, type ResolveOptions } from './resolver.js';
 export {
   RepoContextCache,
@@ -7,5 +7,7 @@ export {
   setCacheTtl,
   setDefaultCache,
 } from './cache.js';
+export { detectMonorepo } from './monorepo.js';
+export type { MonorepoInfo } from './monorepo.js';
 
 export const name = '@qmd-team-intent-kb/repo-resolver';

--- a/packages/repo-resolver/src/monorepo.ts
+++ b/packages/repo-resolver/src/monorepo.ts
@@ -1,0 +1,125 @@
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative, sep } from 'node:path';
+
+const MAX_MANIFEST_SIZE = 64 * 1024;
+
+/**
+ * Detection precedence — first match at any directory wins. See
+ * 000-docs/026-AT-DSGN-repo-resolver-design.md.
+ */
+const MANIFEST_PROBES: Array<(dir: string) => boolean> = [
+  (dir) => existsSync(join(dir, 'pnpm-workspace.yaml')),
+  (dir) => hasNpmWorkspaces(dir),
+  (dir) => existsSync(join(dir, 'nx.json')),
+  (dir) => existsSync(join(dir, 'turbo.json')),
+  (dir) => existsSync(join(dir, 'lerna.json')),
+];
+
+interface PackageJson {
+  name?: unknown;
+  workspaces?: unknown;
+}
+
+function safeReadPackageJson(dir: string): PackageJson | null {
+  const path = join(dir, 'package.json');
+  if (!existsSync(path)) return null;
+  try {
+    const stat = statSync(path);
+    if (stat.size > MAX_MANIFEST_SIZE) return null;
+    return JSON.parse(readFileSync(path, 'utf8')) as PackageJson;
+  } catch {
+    return null;
+  }
+}
+
+function hasNpmWorkspaces(dir: string): boolean {
+  const pkg = safeReadPackageJson(dir);
+  if (!pkg) return false;
+  const ws = pkg.workspaces;
+  if (Array.isArray(ws) && ws.length > 0) return true;
+  if (ws && typeof ws === 'object' && Array.isArray((ws as { packages?: unknown }).packages)) {
+    return true;
+  }
+  return false;
+}
+
+export interface MonorepoInfo {
+  isMonorepo: boolean;
+  workspaceRoot: string | null;
+  workspacePackage: string | null;
+}
+
+const NEGATIVE: MonorepoInfo = {
+  isMonorepo: false,
+  workspaceRoot: null,
+  workspacePackage: null,
+};
+
+/**
+ * Detect monorepo workspace context for `cwd` within `repoRoot`.
+ *
+ * Walks upward from `cwd` to `repoRoot` (inclusive) probing each directory
+ * for a workspace manifest. First match wins. When a workspace root is
+ * found, the nearest enclosing `package.json` between `cwd` and that root
+ * supplies `workspacePackage` — null when cwd is at the workspace root or
+ * the package.json has no `name` field.
+ */
+export function detectMonorepo(cwd: string, repoRoot: string): MonorepoInfo {
+  if (!isWithin(cwd, repoRoot)) return NEGATIVE;
+
+  let workspaceRoot: string | null = null;
+  let dir = cwd;
+  while (true) {
+    for (const probe of MANIFEST_PROBES) {
+      if (probe(dir)) {
+        workspaceRoot = dir;
+        break;
+      }
+    }
+    if (workspaceRoot !== null) break;
+    if (dir === repoRoot) break;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  if (workspaceRoot === null) return NEGATIVE;
+
+  return {
+    isMonorepo: true,
+    workspaceRoot,
+    workspacePackage: findWorkspacePackage(cwd, workspaceRoot),
+  };
+}
+
+/**
+ * Walk from `cwd` back toward `workspaceRoot` (exclusive) finding the
+ * nearest `package.json` with a `name` field. Returns the name string,
+ * or null when cwd is at workspaceRoot itself or no named package.json
+ * exists between them.
+ */
+function findWorkspacePackage(cwd: string, workspaceRoot: string): string | null {
+  if (cwd === workspaceRoot) return null;
+
+  let dir = cwd;
+  while (dir !== workspaceRoot) {
+    const pkg = safeReadPackageJson(dir);
+    if (pkg && typeof pkg.name === 'string' && pkg.name.trim().length > 0) {
+      return pkg.name.trim();
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * True when `child` equals `ancestor` or sits underneath it. Defends against
+ * the `/repo-foo` / `/repo-foo-bar` prefix-match bug.
+ */
+function isWithin(child: string, ancestor: string): boolean {
+  if (child === ancestor) return true;
+  const rel = relative(ancestor, child);
+  return rel.length > 0 && !rel.startsWith('..') && !rel.startsWith(sep);
+}

--- a/packages/repo-resolver/src/resolver.ts
+++ b/packages/repo-resolver/src/resolver.ts
@@ -4,6 +4,7 @@ import { ok, err, type Result } from '@qmd-team-intent-kb/common';
 import type { RepoContext, ResolverError } from './types.js';
 import { runGit } from './git.js';
 import { getDefaultCache, type RepoContextCache } from './cache.js';
+import { detectMonorepo } from './monorepo.js';
 
 export interface ResolveOptions {
   /**
@@ -107,15 +108,15 @@ export async function resolveRepoContext(
   const remoteUrl = remoteResult.exitCode === 0 ? remoteResult.stdout.trim() || null : null;
   const branch = branchResult.exitCode === 0 ? branchResult.stdout.trim() || null : null;
 
+  const monorepo = detectMonorepo(canonicalCwd, repoRoot);
+
   const context: RepoContext = {
     repoRoot,
     repoName: basename(repoRoot).toLowerCase(),
     remoteUrl,
     branch,
     commitSha,
-    isMonorepo: false,
-    workspaceRoot: null,
-    workspacePackage: null,
+    ...monorepo,
   };
 
   if (cache) {


### PR DESCRIPTION
## Summary

Implements bead `mbd.3`. Walks upward from cwd to repoRoot probing for workspace manifests in precedence order:

1. \`pnpm-workspace.yaml\`
2. \`package.json\` with \`workspaces\` field (array or \`{packages: []}\` form)
3. \`nx.json\`
4. \`turbo.json\`
5. \`lerna.json\`

When a workspace root is found, the nearest enclosing \`package.json\` between cwd and that root supplies \`workspacePackage\`.

## Wired into the resolver

\`detectMonorepo()\` is now spread into the `RepoContext` returned by \`resolveRepoContext()\`, so the \`isMonorepo\` / \`workspaceRoot\` / \`workspacePackage\` fields populate from real input rather than the hardcoded false/null defaults from mbd.2.

## Defenses

- 64 KB manifest size cap on package.json reads
- Relative-path containment guard against the \`/repo-foo\` vs \`/repo-foo-bar\` prefix-match bug
- Malformed JSON silently treated as absent (never throws)
- cwd outside repoRoot → returns non-monorepo

## Test plan

- [x] 16 monorepo unit tests (5 manifest types via \`it.each\`, precedence, cwd handling, negative cases, prefix-match, malformed JSON)
- [x] 2 resolver-level integration tests via new \`makeRepoWithPnpmWorkspace\` fixture
- [x] Full suite 1026/1026 pass under \`pnpm validate\`

## Coordination with mbd.4

This PR is independent of #36 (mbd.4 tenant derivation) and can merge in either order. Whichever lands first, the other will rebase.

Closes qmd-team-intent-kb-mbd.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)