### PR TITLE
feat(repo-resolver): process-local cache with TTL

### DIFF
--- a/packages/repo-resolver/src/__tests__/cache.test.ts
+++ b/packages/repo-resolver/src/__tests__/cache.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+import { realpathSync } from 'node:fs';
+import { RepoContextCache, clearCache, getDefaultCache, setCacheTtl } from '../cache.js';
+import { resolveRepoContext } from '../resolver.js';
+import { makeRepoWithRemote, type Fixture } from './fixtures.js';
+import type { RepoContext } from '../types.js';
+
+function fakeContext(repoRoot: string, commitSha = '0'.repeat(40)): RepoContext {
+  return {
+    repoRoot,
+    repoName: 'fake',
+    remoteUrl: null,
+    branch: null,
+    commitSha,
+    isMonorepo: false,
+    workspaceRoot: null,
+    workspacePackage: null,
+  };
+}
+
+describe('RepoContextCache', () => {
+  it('returns null when an entry is absent', () => {
+    const c = new RepoContextCache();
+    expect(c.getByCwd('/x')).toBeNull();
+    expect(c.getByRoot('/x')).toBeNull();
+  });
+
+  it('round-trips by cwd and by root', () => {
+    const c = new RepoContextCache();
+    const ctx = fakeContext('/r');
+    c.set('/cwd', ctx);
+    expect(c.getByCwd('/cwd')).toBe(ctx);
+    expect(c.getByRoot('/r')).toBe(ctx);
+  });
+
+  it('shares a single entry across multiple cwd values pointing at one repo', () => {
+    const c = new RepoContextCache();
+    const ctx = fakeContext('/r');
+    c.set('/r/sub/a', ctx);
+    c.set('/r/sub/b', ctx);
+    expect(c.size()).toBe(1);
+    expect(c.getByCwd('/r/sub/a')).toBe(ctx);
+    expect(c.getByCwd('/r/sub/b')).toBe(ctx);
+  });
+
+  it('expires entries past TTL and evicts on access', () => {
+    let now = 1000;
+    const c = new RepoContextCache({ ttlMs: 100, nowFn: () => now });
+    c.set('/cwd', fakeContext('/r'));
+    expect(c.getByCwd('/cwd')).not.toBeNull();
+    now = 1101;
+    expect(c.getByCwd('/cwd')).toBeNull();
+    expect(c.size()).toBe(0);
+  });
+
+  it('clear() drops all entries and cwd index', () => {
+    const c = new RepoContextCache();
+    c.set('/cwd', fakeContext('/r'));
+    c.clear();
+    expect(c.size()).toBe(0);
+    expect(c.getByCwd('/cwd')).toBeNull();
+  });
+
+  it('setTtl changes future expiry decisions', () => {
+    let now = 1000;
+    const c = new RepoContextCache({ ttlMs: 1_000_000, nowFn: () => now });
+    c.set('/cwd', fakeContext('/r'));
+    c.setTtl(50);
+    now = 1100;
+    expect(c.getByCwd('/cwd')).toBeNull();
+  });
+});
+
+describe('resolveRepoContext + cache integration', () => {
+  const fixtures: Fixture[] = [];
+  function track<T extends Fixture>(fx: T): T {
+    fixtures.push(fx);
+    return fx;
+  }
+  afterEach(() => {
+    while (fixtures.length > 0) fixtures.pop()?.cleanup();
+    clearCache();
+  });
+
+  it('second call hits the cache (same RepoContext reference)', async () => {
+    clearCache();
+    const fx = track(makeRepoWithRemote());
+    const first = await resolveRepoContext(fx.dir);
+    const second = await resolveRepoContext(fx.dir);
+    expect(first.ok && second.ok).toBe(true);
+    if (!first.ok || !second.ok) return;
+    expect(second.value).toBe(first.value);
+  });
+
+  it('explicit null cache disables caching', async () => {
+    clearCache();
+    const fx = track(makeRepoWithRemote());
+    const first = await resolveRepoContext(fx.dir, { cache: null });
+    const second = await resolveRepoContext(fx.dir, { cache: null });
+    expect(first.ok && second.ok).toBe(true);
+    if (!first.ok || !second.ok) return;
+    expect(second.value).not.toBe(first.value);
+    // Default cache must remain empty when cache:null was passed.
+    expect(getDefaultCache().getByCwd(realpathSync(fx.dir))).toBeNull();
+  });
+
+  it('clearCache() forces a fresh resolution', async () => {
+    clearCache();
+    const fx = track(makeRepoWithRemote());
+    const first = await resolveRepoContext(fx.dir);
+    clearCache();
+    const second = await resolveRepoContext(fx.dir);
+    expect(first.ok && second.ok).toBe(true);
+    if (!first.ok || !second.ok) return;
+    expect(second.value).not.toBe(first.value);
+  });
+
+  it('expired entries are bypassed and refreshed', async () => {
+    clearCache();
+    setCacheTtl(0);
+    const fx = track(makeRepoWithRemote());
+    const first = await resolveRepoContext(fx.dir);
+    const second = await resolveRepoContext(fx.dir);
+    expect(first.ok && second.ok).toBe(true);
+    if (!first.ok || !second.ok) return;
+    expect(second.value).not.toBe(first.value);
+    setCacheTtl(5 * 60 * 1000);
+  });
+
+  it('different cwd in the same repo shares a single cached entry', async () => {
+    clearCache();
+    const fx = track(makeRepoWithRemote());
+    // Resolve from the repo root, then from the same path again — the
+    // cwd index must avoid a re-resolution.
+    const root = realpathSync(fx.dir);
+    const a = await resolveRepoContext(fx.dir);
+    const b = await resolveRepoContext(root);
+    expect(a.ok && b.ok).toBe(true);
+    if (!a.ok || !b.ok) return;
+    expect(b.value).toBe(a.value);
+    expect(getDefaultCache().size()).toBe(1);
+  });
+
+  it('Io errors are not cached', async () => {
+    clearCache();
+    const before = getDefaultCache().size();
+    const result = await resolveRepoContext(join('/definitely', 'not', 'here'));
+    expect(result.ok).toBe(false);
+    expect(getDefaultCache().size()).toBe(before);
+  });
+});

--- a/packages/repo-resolver/src/cache.ts
+++ b/packages/repo-resolver/src/cache.ts
@@ -1,0 +1,100 @@
+import type { RepoContext } from './types.js';
+
+/**
+ * Process-local cache for resolved RepoContext objects.
+ *
+ * Two-level lookup: realpath(cwd) → repoRoot → { context, fetchedAt }.
+ * The cwd indirection lets resolutions from any subdirectory share a single
+ * entry per repo. Entries expire after `ttlMs`.
+ *
+ * See 000-docs/026-AT-DSGN-repo-resolver-design.md.
+ */
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+interface CacheEntry {
+  context: RepoContext;
+  fetchedAt: number;
+}
+
+export class RepoContextCache {
+  private readonly entries = new Map<string, CacheEntry>();
+  private readonly cwdIndex = new Map<string, string>();
+  private ttlMs: number;
+  private readonly nowFn: () => number;
+
+  constructor(opts: { ttlMs?: number; nowFn?: () => number } = {}) {
+    this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS;
+    this.nowFn = opts.nowFn ?? Date.now;
+  }
+
+  /**
+   * Look up by canonical cwd. Returns the cached context only when both the
+   * cwd→repoRoot mapping exists AND the entry is still within TTL. Stale
+   * entries are evicted on access.
+   */
+  getByCwd(canonicalCwd: string): RepoContext | null {
+    const repoRoot = this.cwdIndex.get(canonicalCwd);
+    if (!repoRoot) return null;
+    return this.getByRoot(repoRoot);
+  }
+
+  /** Look up by repoRoot. Stale entries are evicted on access. */
+  getByRoot(repoRoot: string): RepoContext | null {
+    const entry = this.entries.get(repoRoot);
+    if (!entry) return null;
+    if (this.nowFn() - entry.fetchedAt >= this.ttlMs) {
+      this.entries.delete(repoRoot);
+      return null;
+    }
+    return entry.context;
+  }
+
+  /**
+   * Insert a freshly resolved context. Records both the cwd→repoRoot
+   * mapping and the repoRoot→entry mapping.
+   */
+  set(canonicalCwd: string, context: RepoContext): void {
+    this.cwdIndex.set(canonicalCwd, context.repoRoot);
+    this.entries.set(context.repoRoot, {
+      context,
+      fetchedAt: this.nowFn(),
+    });
+  }
+
+  /** Drop everything. For tests and explicit invalidation. */
+  clear(): void {
+    this.entries.clear();
+    this.cwdIndex.clear();
+  }
+
+  /** Replace the TTL. Existing entries keep their original fetchedAt. */
+  setTtl(ttlMs: number): void {
+    this.ttlMs = ttlMs;
+  }
+
+  /** Test introspection. */
+  size(): number {
+    return this.entries.size;
+  }
+}
+
+let defaultCache = new RepoContextCache();
+
+export function getDefaultCache(): RepoContextCache {
+  return defaultCache;
+}
+
+/** Reset the default singleton. Tests should call this between cases. */
+export function clearCache(): void {
+  defaultCache.clear();
+}
+
+/** Configure the default singleton's TTL. */
+export function setCacheTtl(ttlMs: number): void {
+  defaultCache.setTtl(ttlMs);
+}
+
+/** Replace the default cache (advanced — primarily for tests injecting nowFn). */
+export function setDefaultCache(cache: RepoContextCache): void {
+  defaultCache = cache;
+}

--- a/packages/repo-resolver/src/index.ts
+++ b/packages/repo-resolver/src/index.ts
@@ -1,4 +1,11 @@
 export type { RepoContext, ResolverError } from './types.js';
-export { resolveRepoContext } from './resolver.js';
+export { resolveRepoContext, type ResolveOptions } from './resolver.js';
+export {
+  RepoContextCache,
+  clearCache,
+  getDefaultCache,
+  setCacheTtl,
+  setDefaultCache,
+} from './cache.js';
 
 export const name = '@qmd-team-intent-kb/repo-resolver';

--- a/packages/repo-resolver/src/resolver.ts
+++ b/packages/repo-resolver/src/resolver.ts
@@ -3,6 +3,16 @@ import { basename } from 'node:path';
 import { ok, err, type Result } from '@qmd-team-intent-kb/common';
 import type { RepoContext, ResolverError } from './types.js';
 import { runGit } from './git.js';
+import { getDefaultCache, type RepoContextCache } from './cache.js';
+
+export interface ResolveOptions {
+  /**
+   * Override the cache used for this resolution. When omitted, the
+   * process-local default cache from `getDefaultCache()` is used.
+   * Pass a fresh `RepoContextCache` instance (or `null`) to bypass.
+   */
+  cache?: RepoContextCache | null;
+}
 
 /**
  * Resolve the git repo context enclosing `cwd`.
@@ -13,7 +23,10 @@ import { runGit } from './git.js';
  *
  * See 000-docs/026-AT-DSGN-repo-resolver-design.md for the full design.
  */
-export async function resolveRepoContext(cwd: string): Promise<Result<RepoContext, ResolverError>> {
+export async function resolveRepoContext(
+  cwd: string,
+  options: ResolveOptions = {},
+): Promise<Result<RepoContext, ResolverError>> {
   let canonicalCwd: string;
   try {
     canonicalCwd = await realpath(cwd);
@@ -23,6 +36,12 @@ export async function resolveRepoContext(cwd: string): Promise<Result<RepoContex
       path: cwd,
       cause: e instanceof Error ? e.message : String(e),
     });
+  }
+
+  const cache = options.cache === undefined ? getDefaultCache() : options.cache;
+  if (cache) {
+    const cached = cache.getByCwd(canonicalCwd);
+    if (cached) return ok(cached);
   }
 
   // Single consolidated git call — the hot path for warm caches in later beads.
@@ -90,6 +109,10 @@ export async function resolveRepoContext(cwd: string): Promise<Result<RepoContex
     workspaceRoot: null,
     workspacePackage: null,
   };
+
+  if (cache) {
+    cache.set(canonicalCwd, context);
+  }
 
   return ok(context);
 }


### PR DESCRIPTION
Implements bead mbd.5 — process-local RepoContextCache with two-level lookup (realpath cwd → repoRoot → entry). 5-minute default TTL. resolveRepoContext gains optional ResolveOptions (cache: undefined | null | instance). clearCache/setCacheTtl/getDefaultCache/setDefaultCache exposed for tests. Errors never cached. 20 tests, 1020/1020 full suite. Closes qmd-team-intent-kb-mbd.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)