### PR TITLE
feat(claude-runtime): integrate repo-resolver for candidate enrichment

### DIFF
--- a/packages/claude-runtime/package.json
+++ b/packages/claude-runtime/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@qmd-team-intent-kb/schema": "workspace:*",
-    "@qmd-team-intent-kb/common": "workspace:*"
+    "@qmd-team-intent-kb/common": "workspace:*",
+    "@qmd-team-intent-kb/repo-resolver": "workspace:*"
   }
 }

--- a/packages/claude-runtime/src/__tests__/candidate-builder.test.ts
+++ b/packages/claude-runtime/src/__tests__/candidate-builder.test.ts
@@ -110,4 +110,43 @@ describe('buildCandidate', () => {
       expect(result.value.candidate.trustLevel).toBe('high');
     }
   });
+
+  it('uses repoName from enriched GitContext as projectContext when event has none', () => {
+    const result = buildCandidate(
+      makeEvent({ projectContext: undefined }),
+      makeGitContext({ repoName: 'my-repo' }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.candidate.metadata.projectContext).toBe('my-repo');
+    }
+  });
+
+  it('event projectContext takes precedence over enriched repoName', () => {
+    const result = buildCandidate(
+      makeEvent({ projectContext: 'explicit-project' }),
+      makeGitContext({ repoName: 'my-repo' }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.candidate.metadata.projectContext).toBe('explicit-project');
+    }
+  });
+
+  it('enriched commitSha is preserved on GitContext', () => {
+    const commitSha = 'a'.repeat(40);
+    const ctx = makeGitContext({ commitSha });
+    expect(ctx.commitSha).toBe(commitSha);
+  });
+
+  it('projectContext remains undefined when event has none and repoName absent', () => {
+    const result = buildCandidate(
+      makeEvent({ projectContext: undefined }),
+      makeGitContext({ repoName: undefined }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.candidate.metadata.projectContext).toBeUndefined();
+    }
+  });
 });

--- a/packages/claude-runtime/src/__tests__/context-provider.test.ts
+++ b/packages/claude-runtime/src/__tests__/context-provider.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import type { Result } from '@qmd-team-intent-kb/common';
+import type { RepoContext, ResolverError } from '@qmd-team-intent-kb/repo-resolver';
+
+vi.mock('@qmd-team-intent-kb/repo-resolver', async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...(mod as object),
+    resolveRepoContext: vi.fn(),
+  };
+});
+
+vi.mock('../capture/git-context.js', () => ({
+  resolveGitContext: vi.fn(),
+}));
+
+import { resolveRepoContext } from '@qmd-team-intent-kb/repo-resolver';
+import { resolveGitContext } from '../capture/git-context.js';
+import { DefaultContextProvider } from '../capture/context-provider.js';
+
+const mockResolveRepoContext = resolveRepoContext as Mock;
+const mockResolveGitContext = resolveGitContext as Mock;
+
+const makeRepoContext = (overrides?: Partial<RepoContext>): RepoContext => ({
+  repoRoot: '/home/user/projects/my-repo',
+  repoName: 'my-repo',
+  remoteUrl: 'https://github.com/acme/my-repo.git',
+  branch: 'main',
+  commitSha: 'a'.repeat(40),
+  isMonorepo: false,
+  workspaceRoot: null,
+  workspacePackage: null,
+  ...overrides,
+});
+
+const okResult = (ctx: RepoContext): Result<RepoContext, ResolverError> => ({
+  ok: true,
+  value: ctx,
+});
+
+const errResult = (error: ResolverError): Result<RepoContext, ResolverError> => ({
+  ok: false,
+  error,
+});
+
+describe('DefaultContextProvider', () => {
+  let provider: DefaultContextProvider;
+
+  beforeEach(() => {
+    provider = new DefaultContextProvider();
+    mockResolveRepoContext.mockReset();
+    mockResolveGitContext.mockReset();
+  });
+
+  it('returns enriched GitContext from repo-resolver on success', async () => {
+    const ctx = makeRepoContext();
+    mockResolveRepoContext.mockResolvedValue(okResult(ctx));
+
+    const result = await provider.resolveGitContext('/some/cwd');
+
+    expect(result).not.toBeNull();
+    expect(result?.repoName).toBe('my-repo');
+    expect(result?.commitSha).toBe('a'.repeat(40));
+    expect(result?.branch).toBe('main');
+    expect(result?.repoUrl).toBe('https://github.com/acme/my-repo.git');
+  });
+
+  it('derives tenantId from repo-resolver context', async () => {
+    const ctx = makeRepoContext({ remoteUrl: 'https://github.com/acme/my-repo.git' });
+    mockResolveRepoContext.mockResolvedValue(okResult(ctx));
+
+    const result = await provider.resolveGitContext('/some/cwd');
+
+    expect(result?.tenantId).toBe('github.com/acme/my-repo');
+  });
+
+  it('falls back to legacy resolveGitContext when resolver returns NotAGitRepo', async () => {
+    mockResolveRepoContext.mockResolvedValue(errResult({ kind: 'NotAGitRepo', cwd: '/some/cwd' }));
+    mockResolveGitContext.mockResolvedValue({
+      repoUrl: 'https://github.com/fallback/repo.git',
+      branch: 'develop',
+      userName: 'dev',
+      tenantId: 'fallback-repo',
+    });
+
+    const result = await provider.resolveGitContext('/some/cwd');
+
+    expect(mockResolveGitContext).toHaveBeenCalledWith('/some/cwd');
+    expect(result?.tenantId).toBe('fallback-repo');
+    expect(result?.branch).toBe('develop');
+  });
+
+  it('falls back when resolver returns GitUnavailable', async () => {
+    mockResolveRepoContext.mockResolvedValue(
+      errResult({ kind: 'GitUnavailable', cause: 'git not found' }),
+    );
+    mockResolveGitContext.mockResolvedValue(null);
+
+    const result = await provider.resolveGitContext('/some/cwd');
+
+    expect(mockResolveGitContext).toHaveBeenCalledWith('/some/cwd');
+    expect(result).toBeNull();
+  });
+
+  it('falls back when resolver returns NoCommits', async () => {
+    mockResolveRepoContext.mockResolvedValue(
+      errResult({ kind: 'NoCommits', repoRoot: '/some/cwd' }),
+    );
+    mockResolveGitContext.mockResolvedValue(null);
+
+    const result = await provider.resolveGitContext('/some/cwd');
+
+    expect(mockResolveGitContext).toHaveBeenCalledTimes(1);
+    expect(result).toBeNull();
+  });
+
+  it('enriched result has no repoName/commitSha on fallback path', async () => {
+    mockResolveRepoContext.mockResolvedValue(errResult({ kind: 'NotAGitRepo', cwd: '/some/cwd' }));
+    mockResolveGitContext.mockResolvedValue({
+      repoUrl: 'https://github.com/org/repo.git',
+      branch: 'main',
+      userName: 'user',
+      tenantId: 'org-repo',
+    });
+
+    const result = await provider.resolveGitContext('/some/cwd');
+
+    expect(result?.repoName).toBeUndefined();
+    expect(result?.commitSha).toBeUndefined();
+  });
+
+  it('handles detached HEAD (null branch) from resolver', async () => {
+    const ctx = makeRepoContext({ branch: null });
+    mockResolveRepoContext.mockResolvedValue(okResult(ctx));
+
+    const result = await provider.resolveGitContext('/some/cwd');
+
+    expect(result?.branch).toBe('unknown');
+  });
+
+  it('handles no remote URL (null remoteUrl) from resolver', async () => {
+    const ctx = makeRepoContext({ remoteUrl: null });
+    mockResolveRepoContext.mockResolvedValue(okResult(ctx));
+
+    const result = await provider.resolveGitContext('/some/cwd');
+
+    expect(result?.repoUrl).toBe('');
+  });
+
+  it('uses process.cwd() when no cwd argument given', async () => {
+    const ctx = makeRepoContext();
+    mockResolveRepoContext.mockResolvedValue(okResult(ctx));
+
+    await provider.resolveGitContext();
+
+    expect(mockResolveRepoContext).toHaveBeenCalledWith(process.cwd());
+  });
+});

--- a/packages/claude-runtime/src/capture/candidate-builder.ts
+++ b/packages/claude-runtime/src/capture/candidate-builder.ts
@@ -35,7 +35,7 @@ export function buildCandidate(
     metadata: {
       filePaths: event.filePaths ?? [],
       language: event.language,
-      projectContext: event.projectContext,
+      projectContext: event.projectContext ?? gitContext?.repoName,
       sessionId: event.sessionId,
       repoUrl: gitContext?.repoUrl,
       branch: gitContext?.branch,

--- a/packages/claude-runtime/src/capture/context-provider.ts
+++ b/packages/claude-runtime/src/capture/context-provider.ts
@@ -1,9 +1,26 @@
+import { resolveRepoContext, deriveTenantId } from '@qmd-team-intent-kb/repo-resolver';
 import type { RepoContextProvider, GitContext } from '../types.js';
 import { resolveGitContext } from './git-context.js';
 
-/** Default context provider that uses local git resolution */
+/** Default context provider that uses repo-resolver with fallback to local git resolution */
 export class DefaultContextProvider implements RepoContextProvider {
   async resolveGitContext(cwd?: string): Promise<GitContext | null> {
+    const dir = cwd ?? process.cwd();
+    const result = await resolveRepoContext(dir);
+
+    if (result.ok) {
+      const ctx = result.value;
+      const tenantId = deriveTenantId(ctx);
+      return {
+        repoUrl: ctx.remoteUrl ?? '',
+        branch: ctx.branch ?? 'unknown',
+        userName: 'unknown',
+        tenantId,
+        repoName: ctx.repoName,
+        commitSha: ctx.commitSha,
+      };
+    }
+
     return resolveGitContext(cwd);
   }
 }

--- a/packages/claude-runtime/src/types.ts
+++ b/packages/claude-runtime/src/types.ts
@@ -19,6 +19,10 @@ export interface GitContext {
   branch: string;
   userName: string;
   tenantId: string;
+  /** Lowercased repo basename, populated when resolved via repo-resolver */
+  repoName?: string;
+  /** HEAD commit SHA (40-char hex), populated when resolved via repo-resolver */
+  commitSha?: string;
 }
 
 /** A named secret detection pattern */

--- a/packages/claude-runtime/tsconfig.json
+++ b/packages/claude-runtime/tsconfig.json
@@ -8,5 +8,5 @@
     "declarationMap": true
   },
   "include": ["src"],
-  "references": [{ "path": "../schema" }, { "path": "../common" }]
+  "references": [{ "path": "../schema" }, { "path": "../common" }, { "path": "../repo-resolver" }]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       '@qmd-team-intent-kb/common':
         specifier: workspace:*
         version: link:../common
+      '@qmd-team-intent-kb/repo-resolver':
+        specifier: workspace:*
+        version: link:../repo-resolver
       '@qmd-team-intent-kb/schema':
         specifier: workspace:*
         version: link:../schema


### PR DESCRIPTION
## Summary

- Wires `resolveRepoContext()` from `@qmd-team-intent-kb/repo-resolver` into `DefaultContextProvider`, replacing the stub pass-through
- Falls back transparently to legacy `resolveGitContext()` on any resolver error (NotAGitRepo, GitUnavailable, NoCommits, BareRepo, Io)
- Enriches `GitContext` with `repoName` and `commitSha` from the resolver; `projectContext` in the candidate now defaults to `repoName` when the capture event has no explicit project context
- `tenantId` is now derived via `deriveTenantId(RepoContext)` (resolver's precedence chain: env var → config file → normalized remote URL → repo basename)

Closes bead qmd-team-intent-kb-mbd.6

## Test plan

- [ ] `pnpm --filter @qmd-team-intent-kb/claude-runtime test` → 15 files, 96 tests pass
- [ ] `pnpm --filter @qmd-team-intent-kb/repo-resolver test` → 4 files, 58 tests pass (no regression)
- [ ] `pnpm validate` → format, lint, typecheck all green; test failures are pre-existing `better-sqlite3` native binding issues unrelated to this change (36 failed baseline → same 36 failed with this PR)
- [ ] New `context-provider.test.ts`: enrichment populates `repoName`/`commitSha`/`tenantId`/`branch`/`repoUrl`; fallback fires on all error kinds; detached HEAD and no-remote edge cases covered
- [ ] New `candidate-builder.test.ts` cases: `repoName` → `projectContext` when event has none; event `projectContext` takes precedence; fallback to undefined when both absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)