### PR TITLE
feat(edge-daemon): pino structured logging

### DIFF
--- a/apps/edge-daemon/package.json
+++ b/apps/edge-daemon/package.json
@@ -27,9 +27,11 @@
     "@qmd-team-intent-kb/claude-runtime": "workspace:*",
     "@qmd-team-intent-kb/curator": "workspace:*",
     "@qmd-team-intent-kb/git-exporter": "workspace:*",
-    "@qmd-team-intent-kb/qmd-adapter": "workspace:*"
+    "@qmd-team-intent-kb/qmd-adapter": "workspace:*",
+    "pino": "^9.0.0"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.0"
+    "@types/better-sqlite3": "^7.6.0",
+    "pino-pretty": "^13.0.0"
   }
 }

--- a/apps/edge-daemon/src/__tests__/pino-logger.test.ts
+++ b/apps/edge-daemon/src/__tests__/pino-logger.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import pino from 'pino';
+import { PinoDaemonLogger } from '../pino-logger.js';
+
+function makeCapturingLogger(): { logger: PinoDaemonLogger; lines: () => unknown[] } {
+  const captured: string[] = [];
+
+  const pinoInstance = pino(
+    { level: 'trace' },
+    {
+      write(line: string) {
+        captured.push(line);
+      },
+    },
+  );
+
+  const logger = new PinoDaemonLogger(pinoInstance);
+  return {
+    logger,
+    lines: () => captured.map((l) => JSON.parse(l) as unknown),
+  };
+}
+
+describe('PinoDaemonLogger', () => {
+  it('emits a JSON line with time, level, and msg for info()', () => {
+    const { logger, lines } = makeCapturingLogger();
+    logger.info('hello world');
+    const [entry] = lines() as Array<{ time: number; level: number; msg: string }>;
+    expect(entry).toBeDefined();
+    expect(typeof entry!.time).toBe('number');
+    expect(entry!.level).toBe(30); // pino info level
+    expect(entry!.msg).toBe('hello world');
+  });
+
+  it('emits correct level codes for warn and error', () => {
+    const { logger, lines } = makeCapturingLogger();
+    logger.warn('be careful');
+    logger.error('something broke');
+    const entries = lines() as Array<{ level: number; msg: string }>;
+    expect(entries[0]!.level).toBe(40); // warn
+    expect(entries[1]!.level).toBe(50); // error
+  });
+
+  it('child() binds tenantId to every subsequent log line', () => {
+    const { logger, lines } = makeCapturingLogger();
+    const child = logger.child({ tenantId: 'team-alpha' });
+    child.info('scoped message');
+    const [entry] = lines() as Array<{ tenantId: string; msg: string }>;
+    expect(entry!.tenantId).toBe('team-alpha');
+    expect(entry!.msg).toBe('scoped message');
+  });
+
+  it('child() returns a PinoDaemonLogger instance', () => {
+    const { logger } = makeCapturingLogger();
+    const child = logger.child({ tenantId: 'team-beta' });
+    expect(child).toBeInstanceOf(PinoDaemonLogger);
+  });
+
+  it('parent logger lines do not include child bindings', () => {
+    const { logger, lines } = makeCapturingLogger();
+    const child = logger.child({ tenantId: 'scoped' });
+    logger.info('parent line');
+    child.info('child line');
+    const entries = lines() as Array<{ tenantId?: string; msg: string }>;
+    expect(entries[0]!.tenantId).toBeUndefined();
+    expect(entries[1]!.tenantId).toBe('scoped');
+  });
+});

--- a/apps/edge-daemon/src/index.ts
+++ b/apps/edge-daemon/src/index.ts
@@ -12,6 +12,7 @@ export type {
 export { loadDaemonConfig } from './config.js';
 export { acquireLock, releaseLock, isLocked } from './lock.js';
 export { ConsoleDaemonLogger, NullLogger } from './health.js';
+export { PinoDaemonLogger } from './pino-logger.js';
 export { runCycle } from './cycle.js';
 export { runStalenessSweep } from './staleness.js';
 export { EdgeDaemon } from './daemon.js';

--- a/apps/edge-daemon/src/main.ts
+++ b/apps/edge-daemon/src/main.ts
@@ -9,7 +9,7 @@ import {
 import { resolveTeamKbPath } from '@qmd-team-intent-kb/common';
 import { QmdAdapter } from '@qmd-team-intent-kb/qmd-adapter';
 import { loadDaemonConfig } from './config.js';
-import { ConsoleDaemonLogger } from './health.js';
+import { PinoDaemonLogger } from './pino-logger.js';
 import { dispatch } from './cli.js';
 
 /**
@@ -20,16 +20,18 @@ import { dispatch } from './cli.js';
  * Default subcommand is `start` when none is provided.
  */
 async function main(): Promise<void> {
-  const logger = new ConsoleDaemonLogger();
+  const rootLogger = new PinoDaemonLogger();
 
   let config;
   try {
     config = loadDaemonConfig();
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    logger.error(`Configuration error: ${msg}`);
+    rootLogger.error(`Configuration error: ${msg}`);
     process.exit(1);
   }
+
+  const logger = rootLogger.child({ tenantId: config.tenantId });
 
   const dbPath = resolveTeamKbPath('teamkb.db');
   const db = createDatabase({ path: dbPath });

--- a/apps/edge-daemon/src/pino-logger.ts
+++ b/apps/edge-daemon/src/pino-logger.ts
@@ -1,0 +1,47 @@
+import pino from 'pino';
+import type { DaemonLogger } from './types.js';
+
+function buildPino(): pino.Logger {
+  const pretty = process.env['DAEMON_LOG_PRETTY'] === '1';
+  if (pretty) {
+    return pino({
+      transport: {
+        target: 'pino-pretty',
+        options: { colorize: true },
+      },
+    });
+  }
+  return pino();
+}
+
+/**
+ * Pino-backed structured logger that satisfies DaemonLogger.
+ *
+ * JSON lines include `time`, `level`, `msg` by default. Bind a `tenantId`
+ * via `child({ tenantId })` so all log lines in a given tenant scope carry
+ * the field automatically.
+ */
+export class PinoDaemonLogger implements DaemonLogger {
+  private readonly logger: pino.Logger;
+
+  constructor(pinoInstance?: pino.Logger) {
+    this.logger = pinoInstance ?? buildPino();
+  }
+
+  /** Return a child logger with additional bound fields (e.g. `{ tenantId }`). */
+  child(bindings: Record<string, unknown>): PinoDaemonLogger {
+    return new PinoDaemonLogger(this.logger.child(bindings));
+  }
+
+  info(message: string): void {
+    this.logger.info(message);
+  }
+
+  warn(message: string): void {
+    this.logger.warn(message);
+  }
+
+  error(message: string): void {
+    this.logger.error(message);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,10 +101,16 @@ importers:
       '@qmd-team-intent-kb/store':
         specifier: workspace:*
         version: link:../../packages/store
+      pino:
+        specifier: ^9.0.0
+        version: 9.14.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.0
         version: 7.6.13
+      pino-pretty:
+        specifier: ^13.0.0
+        version: 13.1.3
 
   apps/git-exporter:
     dependencies:
@@ -825,6 +831,9 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
     engines: {node: '>=18'}
@@ -855,6 +864,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1004,6 +1016,9 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  fast-copy@4.0.3:
+    resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
+
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
 
@@ -1025,6 +1040,9 @@ packages:
 
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -1124,6 +1142,9 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+
   hono@4.12.12:
     resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
     engines: {node: '>=16.9.0'}
@@ -1189,6 +1210,10 @@ packages:
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -1360,14 +1385,21 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
   pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-pretty@13.1.3:
+    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
+    hasBin: true
 
   pino-std-serializers@7.1.0:
     resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
 
-  pino@10.3.1:
-    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
 
   pkce-challenge@5.0.1:
@@ -1564,6 +1596,10 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
+
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
@@ -1571,9 +1607,8 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  thread-stream@4.0.0:
-    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
-    engines: {node: '>=20'}
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -2294,6 +2329,8 @@ snapshots:
 
   chownr@1.1.4: {}
 
+  colorette@2.0.20: {}
+
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
@@ -2316,6 +2353,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  dateformat@4.6.3: {}
 
   debug@4.4.3:
     dependencies:
@@ -2510,6 +2549,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-copy@4.0.3: {}
+
   fast-decode-uri-component@1.0.1: {}
 
   fast-deep-equal@3.1.3: {}
@@ -2539,6 +2580,8 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
+  fast-safe-stringify@2.1.1: {}
+
   fast-uri@3.1.0: {}
 
   fastify@5.8.5:
@@ -2552,7 +2595,7 @@ snapshots:
       fast-json-stringify: 6.3.0
       find-my-way: 9.5.0
       light-my-request: 6.6.0
-      pino: 10.3.1
+      pino: 9.14.0
       process-warning: 5.0.0
       rfdc: 1.4.1
       secure-json-parse: 4.1.0
@@ -2657,6 +2700,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  help-me@5.0.0: {}
+
   hono@4.12.12: {}
 
   http-errors@2.0.1:
@@ -2702,6 +2747,8 @@ snapshots:
   isexe@2.0.0: {}
 
   jose@6.2.2: {}
+
+  joycon@3.1.1: {}
 
   json-buffer@3.0.1: {}
 
@@ -2838,25 +2885,45 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
   pino-abstract-transport@3.0.0:
     dependencies:
       split2: 4.2.0
 
+  pino-pretty@13.1.3:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 4.0.3
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pump: 3.0.4
+      secure-json-parse: 4.1.0
+      sonic-boom: 4.2.1
+      strip-json-comments: 5.0.3
+
   pino-std-serializers@7.1.0: {}
 
-  pino@10.3.1:
+  pino@9.14.0:
     dependencies:
       '@pinojs/redact': 0.4.0
       atomic-sleep: 1.0.0
       on-exit-leak-free: 2.1.2
-      pino-abstract-transport: 3.0.0
+      pino-abstract-transport: 2.0.0
       pino-std-serializers: 7.1.0
       process-warning: 5.0.0
       quick-format-unescaped: 4.0.4
       real-require: 0.2.0
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
-      thread-stream: 4.0.0
+      thread-stream: 3.1.0
 
   pkce-challenge@5.0.1: {}
 
@@ -3093,6 +3160,8 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
+  strip-json-comments@5.0.3: {}
+
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
@@ -3108,7 +3177,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  thread-stream@4.0.0:
+  thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
 


### PR DESCRIPTION
## Summary

- Adds `PinoDaemonLogger` class backed by pino for JSON-structured log output; each line includes `time`, `level`, and `msg`
- Exposes a `child({ tenantId })` method so tenant-scoped callers automatically get `tenantId` on every line without passing it per-call
- Sets `PinoDaemonLogger` as the production logger in `main.ts`; the tenant-child is created after config loads so all runtime lines carry `tenantId`
- `DAEMON_LOG_PRETTY=1` env var switches pino to pino-pretty transport for developer consoles
- `ConsoleDaemonLogger` and `NullLogger` remain unchanged; all existing test fixtures using `RecordingLogger` continue to pass without modification

## Test plan

- [ ] `pnpm vitest run apps/edge-daemon/src/__tests__/pino-logger.test.ts` — 5 new tests pass (timestamp/level/msg shape, warn/error level codes, child binding, child type, scope isolation)
- [ ] `pnpm vitest run apps/edge-daemon/src/__tests__/lock.test.ts` — pre-existing tests unaffected
- [ ] `pnpm prettier --check` passes on all modified files
- [ ] `pnpm eslint apps/edge-daemon/src/pino-logger.ts apps/edge-daemon/src/__tests__/pino-logger.test.ts` — no lint errors
- [ ] Pre-existing failures in daemon/cli/cycle/staleness/feedback tests are caused by unbuilt workspace packages (better-sqlite3 native binding issue noted in bead spec), not regressions from this PR

Closes bead qmd-team-intent-kb-1x6.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)