### PR TITLE
feat(edge-daemon): CLI subcommands (start/stop/status/run-once)

### DIFF
--- a/apps/edge-daemon/src/__tests__/cli.test.ts
+++ b/apps/edge-daemon/src/__tests__/cli.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { writeFileSync, existsSync, unlinkSync } from 'node:fs';
+import { createTestDatabase } from '@qmd-team-intent-kb/store';
+import type Database from 'better-sqlite3';
+import { dispatch } from '../cli.js';
+import type { CliDeps } from '../cli.js';
+import { makeDeps, makeConfig, RecordingLogger } from './fixtures.js';
+
+function tmpPidPath(): string {
+  return join(tmpdir(), `cli-test-${randomUUID()}.pid`);
+}
+
+describe('dispatch', () => {
+  let db: Database.Database;
+  let deps: CliDeps;
+  let pidPath: string;
+  let logger: RecordingLogger;
+
+  const stderrWrites: string[] = [];
+  const stdoutWrites: string[] = [];
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    pidPath = tmpPidPath();
+    logger = new RecordingLogger();
+
+    deps = {
+      config: makeConfig({ pidFilePath: pidPath }),
+      daemonDeps: makeDeps(db),
+      logger,
+    };
+
+    stderrWrites.length = 0;
+    stdoutWrites.length = 0;
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderrWrites.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdoutWrites.push(String(chunk));
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    try {
+      if (existsSync(pidPath)) unlinkSync(pidPath);
+    } catch {
+      /* ignore */
+    }
+  });
+
+  describe('unknown subcommand', () => {
+    it('returns exit code 1', async () => {
+      const code = await dispatch(['bogus'], deps);
+      expect(code).toBe(1);
+    });
+
+    it('writes usage to stderr', async () => {
+      await dispatch(['bogus'], deps);
+      const combined = stderrWrites.join('');
+      expect(combined).toContain("unknown subcommand 'bogus'");
+      expect(combined).toContain('Usage:');
+    });
+  });
+
+  describe('start (default)', () => {
+    it('returns exit code 0 with no args (defaults to start)', async () => {
+      // start() with a valid config will succeed, then daemon loops — we just verify
+      // the code path doesn't blow up synchronously. We stop immediately via the
+      // returned daemon reference which is opaque here, so we rely on the lock file.
+      const pidPathLocal = tmpPidPath();
+      const localDeps: CliDeps = {
+        ...deps,
+        config: makeConfig({ pidFilePath: pidPathLocal, pollIntervalMs: 9_999_999 }),
+      };
+
+      // dispatch(['start']) calls daemon.start() which is synchronous and sets up
+      // a timer. The function returns 0. We confirm the lock was created then clean up.
+      const resultPromise = dispatch([], localDeps);
+      // start() is synchronous before returning 0 — the lock file exists immediately
+      expect(existsSync(pidPathLocal)).toBe(true);
+      const code = await resultPromise;
+      expect(code).toBe(0);
+
+      // Cleanup: unlock the PID so afterEach doesn't fail
+      try {
+        unlinkSync(pidPathLocal);
+      } catch {
+        /* ignore */
+      }
+    });
+
+    it('returns exit code 1 when lock is already held', async () => {
+      writeFileSync(pidPath, String(process.pid), 'utf8');
+      const code = await dispatch(['start'], deps);
+      expect(code).toBe(1);
+    });
+  });
+
+  describe('stop', () => {
+    it('returns 1 when no lock file exists', async () => {
+      const code = await dispatch(['stop'], deps);
+      expect(code).toBe(1);
+      const combined = stderrWrites.join('');
+      expect(combined).toContain('no lock file found');
+    });
+
+    it('returns 0 and removes stale lock file when PID is not running', async () => {
+      writeFileSync(pidPath, '999999999', 'utf8');
+      const code = await dispatch(['stop'], deps);
+      expect(code).toBe(0);
+      expect(existsSync(pidPath)).toBe(false);
+      const combined = stderrWrites.join('');
+      expect(combined).toContain('stale lock file removed');
+    });
+
+    it('sends SIGTERM when process is running and returns 0', async () => {
+      writeFileSync(pidPath, String(process.pid), 'utf8');
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+      const code = await dispatch(['stop'], deps);
+      expect(code).toBe(0);
+      expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGTERM');
+
+      killSpy.mockRestore();
+    });
+  });
+
+  describe('status', () => {
+    it('returns 0 with stopped JSON when no lock file', async () => {
+      const code = await dispatch(['status'], deps);
+      expect(code).toBe(0);
+      const output = stdoutWrites.join('');
+      expect(JSON.parse(output.trim())).toEqual({ status: 'stopped' });
+    });
+
+    it('returns 0 with stopped + staleLockPid when lock file has dead PID', async () => {
+      writeFileSync(pidPath, '999999999', 'utf8');
+      const code = await dispatch(['status'], deps);
+      expect(code).toBe(0);
+      const output = stdoutWrites.join('');
+      const parsed = JSON.parse(output.trim()) as { status: string; staleLockPid: number };
+      expect(parsed.status).toBe('stopped');
+      expect(parsed.staleLockPid).toBe(999999999);
+    });
+
+    it('returns 0 with running + pid when daemon is live', async () => {
+      writeFileSync(pidPath, String(process.pid), 'utf8');
+      const code = await dispatch(['status'], deps);
+      expect(code).toBe(0);
+      const output = stdoutWrites.join('');
+      const parsed = JSON.parse(output.trim()) as { status: string; pid: number };
+      expect(parsed.status).toBe('running');
+      expect(parsed.pid).toBe(process.pid);
+    });
+  });
+
+  describe('run-once', () => {
+    it('returns 0 on successful cycle', async () => {
+      const code = await dispatch(['run-once'], deps);
+      expect(code).toBe(0);
+    });
+
+    it('does not create a lock file', async () => {
+      await dispatch(['run-once'], deps);
+      expect(existsSync(pidPath)).toBe(false);
+    });
+
+    it('cycle errors are caught internally; only uncaught exceptions return 1', async () => {
+      // runCycle catches per-step errors, so ingest failures still produce exit 0.
+      // A non-existent spoolDir causes ingestFromSpool to error internally, not throw.
+      const localDeps: CliDeps = {
+        ...deps,
+        config: makeConfig({ pidFilePath: pidPath, spoolDir: '/nonexistent-spool-path' }),
+      };
+      const code = await dispatch(['run-once'], localDeps);
+      expect(code).toBe(0);
+    });
+  });
+});

--- a/apps/edge-daemon/src/cli.ts
+++ b/apps/edge-daemon/src/cli.ts
@@ -1,0 +1,126 @@
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
+import type { DaemonConfig, DaemonDependencies, DaemonLogger } from './types.js';
+import { isLocked } from './lock.js';
+import { EdgeDaemon } from './daemon.js';
+import { runCycle } from './cycle.js';
+
+export type Subcommand = 'start' | 'stop' | 'status' | 'run-once';
+
+export interface CliDeps {
+  config: DaemonConfig;
+  daemonDeps: DaemonDependencies;
+  logger: DaemonLogger;
+}
+
+const USAGE = `Usage: edge-daemon <subcommand>
+
+Subcommands:
+  start     Start the daemon (default if no subcommand given)
+  stop      Send SIGTERM to the running daemon and exit
+  status    Print daemon status as JSON and exit
+  run-once  Run exactly one cycle and exit
+`;
+
+function readPid(pidFilePath: string): number | null {
+  if (!existsSync(pidFilePath)) return null;
+  try {
+    const content = readFileSync(pidFilePath, 'utf8').trim();
+    const pid = parseInt(content, 10);
+    return Number.isNaN(pid) ? null : pid;
+  } catch {
+    return null;
+  }
+}
+
+async function cmdStart(deps: CliDeps): Promise<number> {
+  const daemon = new EdgeDaemon(deps.config, deps.daemonDeps, deps.logger);
+  try {
+    daemon.start();
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    deps.logger.error(msg);
+    return 1;
+  }
+  return 0;
+}
+
+async function cmdStop(deps: CliDeps): Promise<number> {
+  const pid = readPid(deps.config.pidFilePath);
+
+  if (pid === null) {
+    process.stderr.write('edge-daemon: no lock file found — daemon is not running\n');
+    return 1;
+  }
+
+  const running = isLocked(deps.config.pidFilePath);
+
+  if (!running) {
+    // Stale lock: the PID is recorded but the process is gone. Clean up and treat as stopped.
+    unlinkSync(deps.config.pidFilePath);
+    process.stderr.write('edge-daemon: stale lock file removed — daemon was not running\n');
+    return 0;
+  }
+
+  try {
+    process.kill(pid, 'SIGTERM');
+    return 0;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    process.stderr.write(`edge-daemon: failed to send SIGTERM to PID ${pid}: ${msg}\n`);
+    return 1;
+  }
+}
+
+async function cmdStatus(deps: CliDeps): Promise<number> {
+  const pid = readPid(deps.config.pidFilePath);
+
+  if (pid === null) {
+    process.stdout.write(JSON.stringify({ status: 'stopped' }) + '\n');
+    return 0;
+  }
+
+  const running = isLocked(deps.config.pidFilePath);
+  if (!running) {
+    process.stdout.write(JSON.stringify({ status: 'stopped', staleLockPid: pid }) + '\n');
+    return 0;
+  }
+
+  process.stdout.write(JSON.stringify({ status: 'running', pid }) + '\n');
+  return 0;
+}
+
+async function cmdRunOnce(deps: CliDeps): Promise<number> {
+  try {
+    await runCycle(deps.config, deps.daemonDeps, deps.logger);
+    return 0;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    deps.logger.error(`run-once failed: ${msg}`);
+    return 1;
+  }
+}
+
+/**
+ * Dispatch a CLI subcommand. Returns an exit code.
+ *
+ * Default subcommand (no argument) is `start` — daemon invocations are almost
+ * always meant to start the long-running loop, so requiring an explicit flag
+ * would add unnecessary friction for the primary use case.
+ */
+export async function dispatch(argv: string[], deps: CliDeps): Promise<number> {
+  const subcommand = argv[0] ?? 'start';
+
+  switch (subcommand) {
+    case 'start':
+      return cmdStart(deps);
+    case 'stop':
+      return cmdStop(deps);
+    case 'status':
+      return cmdStatus(deps);
+    case 'run-once':
+      return cmdRunOnce(deps);
+    default:
+      process.stderr.write(`edge-daemon: unknown subcommand '${subcommand}'\n\n${USAGE}`);
+      return 1;
+  }
+}

--- a/apps/edge-daemon/src/main.ts
+++ b/apps/edge-daemon/src/main.ts
@@ -9,13 +9,15 @@ import {
 import { resolveTeamKbPath } from '@qmd-team-intent-kb/common';
 import { QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
 import { loadDaemonConfig } from './config.js';
-import { EdgeDaemon } from './daemon.js';
 import { ConsoleDaemonLogger } from './health.js';
+import { dispatch } from './cli.js';
 
 /**
  * CLI entry point for the edge daemon.
  *
- * Usage: DAEMON_TENANT_ID=my-team tsx src/main.ts
+ * Usage: DAEMON_TENANT_ID=my-team tsx src/main.ts [start|stop|status|run-once]
+ *
+ * Default subcommand is `start` when none is provided.
  */
 async function main(): Promise<void> {
   const logger = new ConsoleDaemonLogger();
@@ -29,11 +31,10 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // Open (or create) the canonical SQLite store
   const dbPath = resolveTeamKbPath('teamkb.db');
   const db = createDatabase({ path: dbPath });
 
-  const deps = {
+  const daemonDeps = {
     candidateRepo: new CandidateRepository(db),
     memoryRepo: new MemoryRepository(db),
     policyRepo: new PolicyRepository(db),
@@ -42,15 +43,8 @@ async function main(): Promise<void> {
     qmdAdapter: new QmdAdapter({ tenantId: config.tenantId }),
   };
 
-  const daemon = new EdgeDaemon(config, deps, logger);
-
-  try {
-    daemon.start();
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    logger.error(msg);
-    process.exit(1);
-  }
+  const exitCode = await dispatch(process.argv.slice(2), { config, daemonDeps, logger });
+  process.exit(exitCode);
 }
 
 void main();


### PR DESCRIPTION
## Summary

- Adds `apps/edge-daemon/src/cli.ts` with exported `dispatch(argv, deps)` function — a plain `process.argv.slice(2)` switch with no extra dependencies
- Implements four subcommands: `start` (long-running daemon loop), `stop` (SIGTERM via lock file PID), `status` (JSON to stdout), `run-once` (single cycle, no lock acquired)
- Refactors `apps/edge-daemon/src/main.ts` to delegate to `dispatch` and `process.exit` on the returned code
- Adds 13 new vitest unit tests in `apps/edge-daemon/src/__tests__/cli.test.ts` covering all four subcommands plus edge cases
- Full validation gate: 1071/1071 tests passing, format/lint/typecheck all clean

## Key decisions

- **Default subcommand is `start`** (no arg given = start). Daemon invocations are almost always meant to start the long-running loop; requiring an explicit flag would add unnecessary friction for the primary use case.
- **Stale lock on `stop`**: removes the stale lock file and exits **0**. The process is effectively already stopped, so treating it as an error would break scripted stop-then-start sequences.
- **`status` when not running**: exits **0** with `{"status":"stopped"}`. Non-running is not an error state; callers can branch on the JSON `status` field.
- **`run-once` does not acquire the lock**: it's a one-shot cycle, not a long-running daemon. Acquiring the lock would block concurrent `start` usage.

## Test plan

- [ ] `pnpm --filter @qmd-team-intent-kb/edge-daemon exec tsx src/main.ts status` — prints `{"status":"stopped"}`, exits 0
- [ ] `pnpm --filter @qmd-team-intent-kb/edge-daemon exec tsx src/main.ts run-once` — runs one cycle, exits 0
- [ ] `pnpm --filter @qmd-team-intent-kb/edge-daemon exec tsx src/main.ts bogus` — prints usage to stderr, exits 1
- [ ] `pnpm --filter @qmd-team-intent-kb/edge-daemon test` — 84/84 tests pass
- [ ] `pnpm validate` — 1071/1071 tests pass, format/lint/typecheck clean

Closes bead qmd-team-intent-kb-1x6.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)