### PR TITLE
feat(edge-daemon): deployment artifacts (systemd/launchd/docker) + ops runbook

### DIFF
--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -58,35 +58,35 @@
 
 ## Chronological Listing
 
-| #   | Code    | File                        | Description                  |
-| --- | ------- | --------------------------- | ---------------------------- |
-| 000 | PP-PLAN | mega-blueprint              | Canonical project blueprint  |
-| 001 | AT-ARCH | repo-blueprint              | Repository structure         |
-| 002 | AT-ARCH | architecture-overview       | System architecture          |
-| 003 | AT-DSGN | system-thesis               | Design rationale             |
-| 004 | PP-RMAP | phase-plan                  | Implementation roadmap       |
-| 005 | TQ-TEST | testing-ci-strategy         | Testing and CI               |
-| 006 | TQ-SECU | security-governance         | Security and threats         |
-| 007 | AT-DSGN | data-model-draft            | Domain model                 |
-| 008 | OD-RELS | release-versioning-policy   | Release policy               |
-| 009 | DR-GUID | contribution-workflow       | Contributor guide            |
-| 010 | WA-WFLW | internal-claude-operations  | Claude workflows             |
-| 011 | PM-RISK | risk-register               | Risk tracking                |
-| 012 | AA-AACR | initial-aar                 | Phase 0 AAR                  |
-| 013 | AA-AACR | phase1-schema               | Phase 1 AAR                  |
-| 014 | AA-AACR | phase2-runtime              | Phase 2 AAR                  |
-| 015 | AA-AACR | phase3-adapter              | Phase 3 AAR                  |
-| 016 | OD-OPSM | branch-protection-checklist | Branch protection setup      |
-| 017 | AA-AACR | phase4-api                  | Phase 4 AAR                  |
-| 018 | AA-AACR | phase5-curator              | Phase 5 AAR                  |
-| 019 | AA-AACR | phase6-exporter             | Phase 6 AAR                  |
-| 020 | OD-RELS | v1-release-checklist        | v1 release checklist         |
-| 021 | AA-AACR | phase7-reporting            | Phase 7 AAR                  |
-| 022 | AA-AACR | phase8-security             | Phase 8 AAR                  |
-| 023 | AA-AACR | phase9-release-readiness    | Phase 9 AAR                  |
-| 024 | PP-CLOS | v1-scope-closeout           | v1 scope closeout            |
-| 025 | AA-AACR | v0.3.0-release-report       | v0.3.0 release report        |
-| 026 | AT-DSGN | repo-resolver-design        | repo-resolver package design |
+| #   | Code    | File                        | Description                    |
+| --- | ------- | --------------------------- | ------------------------------ |
+| 000 | PP-PLAN | mega-blueprint              | Canonical project blueprint    |
+| 001 | AT-ARCH | repo-blueprint              | Repository structure           |
+| 002 | AT-ARCH | architecture-overview       | System architecture            |
+| 003 | AT-DSGN | system-thesis               | Design rationale               |
+| 004 | PP-RMAP | phase-plan                  | Implementation roadmap         |
+| 005 | TQ-TEST | testing-ci-strategy         | Testing and CI                 |
+| 006 | TQ-SECU | security-governance         | Security and threats           |
+| 007 | AT-DSGN | data-model-draft            | Domain model                   |
+| 008 | OD-RELS | release-versioning-policy   | Release policy                 |
+| 009 | DR-GUID | contribution-workflow       | Contributor guide              |
+| 010 | WA-WFLW | internal-claude-operations  | Claude workflows               |
+| 011 | PM-RISK | risk-register               | Risk tracking                  |
+| 012 | AA-AACR | initial-aar                 | Phase 0 AAR                    |
+| 013 | AA-AACR | phase1-schema               | Phase 1 AAR                    |
+| 014 | AA-AACR | phase2-runtime              | Phase 2 AAR                    |
+| 015 | AA-AACR | phase3-adapter              | Phase 3 AAR                    |
+| 016 | OD-OPSM | branch-protection-checklist | Branch protection setup        |
+| 017 | AA-AACR | phase4-api                  | Phase 4 AAR                    |
+| 018 | AA-AACR | phase5-curator              | Phase 5 AAR                    |
+| 019 | AA-AACR | phase6-exporter             | Phase 6 AAR                    |
+| 020 | OD-RELS | v1-release-checklist        | v1 release checklist           |
+| 021 | AA-AACR | phase7-reporting            | Phase 7 AAR                    |
+| 022 | AA-AACR | phase8-security             | Phase 8 AAR                    |
+| 023 | AA-AACR | phase9-release-readiness    | Phase 9 AAR                    |
+| 024 | PP-CLOS | v1-scope-closeout           | v1 scope closeout              |
+| 025 | AA-AACR | v0.3.0-release-report       | v0.3.0 release report          |
+| 026 | AT-DSGN | repo-resolver-design        | repo-resolver package design   |
 | 027 | OD-OPSM | edge-daemon-runbook         | edge-daemon operations runbook |
 
 ## Next Available Sequence: 028

--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -41,6 +41,7 @@
 ### OD — Operations & Deployment (continued)
 
 - `016-OD-OPSM-branch-protection-checklist.md` — GitHub branch protection configuration checklist
+- `027-OD-OPSM-edge-daemon-runbook.md` — edge-daemon operations runbook (install, config, health check, recovery, upgrade, rollback)
 
 ### AA — After Action & Review
 
@@ -86,5 +87,6 @@
 | 024 | PP-CLOS | v1-scope-closeout           | v1 scope closeout            |
 | 025 | AA-AACR | v0.3.0-release-report       | v0.3.0 release report        |
 | 026 | AT-DSGN | repo-resolver-design        | repo-resolver package design |
+| 027 | OD-OPSM | edge-daemon-runbook         | edge-daemon operations runbook |
 
-## Next Available Sequence: 027
+## Next Available Sequence: 028

--- a/000-docs/027-OD-OPSM-edge-daemon-runbook.md
+++ b/000-docs/027-OD-OPSM-edge-daemon-runbook.md
@@ -1,0 +1,448 @@
+# 027-OD-OPSM — edge-daemon Operations Runbook
+
+**Category:** OD — Operations & Deployment
+**Type:** OPSM — Operations Manual
+**Status:** Active
+**Version:** 0.1.0
+**Component:** `apps/edge-daemon`
+
+---
+
+## Overview
+
+The edge-daemon is the local process that bridges Claude Code sessions to the
+team knowledge-base control plane.  It runs as a long-lived background service
+on every developer machine or CI host that participates in a tenant.
+
+Responsibilities:
+
+- Poll the spool directory for new memory candidates written by
+  `@qmd-team-intent-kb/claude-runtime`.
+- Run each candidate through the governance policy pipeline.
+- Promote approved candidates into the SQLite store.
+- Trigger incremental git-export to `kb-export/`.
+- Trigger qmd index updates so local search reflects new memories.
+- Deprecate memories that have not been accessed within the staleness window.
+
+The daemon is a single Node.js process.  It uses a PID lock file to prevent
+multiple concurrent instances.  All state is local to the machine; there is no
+peer-to-peer coordination between daemon instances.
+
+---
+
+## Install
+
+### Prerequisites
+
+- Node.js >= 20 (check with `node --version`)
+- The monorepo built: `pnpm install && pnpm build`
+  (or a Docker image — see the Docker section)
+- A dedicated system user `edge-daemon` (Linux only; see below)
+
+### Linux — systemd
+
+1. Create a dedicated user and data directory:
+
+   ```sh
+   sudo useradd --system --no-create-home --shell /usr/sbin/nologin edge-daemon
+   sudo mkdir -p /var/lib/edge-daemon/spool /var/lib/edge-daemon/kb-export
+   sudo chown -R edge-daemon:edge-daemon /var/lib/edge-daemon
+   ```
+
+2. Create the environment file at `/etc/edge-daemon/env` (mode `0640`,
+   owner `root:edge-daemon`).  This file must contain at least:
+
+   ```
+   DAEMON_TENANT_ID=<your-tenant>
+   ```
+
+   Add any other variables from the Configuration section as needed.
+
+3. Install and enable the unit:
+
+   ```sh
+   sudo cp apps/edge-daemon/deploy/edge-daemon.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now edge-daemon
+   ```
+
+4. Verify:
+
+   ```sh
+   systemctl status edge-daemon
+   journalctl -u edge-daemon -f
+   ```
+
+### macOS — launchd
+
+1. Edit `EnvironmentVariables` in the plist:
+
+   ```sh
+   nano apps/edge-daemon/deploy/com.intentsolutions.edge-daemon.plist
+   # Set DAEMON_TENANT_ID and adjust APP_DIR / ProgramArguments paths.
+   ```
+
+2. Create the log directory:
+
+   ```sh
+   mkdir -p /usr/local/var/log/edge-daemon
+   ```
+
+3. Load the agent:
+
+   ```sh
+   cp apps/edge-daemon/deploy/com.intentsolutions.edge-daemon.plist \
+      ~/Library/LaunchAgents/
+   launchctl load ~/Library/LaunchAgents/com.intentsolutions.edge-daemon.plist
+   ```
+
+4. Verify:
+
+   ```sh
+   launchctl list | grep edge-daemon
+   tail -f /usr/local/var/log/edge-daemon/stdout.log
+   ```
+
+### Docker
+
+Build the image from the repo root (the Dockerfile uses a monorepo context):
+
+```sh
+docker build \
+  -f apps/edge-daemon/deploy/Dockerfile \
+  -t edge-daemon:latest \
+  .
+```
+
+Run with the required environment variable mounted:
+
+```sh
+docker run -d \
+  --name edge-daemon \
+  --restart on-failure \
+  -e DAEMON_TENANT_ID=my-team \
+  -v /var/lib/edge-daemon:/var/lib/edge-daemon \
+  edge-daemon:latest
+```
+
+For Kubernetes, map `DAEMON_TENANT_ID` from a Secret and mount a PersistentVolume
+at `/var/lib/edge-daemon`.
+
+---
+
+## Configuration
+
+All configuration is via environment variables.  There are no CLI flags; the
+only optional positional argument to the daemon is the subcommand (`start`,
+`stop`, `status`, `run-once`), which defaults to `start`.
+
+Source: `apps/edge-daemon/src/config.ts`
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `DAEMON_TENANT_ID` | Yes | — | Tenant identifier. Used to scope memory retrieval and qmd index namespacing. |
+| `DAEMON_POLL_INTERVAL` | No | `10000` | Milliseconds between spool poll cycles. |
+| `DAEMON_MAX_CANDIDATES` | No | `100` | Maximum candidates processed per cycle. |
+| `DAEMON_MAX_SPOOL_SIZE` | No | `10485760` | Maximum spool file size in bytes (10 MB). Files larger than this are skipped. |
+| `DAEMON_ENABLE_EXPORT` | No | `true` | Enable incremental git-export after each cycle. |
+| `DAEMON_ENABLE_INDEX` | No | `true` | Enable qmd index update after each cycle. |
+| `DAEMON_ENABLE_STALENESS` | No | `true` | Enable automatic staleness sweep (deprecation of old memories). |
+| `DAEMON_STALE_DAYS` | No | `90` | Days after last access before a memory is auto-deprecated. |
+| `DAEMON_SPOOL_DIR` | No | `~/.qmd-team-intent-kb/spool` | Directory watched for incoming candidate files. |
+| `DAEMON_EXPORT_DIR` | No | `kb-export/` | Output directory for git-exporter Markdown files. |
+| `DAEMON_EXPORT_TARGET` | No | `kb-export-default` | Export target identifier passed to git-exporter. |
+| `DAEMON_SUPERSESSION_THRESHOLD` | No | `0.6` | Jaccard similarity threshold above which a new candidate supersedes an existing memory. |
+| `DAEMON_PID_FILE` | No | `~/.qmd-team-intent-kb/daemon.pid` | Path of the PID lock file. Must be writable by the daemon user. |
+
+`DAEMON_TENANT_ID` is the only required variable.  The daemon exits immediately
+with code 1 if it is absent.
+
+Boolean variables accept only the literal strings `true` or `false`.  Any other
+value falls back to the default.
+
+---
+
+## Health Check
+
+The edge-daemon does not expose an HTTP health endpoint; it is a single-process
+local daemon.  Use the PID lock file and `status` subcommand to determine whether
+it is running.
+
+### Quick status check
+
+```sh
+# Returns JSON: {"status":"running","pid":12345} or {"status":"stopped"}
+node apps/edge-daemon/dist/main.js status
+```
+
+### PID lock file inspection
+
+```sh
+# Default path (adjust to DAEMON_PID_FILE if overridden):
+PID_FILE="${HOME}/.qmd-team-intent-kb/daemon.pid"
+
+if [ -f "$PID_FILE" ]; then
+  PID=$(cat "$PID_FILE")
+  if kill -0 "$PID" 2>/dev/null; then
+    echo "daemon running (PID $PID)"
+  else
+    echo "stale lock file — daemon not running"
+  fi
+else
+  echo "no lock file — daemon not running"
+fi
+```
+
+### systemd health (Linux)
+
+```sh
+systemctl is-active edge-daemon   # prints "active" or "inactive"
+systemctl status edge-daemon      # shows last log lines and restart count
+```
+
+### launchd health (macOS)
+
+```sh
+# Exit code 0 = running, non-zero = not loaded or stopped
+launchctl list com.intentsolutions.edge-daemon
+```
+
+### Docker health
+
+```sh
+docker inspect --format='{{.State.Status}}' edge-daemon
+# Expected: "running"
+```
+
+---
+
+## Log Inspection
+
+### systemd (Linux)
+
+```sh
+# Follow live:
+journalctl -u edge-daemon -f
+
+# Last 100 lines:
+journalctl -u edge-daemon -n 100
+
+# Since a specific time:
+journalctl -u edge-daemon --since "2026-04-14 00:00:00"
+
+# Filter by priority (errors only):
+journalctl -u edge-daemon -p err
+```
+
+### launchd (macOS)
+
+```sh
+tail -f /usr/local/var/log/edge-daemon/stdout.log
+tail -f /usr/local/var/log/edge-daemon/stderr.log
+```
+
+### Docker
+
+```sh
+docker logs -f edge-daemon
+docker logs --tail 100 edge-daemon
+```
+
+### Log format
+
+The daemon uses `ConsoleDaemonLogger` (structured text, not JSON).  Each line
+is prefixed with the ISO-8601 timestamp and severity level:
+
+```
+2026-04-14T12:00:00.000Z [info]  edge-daemon: cycle complete (3 promoted, 0 rejected)
+2026-04-14T12:00:10.000Z [error] edge-daemon: policy pipeline error: ...
+```
+
+---
+
+## Common Failure Modes
+
+### Daemon fails to start: "DAEMON_TENANT_ID environment variable is required"
+
+The environment file was not loaded or is missing the required variable.
+
+- systemd: confirm `/etc/edge-daemon/env` exists and contains `DAEMON_TENANT_ID=`.
+  Check `systemctl status edge-daemon` for "EnvironmentFile" errors.
+- launchd: confirm the plist `EnvironmentVariables` dict has `DAEMON_TENANT_ID`.
+- Docker: confirm `-e DAEMON_TENANT_ID=...` is present in the run command or
+  that an env-file is mounted.
+
+### Daemon fails to start: "lock already held"
+
+Another instance is running, or a stale PID file exists from a previous crash.
+
+Run the stop subcommand which cleans up stale locks automatically:
+
+```sh
+node apps/edge-daemon/dist/main.js stop
+```
+
+If stop reports "daemon not running" but the daemon still fails to start, manually
+remove the stale lock file:
+
+```sh
+rm "${DAEMON_PID_FILE:-$HOME/.qmd-team-intent-kb/daemon.pid}"
+```
+
+### Daemon exits immediately after starting (exit code 1)
+
+Check the logs for a configuration or database error.  Common causes:
+
+- SQLite database path not writable by the daemon user.
+- `DAEMON_SPOOL_DIR` does not exist and cannot be created (permissions).
+- A dependency package (`better-sqlite3`, `qmd-adapter`) is missing from the
+  production install tree — ensure `pnpm install` completed cleanly.
+
+### Spool files not processed
+
+- Verify `DAEMON_SPOOL_DIR` points to the same directory that `claude-runtime`
+  is writing to.  If `DAEMON_SPOOL_DIR` is unset on both sides, both will use
+  the `common` package default (`resolveTeamKbPath`), which should agree.
+- Check that the daemon user can read files in the spool directory.
+
+### qmd index not updating
+
+- Confirm `DAEMON_ENABLE_INDEX=true` (the default).
+- Verify the `qmd` CLI is on `PATH` as seen by the daemon process.  On systemd,
+  PATH is not inherited from the user shell — add it explicitly in the
+  environment file if needed.
+
+### High CPU or tight restart loop (systemd)
+
+The `RestartSec=5s` guard in the unit file prevents spinning.  If the daemon is
+restarting repeatedly, check for a hard configuration error (see above).
+Temporarily disable auto-restart while diagnosing:
+
+```sh
+sudo systemctl stop edge-daemon
+# investigate, fix env, then:
+sudo systemctl start edge-daemon
+```
+
+---
+
+## Recovery Procedures
+
+### Full restart
+
+```sh
+# systemd
+sudo systemctl restart edge-daemon
+
+# launchd
+launchctl unload ~/Library/LaunchAgents/com.intentsolutions.edge-daemon.plist
+launchctl load  ~/Library/LaunchAgents/com.intentsolutions.edge-daemon.plist
+
+# Docker
+docker restart edge-daemon
+```
+
+### Manual single cycle (bypass daemon loop)
+
+Run exactly one cycle without starting the long-running loop.  Useful for
+diagnosing spool processing issues:
+
+```sh
+DAEMON_TENANT_ID=my-team \
+  node apps/edge-daemon/dist/main.js run-once
+```
+
+### Wipe stale PID lock
+
+```sh
+node apps/edge-daemon/dist/main.js stop
+# If stop exits non-zero, remove manually:
+rm "${DAEMON_PID_FILE:-$HOME/.qmd-team-intent-kb/daemon.pid}"
+```
+
+### Recover from corrupted SQLite database
+
+The SQLite database (`teamkb.db`) is managed by `packages/store`.  If it is
+corrupted:
+
+1. Stop the daemon.
+2. Back up the database: `cp teamkb.db teamkb.db.$(date +%Y%m%d%H%M%S).bak`
+3. Delete or rename the corrupted file.
+4. Restart the daemon — `createDatabase()` will create a fresh schema on start.
+5. Memories are re-seeded from the git-export directory (`kb-export/`) or from
+   spool files that have not yet been processed.
+
+---
+
+## Upgrade Procedure
+
+1. Stop the daemon:
+
+   ```sh
+   sudo systemctl stop edge-daemon   # systemd
+   # or: launchctl unload ~/Library/LaunchAgents/com.intentsolutions.edge-daemon.plist
+   ```
+
+2. Pull and build the new version:
+
+   ```sh
+   git pull origin main
+   pnpm install --frozen-lockfile
+   pnpm build
+   ```
+
+3. If the systemd unit file changed, reinstall it:
+
+   ```sh
+   sudo cp apps/edge-daemon/deploy/edge-daemon.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   ```
+
+4. Start the daemon:
+
+   ```sh
+   sudo systemctl start edge-daemon
+   ```
+
+5. Verify health (see Health Check section).
+
+For Docker, rebuild the image and redeploy:
+
+```sh
+docker build -f apps/edge-daemon/deploy/Dockerfile -t edge-daemon:<new-version> .
+docker stop edge-daemon && docker rm edge-daemon
+docker run -d --name edge-daemon ... edge-daemon:<new-version>
+```
+
+---
+
+## Rollback
+
+1. Stop the running daemon.
+
+2. Check out the previous release tag or commit:
+
+   ```sh
+   git checkout v<previous-version>
+   pnpm install --frozen-lockfile
+   pnpm build
+   ```
+
+3. Restore the previous unit file if it changed:
+
+   ```sh
+   sudo cp apps/edge-daemon/deploy/edge-daemon.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   ```
+
+4. Start the daemon and verify health.
+
+For Docker, roll back by running the previous image tag:
+
+```sh
+docker stop edge-daemon && docker rm edge-daemon
+docker run -d --name edge-daemon ... edge-daemon:<previous-version>
+```
+
+If the SQLite schema was migrated in the rolled-back release, restore the
+database from a backup taken before the upgrade (see Recovery Procedures).

--- a/000-docs/027-OD-OPSM-edge-daemon-runbook.md
+++ b/000-docs/027-OD-OPSM-edge-daemon-runbook.md
@@ -11,7 +11,7 @@
 ## Overview
 
 The edge-daemon is the local process that bridges Claude Code sessions to the
-team knowledge-base control plane.  It runs as a long-lived background service
+team knowledge-base control plane. It runs as a long-lived background service
 on every developer machine or CI host that participates in a tenant.
 
 Responsibilities:
@@ -24,8 +24,8 @@ Responsibilities:
 - Trigger qmd index updates so local search reflects new memories.
 - Deprecate memories that have not been accessed within the staleness window.
 
-The daemon is a single Node.js process.  It uses a PID lock file to prevent
-multiple concurrent instances.  All state is local to the machine; there is no
+The daemon is a single Node.js process. It uses a PID lock file to prevent
+multiple concurrent instances. All state is local to the machine; there is no
 peer-to-peer coordination between daemon instances.
 
 ---
@@ -50,7 +50,7 @@ peer-to-peer coordination between daemon instances.
    ```
 
 2. Create the environment file at `/etc/edge-daemon/env` (mode `0640`,
-   owner `root:edge-daemon`).  This file must contain at least:
+   owner `root:edge-daemon`). This file must contain at least:
 
    ```
    DAEMON_TENANT_ID=<your-tenant>
@@ -132,32 +132,32 @@ at `/var/lib/edge-daemon`.
 
 ## Configuration
 
-All configuration is via environment variables.  There are no CLI flags; the
+All configuration is via environment variables. There are no CLI flags; the
 only optional positional argument to the daemon is the subcommand (`start`,
 `stop`, `status`, `run-once`), which defaults to `start`.
 
 Source: `apps/edge-daemon/src/config.ts`
 
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `DAEMON_TENANT_ID` | Yes | — | Tenant identifier. Used to scope memory retrieval and qmd index namespacing. |
-| `DAEMON_POLL_INTERVAL` | No | `10000` | Milliseconds between spool poll cycles. |
-| `DAEMON_MAX_CANDIDATES` | No | `100` | Maximum candidates processed per cycle. |
-| `DAEMON_MAX_SPOOL_SIZE` | No | `10485760` | Maximum spool file size in bytes (10 MB). Files larger than this are skipped. |
-| `DAEMON_ENABLE_EXPORT` | No | `true` | Enable incremental git-export after each cycle. |
-| `DAEMON_ENABLE_INDEX` | No | `true` | Enable qmd index update after each cycle. |
-| `DAEMON_ENABLE_STALENESS` | No | `true` | Enable automatic staleness sweep (deprecation of old memories). |
-| `DAEMON_STALE_DAYS` | No | `90` | Days after last access before a memory is auto-deprecated. |
-| `DAEMON_SPOOL_DIR` | No | `~/.qmd-team-intent-kb/spool` | Directory watched for incoming candidate files. |
-| `DAEMON_EXPORT_DIR` | No | `kb-export/` | Output directory for git-exporter Markdown files. |
-| `DAEMON_EXPORT_TARGET` | No | `kb-export-default` | Export target identifier passed to git-exporter. |
-| `DAEMON_SUPERSESSION_THRESHOLD` | No | `0.6` | Jaccard similarity threshold above which a new candidate supersedes an existing memory. |
-| `DAEMON_PID_FILE` | No | `~/.qmd-team-intent-kb/daemon.pid` | Path of the PID lock file. Must be writable by the daemon user. |
+| Variable                        | Required | Default                            | Description                                                                             |
+| ------------------------------- | -------- | ---------------------------------- | --------------------------------------------------------------------------------------- |
+| `DAEMON_TENANT_ID`              | Yes      | —                                  | Tenant identifier. Used to scope memory retrieval and qmd index namespacing.            |
+| `DAEMON_POLL_INTERVAL`          | No       | `10000`                            | Milliseconds between spool poll cycles.                                                 |
+| `DAEMON_MAX_CANDIDATES`         | No       | `100`                              | Maximum candidates processed per cycle.                                                 |
+| `DAEMON_MAX_SPOOL_SIZE`         | No       | `10485760`                         | Maximum spool file size in bytes (10 MB). Files larger than this are skipped.           |
+| `DAEMON_ENABLE_EXPORT`          | No       | `true`                             | Enable incremental git-export after each cycle.                                         |
+| `DAEMON_ENABLE_INDEX`           | No       | `true`                             | Enable qmd index update after each cycle.                                               |
+| `DAEMON_ENABLE_STALENESS`       | No       | `true`                             | Enable automatic staleness sweep (deprecation of old memories).                         |
+| `DAEMON_STALE_DAYS`             | No       | `90`                               | Days after last access before a memory is auto-deprecated.                              |
+| `DAEMON_SPOOL_DIR`              | No       | `~/.qmd-team-intent-kb/spool`      | Directory watched for incoming candidate files.                                         |
+| `DAEMON_EXPORT_DIR`             | No       | `kb-export/`                       | Output directory for git-exporter Markdown files.                                       |
+| `DAEMON_EXPORT_TARGET`          | No       | `kb-export-default`                | Export target identifier passed to git-exporter.                                        |
+| `DAEMON_SUPERSESSION_THRESHOLD` | No       | `0.6`                              | Jaccard similarity threshold above which a new candidate supersedes an existing memory. |
+| `DAEMON_PID_FILE`               | No       | `~/.qmd-team-intent-kb/daemon.pid` | Path of the PID lock file. Must be writable by the daemon user.                         |
 
-`DAEMON_TENANT_ID` is the only required variable.  The daemon exits immediately
+`DAEMON_TENANT_ID` is the only required variable. The daemon exits immediately
 with code 1 if it is absent.
 
-Boolean variables accept only the literal strings `true` or `false`.  Any other
+Boolean variables accept only the literal strings `true` or `false`. Any other
 value falls back to the default.
 
 ---
@@ -165,7 +165,7 @@ value falls back to the default.
 ## Health Check
 
 The edge-daemon does not expose an HTTP health endpoint; it is a single-process
-local daemon.  Use the PID lock file and `status` subcommand to determine whether
+local daemon. Use the PID lock file and `status` subcommand to determine whether
 it is running.
 
 ### Quick status check
@@ -250,7 +250,7 @@ docker logs --tail 100 edge-daemon
 
 ### Log format
 
-The daemon uses `ConsoleDaemonLogger` (structured text, not JSON).  Each line
+The daemon uses `ConsoleDaemonLogger` (structured text, not JSON). Each line
 is prefixed with the ISO-8601 timestamp and severity level:
 
 ```
@@ -291,7 +291,7 @@ rm "${DAEMON_PID_FILE:-$HOME/.qmd-team-intent-kb/daemon.pid}"
 
 ### Daemon exits immediately after starting (exit code 1)
 
-Check the logs for a configuration or database error.  Common causes:
+Check the logs for a configuration or database error. Common causes:
 
 - SQLite database path not writable by the daemon user.
 - `DAEMON_SPOOL_DIR` does not exist and cannot be created (permissions).
@@ -301,20 +301,20 @@ Check the logs for a configuration or database error.  Common causes:
 ### Spool files not processed
 
 - Verify `DAEMON_SPOOL_DIR` points to the same directory that `claude-runtime`
-  is writing to.  If `DAEMON_SPOOL_DIR` is unset on both sides, both will use
+  is writing to. If `DAEMON_SPOOL_DIR` is unset on both sides, both will use
   the `common` package default (`resolveTeamKbPath`), which should agree.
 - Check that the daemon user can read files in the spool directory.
 
 ### qmd index not updating
 
 - Confirm `DAEMON_ENABLE_INDEX=true` (the default).
-- Verify the `qmd` CLI is on `PATH` as seen by the daemon process.  On systemd,
+- Verify the `qmd` CLI is on `PATH` as seen by the daemon process. On systemd,
   PATH is not inherited from the user shell — add it explicitly in the
   environment file if needed.
 
 ### High CPU or tight restart loop (systemd)
 
-The `RestartSec=5s` guard in the unit file prevents spinning.  If the daemon is
+The `RestartSec=5s` guard in the unit file prevents spinning. If the daemon is
 restarting repeatedly, check for a hard configuration error (see above).
 Temporarily disable auto-restart while diagnosing:
 
@@ -344,7 +344,7 @@ docker restart edge-daemon
 
 ### Manual single cycle (bypass daemon loop)
 
-Run exactly one cycle without starting the long-running loop.  Useful for
+Run exactly one cycle without starting the long-running loop. Useful for
 diagnosing spool processing issues:
 
 ```sh
@@ -362,7 +362,7 @@ rm "${DAEMON_PID_FILE:-$HOME/.qmd-team-intent-kb/daemon.pid}"
 
 ### Recover from corrupted SQLite database
 
-The SQLite database (`teamkb.db`) is managed by `packages/store`.  If it is
+The SQLite database (`teamkb.db`) is managed by `packages/store`. If it is
 corrupted:
 
 1. Stop the daemon.

--- a/apps/edge-daemon/deploy/.dockerignore
+++ b/apps/edge-daemon/deploy/.dockerignore
@@ -1,0 +1,30 @@
+# Exclude everything that the Docker build does not need.
+# The Dockerfile performs its own selective COPY; this file prevents large
+# directories from being sent as build context at all.
+
+# Build artifacts and caches
+**/dist
+**/node_modules
+**/*.tsbuildinfo
+.pnpm-store
+
+# Test fixtures and coverage
+**/coverage
+**/__tests__
+**/tests
+
+# Dev tooling and editor configs
+.git
+.github
+.husky
+.vscode
+.idea
+*.log
+
+# Docs and non-build assets — keep small context
+000-docs
+kb-export
+
+# OS noise
+.DS_Store
+Thumbs.db

--- a/apps/edge-daemon/deploy/Dockerfile
+++ b/apps/edge-daemon/deploy/Dockerfile
@@ -1,0 +1,94 @@
+# Multi-stage Dockerfile for apps/edge-daemon.
+#
+# Build context: repo root  (docker build -f apps/edge-daemon/deploy/Dockerfile .)
+#
+# Stage 1 (builder) — installs the full monorepo dev tree, builds every
+#   workspace package that edge-daemon depends on, then prunes to the minimal
+#   production dependency set.
+#
+# Stage 2 (runtime) — copies only what node needs to run.  Runs as a
+#   dedicated non-root user.  No build toolchain present in the final image.
+
+# ---- Stage 1: builder -------------------------------------------------------
+FROM node:20-alpine AS builder
+
+# pnpm is pinned to match the packageManager field in the root package.json.
+ENV PNPM_VERSION=9.15.4
+
+# Install pnpm via corepack (ships with Node 20; no extra network calls).
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+WORKDIR /build
+
+# Copy workspace manifests first so Docker can cache the install layer
+# independently of source changes.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY tsconfig.base.json ./
+
+# Copy all package.json / tsconfig files before source so the dependency
+# install layer is cached even when source changes.
+COPY apps/api/package.json             apps/api/
+COPY apps/curator/package.json         apps/curator/
+COPY apps/edge-daemon/package.json     apps/edge-daemon/
+COPY apps/git-exporter/package.json    apps/git-exporter/
+COPY apps/reporting/package.json       apps/reporting/
+COPY packages/schema/package.json      packages/schema/
+COPY packages/common/package.json      packages/common/
+COPY packages/store/package.json       packages/store/
+COPY packages/policy-engine/package.json  packages/policy-engine/
+COPY packages/claude-runtime/package.json packages/claude-runtime/
+COPY packages/qmd-adapter/package.json    packages/qmd-adapter/
+COPY packages/repo-resolver/package.json  packages/repo-resolver/
+
+# Install all workspace deps (frozen; fails if lockfile is stale).
+RUN pnpm install --frozen-lockfile
+
+# Copy full source.
+COPY . .
+
+# Build the edge-daemon and all packages it depends on via workspace references.
+# tsc -b resolves project references in the right order automatically.
+RUN pnpm --filter @qmd-team-intent-kb/edge-daemon... build
+
+# Prune the install tree to production-only deps so we only copy what the
+# runtime image needs.
+RUN pnpm --filter @qmd-team-intent-kb/edge-daemon... --prod deploy /app/deploy
+
+
+# ---- Stage 2: runtime -------------------------------------------------------
+FROM node:20-alpine AS runtime
+
+# Create a non-root user that matches the systemd unit expectation.
+RUN addgroup -S edge-daemon && adduser -S -G edge-daemon edge-daemon
+
+WORKDIR /app
+
+# Copy the pruned deployment tree from the builder stage.
+COPY --from=builder /app/deploy/node_modules ./node_modules
+COPY --from=builder /build/apps/edge-daemon/dist ./apps/edge-daemon/dist
+# Workspace packages are bundled into node_modules by pnpm deploy; no extra
+# copy needed.
+
+# Default environment — all of these can be overridden at runtime via
+# --env / --env-file / Kubernetes configmap+secret.
+ENV NODE_ENV=production
+ENV DAEMON_TENANT_ID=""
+ENV DAEMON_POLL_INTERVAL=10000
+ENV DAEMON_MAX_CANDIDATES=100
+ENV DAEMON_MAX_SPOOL_SIZE=10485760
+ENV DAEMON_ENABLE_EXPORT=true
+ENV DAEMON_ENABLE_INDEX=true
+ENV DAEMON_ENABLE_STALENESS=true
+ENV DAEMON_STALE_DAYS=90
+ENV DAEMON_SPOOL_DIR=/var/lib/edge-daemon/spool
+ENV DAEMON_EXPORT_DIR=/var/lib/edge-daemon/kb-export
+ENV DAEMON_PID_FILE=/var/lib/edge-daemon/daemon.pid
+
+RUN mkdir -p /var/lib/edge-daemon/spool /var/lib/edge-daemon/kb-export \
+    && chown -R edge-daemon:edge-daemon /var/lib/edge-daemon
+
+USER edge-daemon
+
+# DAEMON_TENANT_ID must be supplied by the caller — the daemon will exit(1)
+# immediately if it is missing.
+CMD ["node", "apps/edge-daemon/dist/main.js", "start"]

--- a/apps/edge-daemon/deploy/README.md
+++ b/apps/edge-daemon/deploy/README.md
@@ -3,12 +3,12 @@
 This directory contains ready-to-use deployment artifacts for the
 `@qmd-team-intent-kb/edge-daemon` process.
 
-| File | Purpose |
-|---|---|
-| `edge-daemon.service` | systemd unit (Linux / server installs) |
-| `com.intentsolutions.edge-daemon.plist` | launchd agent (macOS developer machines) |
-| `Dockerfile` | Multi-stage container image (build context: repo root) |
-| `.dockerignore` | Companion to Dockerfile; keeps build context minimal |
+| File                                    | Purpose                                                |
+| --------------------------------------- | ------------------------------------------------------ |
+| `edge-daemon.service`                   | systemd unit (Linux / server installs)                 |
+| `com.intentsolutions.edge-daemon.plist` | launchd agent (macOS developer machines)               |
+| `Dockerfile`                            | Multi-stage container image (build context: repo root) |
+| `.dockerignore`                         | Companion to Dockerfile; keeps build context minimal   |
 
 ## Quick start
 

--- a/apps/edge-daemon/deploy/README.md
+++ b/apps/edge-daemon/deploy/README.md
@@ -1,0 +1,50 @@
+# edge-daemon deployment assets
+
+This directory contains ready-to-use deployment artifacts for the
+`@qmd-team-intent-kb/edge-daemon` process.
+
+| File | Purpose |
+|---|---|
+| `edge-daemon.service` | systemd unit (Linux / server installs) |
+| `com.intentsolutions.edge-daemon.plist` | launchd agent (macOS developer machines) |
+| `Dockerfile` | Multi-stage container image (build context: repo root) |
+| `.dockerignore` | Companion to Dockerfile; keeps build context minimal |
+
+## Quick start
+
+See the full operations runbook at
+`000-docs/027-OD-OPSM-edge-daemon-runbook.md` for installation procedures,
+all environment variables, health checks, log inspection, and rollback.
+
+### systemd (Linux)
+
+```sh
+sudo cp edge-daemon.service /etc/systemd/system/
+sudo mkdir -p /etc/edge-daemon
+# Create /etc/edge-daemon/env (mode 0640, owner root:edge-daemon) with at least:
+#   DAEMON_TENANT_ID=<your-team>
+sudo systemctl daemon-reload
+sudo systemctl enable --now edge-daemon
+```
+
+### launchd (macOS)
+
+```sh
+# Edit EnvironmentVariables in the plist — set DAEMON_TENANT_ID at minimum.
+cp com.intentsolutions.edge-daemon.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.intentsolutions.edge-daemon.plist
+```
+
+### Docker
+
+```sh
+# Build from repo root:
+docker build -f apps/edge-daemon/deploy/Dockerfile -t edge-daemon:latest .
+
+# Run — DAEMON_TENANT_ID is required:
+docker run -d \
+  --name edge-daemon \
+  -e DAEMON_TENANT_ID=my-team \
+  -v /var/lib/edge-daemon:/var/lib/edge-daemon \
+  edge-daemon:latest
+```

--- a/apps/edge-daemon/deploy/com.intentsolutions.edge-daemon.plist
+++ b/apps/edge-daemon/deploy/com.intentsolutions.edge-daemon.plist
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  launchd plist for the qmd-team-intent-kb edge daemon.
+
+  Install (per-user agent):
+    cp com.intentsolutions.edge-daemon.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.intentsolutions.edge-daemon.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.intentsolutions.edge-daemon.plist
+    rm ~/Library/LaunchAgents/com.intentsolutions.edge-daemon.plist
+
+  Edit EnvironmentVariables before loading.  DAEMON_TENANT_ID is required.
+  See 000-docs/027-OD-OPSM-edge-daemon-runbook.md for the full variable list.
+
+  APP_DIR defaults to /opt/qmd-team-intent-kb — adjust to match the actual
+  installation path on this machine.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.intentsolutions.edge-daemon</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/node</string>
+        <string>/opt/qmd-team-intent-kb/apps/edge-daemon/dist/main.js</string>
+        <string>start</string>
+    </array>
+
+    <!-- Required: set at minimum DAEMON_TENANT_ID. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>DAEMON_TENANT_ID</key>
+        <string>my-team</string>
+        <key>DAEMON_POLL_INTERVAL</key>
+        <string>10000</string>
+        <key>DAEMON_ENABLE_EXPORT</key>
+        <string>true</string>
+        <key>DAEMON_ENABLE_INDEX</key>
+        <string>true</string>
+        <key>DAEMON_ENABLE_STALENESS</key>
+        <string>true</string>
+    </dict>
+
+    <!-- Start automatically on login. -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Restart on crash (exit code != 0 or signal). -->
+    <key>KeepAlive</key>
+    <dict>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <!-- Throttle rapid restart loops to avoid spinning on a hard failure. -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>/usr/local/var/log/edge-daemon/stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/usr/local/var/log/edge-daemon/stderr.log</string>
+
+    <key>WorkingDirectory</key>
+    <string>/opt/qmd-team-intent-kb</string>
+</dict>
+</plist>

--- a/apps/edge-daemon/deploy/edge-daemon.service
+++ b/apps/edge-daemon/deploy/edge-daemon.service
@@ -1,0 +1,57 @@
+# systemd unit for the qmd-team-intent-kb edge daemon.
+#
+# Install:
+#   sudo cp edge-daemon.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now edge-daemon
+#
+# Environment:
+#   Create /etc/edge-daemon/env (mode 0640, owner root:edge-daemon) with at
+#   minimum:
+#     DAEMON_TENANT_ID=<your-tenant>
+#   See 000-docs/027-OD-OPSM-edge-daemon-runbook.md for the full variable list.
+
+[Unit]
+Description=qmd-team-intent-kb edge daemon — local qmd sync and memory promotion
+Documentation=https://github.com/intentsolutions/qmd-team-intent-kb
+After=network.target
+
+[Service]
+Type=simple
+User=edge-daemon
+Group=edge-daemon
+
+# Load tenant-specific environment from a restricted file so secrets never
+# appear in the process table or journal metadata.
+EnvironmentFile=/etc/edge-daemon/env
+
+# Point at the compiled entry-point. Adjust APP_DIR if the deployment path
+# differs (e.g. /opt/qmd-team-intent-kb).
+Environment=APP_DIR=/opt/qmd-team-intent-kb
+ExecStart=/usr/bin/node ${APP_DIR}/apps/edge-daemon/dist/main.js start
+
+# Restart on non-zero exit or signal, but not on clean exit (code 0).
+Restart=on-failure
+RestartSec=5s
+
+# Give the daemon time to flush state and release its PID lock on SIGTERM.
+TimeoutStopSec=30s
+
+# Resource guards — tune to the deployment host.
+LimitNOFILE=65536
+MemoryMax=512M
+
+# Harden the service process. The daemon only needs filesystem access to its
+# own data directory; it does not need network privileges.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/edge-daemon /tmp
+PrivateTmp=true
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=edge-daemon
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Adds `apps/edge-daemon/deploy/` with systemd unit, launchd plist, multi-stage Dockerfile, `.dockerignore`, and a quick-start `README.md`
- Ships `000-docs/027-OD-OPSM-edge-daemon-runbook.md` — full operations manual covering install, configuration, health checks, log inspection, failure modes, recovery, upgrade, and rollback
- Updates `000-docs/000-INDEX.md` with the new 027 entry and advances the next-sequence marker to 028

Closes bead qmd-team-intent-kb-1x6.6

## Decisions

- Doc code `OD-OPSM` was chosen by reading the existing index — `016-OD-OPSM-branch-protection-checklist.md` already established this combination for operational manuals; no new codes invented.
- Dockerfile build context is the repo root (required for `pnpm deploy` to resolve all workspace package sources). The `.dockerignore` keeps the context small by excluding `dist/`, `node_modules/`, test fixtures, and `000-docs/`.
- The systemd `EnvironmentFile` approach keeps secrets out of the process table and journal metadata, consistent with the security-governance doc (`006-TQ-SECU`).
- launchd `KeepAlive.Crashed: true` (not the blanket `KeepAlive: true`) so the agent does not restart on clean `exit(0)` (e.g., after a `stop` subcommand).
- No source files in `apps/edge-daemon/src/` were touched.

## Test plan

- [ ] `python3 -c "import plistlib; plistlib.loads(open('apps/edge-daemon/deploy/com.intentsolutions.edge-daemon.plist','rb').read())"` — plist parses without error (validated locally: "plist parsed OK")
- [ ] `pnpm install --frozen-lockfile` completes as a no-op (no new deps added)
- [ ] `pnpm validate` passes (format, lint, typecheck, test — no source changes)
- [ ] Systemd unit reviewed visually: correct `[Unit]`, `[Service]`, `[Install]` sections; `Type=simple`, `Restart=on-failure`, `EnvironmentFile`, `ExecStart` pointing at `node dist/main.js start`
- [ ] Runbook sections cover all env vars surfaced in `apps/edge-daemon/src/config.ts`
- [ ] `000-docs/000-INDEX.md` entry added, sequence bumped to 028

🤖 Generated with [Claude Code](https://claude.com/claude-code)