### PR TITLE
fix(repo-resolver): address Gemini PR #35 review feedback

### DIFF
--- a/000-docs/026-AT-DSGN-repo-resolver-design.md
+++ b/000-docs/026-AT-DSGN-repo-resolver-design.md
@@ -33,33 +33,38 @@ Out of scope:
 
 ### `RepoContext`
 
+Defined as a Zod schema with the TypeScript type derived via `z.infer<>`, matching the project convention from `packages/schema` (every domain type is Zod-defined so schema and TS types cannot drift, and runtime validation is available if the type ever crosses a boundary).
+
 ```ts
-export interface RepoContext {
-  repoRoot: string; // absolute path to the .git parent
-  repoName: string; // basename(repoRoot), lowercased
-  remoteUrl: string | null; // origin remote URL, or null if unset
-  branch: string | null; // current branch, or null when detached
-  commitSha: string; // HEAD commit SHA (40-char hex)
-  isMonorepo: boolean; // true if a workspace manifest was detected
-  workspaceRoot: string | null; // monorepo root (may equal repoRoot)
-  workspacePackage: string | null; // package name containing cwd, or null
-}
+export const RepoContext = z.object({
+  repoRoot: z.string().min(1), // absolute path to the .git parent
+  repoName: z.string().min(1), // basename(repoRoot), lowercased
+  remoteUrl: z.string().nullable(), // origin remote URL, or null if unset
+  branch: z.string().nullable(), // current branch, or null when detached
+  commitSha: z.string().regex(/^[0-9a-f]{40}$/), // HEAD commit SHA
+  isMonorepo: z.boolean(),
+  workspaceRoot: z.string().nullable(), // monorepo root (may equal repoRoot)
+  workspacePackage: z.string().nullable(), // package name containing cwd
+});
+export type RepoContext = z.infer<typeof RepoContext>;
 ```
 
-Fields that can legitimately be absent are typed as nullable. Consumers must handle `null` without crashing. `commitSha` is non-nullable because a resolved working tree always has a HEAD — the no-commits edge case is treated as an unresolvable repo and surfaces as an error, not a partial context.
+Fields that can legitimately be absent are nullable. Consumers must handle `null` without crashing. `commitSha` is non-nullable because a resolved working tree always has a HEAD — the no-commits edge case is treated as an unresolvable repo and surfaces as an error, not a partial context.
 
 ### `ResolverError`
 
 ```ts
-export type ResolverError =
-  | { kind: 'NotAGitRepo'; cwd: string }
-  | { kind: 'BareRepo'; repoRoot: string }
-  | { kind: 'NoCommits'; repoRoot: string }
-  | { kind: 'GitUnavailable'; cause: string }
-  | { kind: 'Io'; path: string; cause: string };
+export const ResolverError = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('NotAGitRepo'), cwd: z.string() }),
+  z.object({ kind: z.literal('BareRepo'), repoRoot: z.string() }),
+  z.object({ kind: z.literal('NoCommits'), repoRoot: z.string() }),
+  z.object({ kind: z.literal('GitUnavailable'), cause: z.string() }),
+  z.object({ kind: z.literal('Io'), path: z.string(), cause: z.string() }),
+]);
+export type ResolverError = z.infer<typeof ResolverError>;
 ```
 
-All errors are typed discriminated unions. The resolver returns `Result<RepoContext, ResolverError>` using the existing `Result<T, E>` type in `packages/common`. No exceptions cross the package boundary.
+All errors are discriminated by `kind`. The resolver returns `Result<RepoContext, ResolverError>` using the existing `Result<T, E>` type in `packages/common`. No exceptions cross the package boundary.
 
 ## Resolution Procedure
 

--- a/packages/repo-resolver/package.json
+++ b/packages/repo-resolver/package.json
@@ -19,6 +19,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@qmd-team-intent-kb/common": "workspace:*"
+    "@qmd-team-intent-kb/common": "workspace:*",
+    "zod": "^3.23.0"
   }
 }

--- a/packages/repo-resolver/src/resolver.ts
+++ b/packages/repo-resolver/src/resolver.ts
@@ -64,7 +64,15 @@ export async function resolveRepoContext(cwd: string): Promise<Result<RepoContex
       cause: `Unexpected git rev-parse output: ${probe.stdout}`,
     });
   }
-  const [rawRepoRoot, isBareStr, commitSha] = lines as [string, string, string];
+  const rawRepoRoot = lines[0];
+  const isBareStr = lines[1];
+  const commitSha = lines[2];
+  if (rawRepoRoot === undefined || isBareStr === undefined || commitSha === undefined) {
+    return err<ResolverError>({
+      kind: 'GitUnavailable',
+      cause: `Unexpected git rev-parse output: ${probe.stdout}`,
+    });
+  }
 
   if (isBareStr.trim() === 'true') {
     return err<ResolverError>({ kind: 'BareRepo', repoRoot: rawRepoRoot });

--- a/packages/repo-resolver/src/types.ts
+++ b/packages/repo-resolver/src/types.ts
@@ -1,37 +1,41 @@
+import { z } from 'zod';
+
 /**
  * Resolved context for a git working tree.
  *
  * See 000-docs/026-AT-DSGN-repo-resolver-design.md for field semantics.
- * Monorepo fields (`isMonorepo`, `workspaceRoot`, `workspacePackage`) are
- * populated by the monorepo detection pass (mbd.3); the core resolver
- * leaves them at their "not a monorepo" defaults.
+ * Defined as a Zod schema with the TypeScript type derived via `z.infer<>`,
+ * matching the project convention from `packages/schema`.
  */
-export interface RepoContext {
+export const RepoContext = z.object({
   /** Absolute path to the repo working tree root. */
-  repoRoot: string;
+  repoRoot: z.string().min(1),
   /** Lowercased basename of `repoRoot`. */
-  repoName: string;
+  repoName: z.string().min(1),
   /** Origin remote URL, or null when no origin is configured. */
-  remoteUrl: string | null;
+  remoteUrl: z.string().nullable(),
   /** Current branch, or null when HEAD is detached. */
-  branch: string | null;
+  branch: z.string().nullable(),
   /** HEAD commit SHA (40-char hex). */
-  commitSha: string;
+  commitSha: z.string().regex(/^[0-9a-f]{40}$/),
   /** True when a workspace manifest was detected. */
-  isMonorepo: boolean;
+  isMonorepo: z.boolean(),
   /** Monorepo root (may equal `repoRoot`), or null when not a monorepo. */
-  workspaceRoot: string | null;
+  workspaceRoot: z.string().nullable(),
   /** Workspace package `name` containing `cwd`, or null. */
-  workspacePackage: string | null;
-}
+  workspacePackage: z.string().nullable(),
+});
+export type RepoContext = z.infer<typeof RepoContext>;
 
 /**
  * Typed failure modes. The resolver never throws — every failure path
  * returns `Err<ResolverError>`.
  */
-export type ResolverError =
-  | { kind: 'NotAGitRepo'; cwd: string }
-  | { kind: 'BareRepo'; repoRoot: string }
-  | { kind: 'NoCommits'; repoRoot: string }
-  | { kind: 'GitUnavailable'; cause: string }
-  | { kind: 'Io'; path: string; cause: string };
+export const ResolverError = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('NotAGitRepo'), cwd: z.string() }),
+  z.object({ kind: z.literal('BareRepo'), repoRoot: z.string() }),
+  z.object({ kind: z.literal('NoCommits'), repoRoot: z.string() }),
+  z.object({ kind: z.literal('GitUnavailable'), cause: z.string() }),
+  z.object({ kind: z.literal('Io'), path: z.string(), cause: z.string() }),
+]);
+export type ResolverError = z.infer<typeof ResolverError>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       '@qmd-team-intent-kb/common':
         specifier: workspace:*
         version: link:../common
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
 
   packages/schema:
     dependencies:


### PR DESCRIPTION
Fix-forward for two Gemini findings on PR #35 (merged through unaddressed):

1. **types.ts** — Convert `RepoContext` and `ResolverError` to Zod schemas with TS types derived via `z.infer<>`. Matches the project convention from `packages/schema`. `ResolverError` uses `z.discriminatedUnion('kind', [...])`.
2. **resolver.ts:72** — Replace tuple-cast with explicit per-index access + undefined guard.
3. **000-docs/026** — Update ADR snippets to show Zod form so the doc matches reality.

## Tradeoffs

Zod adds runtime validation that's not actively useful today (`RepoContext` is built internally, consumed in-process). The reason to do it is convention consistency: every other domain type is Zod, and the platform makes promises elsewhere (schema migrations, audit trails, future API surfaces) that assume it. Runtime cost is negligible.

## Test plan

- [x] Full suite 1008/1008 pass under `pnpm validate`
- [x] No behavior change — all existing fixture tests untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)