### PR TITLE
feat(edge-daemon): transient-failure retry with exponential backoff + jitter

### DIFF
--- a/apps/edge-daemon/src/__tests__/cycle.test.ts
+++ b/apps/edge-daemon/src/__tests__/cycle.test.ts
@@ -368,4 +368,100 @@ describe('runCycle', () => {
     // Export should have run regardless of curation outcome
     expect(result.export).not.toBeNull();
   });
+
+  it('index update retries transient qmd errors and succeeds on final attempt', async () => {
+    const sleepCalls: number[] = [];
+    let ensureAttempts = 0;
+
+    const flakeyAdapter = {
+      ensureCollections: async () => {
+        ensureAttempts++;
+        if (ensureAttempts < 3) {
+          return { ok: false as const, error: { message: 'qmd unreachable' } };
+        }
+        return { ok: true as const, value: ['curated'] };
+      },
+      update: async () => ({ ok: true as const, value: undefined }),
+    };
+
+    const retryConfig = makeConfig({
+      spoolDir,
+      enableExport: false,
+      enableIndexUpdate: true,
+      maxRetries: 3,
+      retryBaseDelayMs: 10,
+      retryMaxJitterMs: 0,
+      sleepFn: async (ms: number) => {
+        sleepCalls.push(ms);
+      },
+    });
+
+    const retryDeps = { ...deps, qmdAdapter: flakeyAdapter as never };
+    const result = await runCycle(retryConfig, retryDeps, logger);
+
+    expect(result.indexUpdate).not.toBeNull();
+    expect(result.indexUpdate!.ok).toBe(true);
+    expect(ensureAttempts).toBe(3);
+    expect(sleepCalls).toHaveLength(2);
+  });
+
+  it('index update exhausts retries and records permanent failure', async () => {
+    const sleepFn = async (_ms: number) => {};
+    let attempts = 0;
+
+    const alwaysFailAdapter = {
+      ensureCollections: async () => {
+        attempts++;
+        return { ok: false as const, error: { message: 'qmd unreachable' } };
+      },
+      update: async () => ({ ok: true as const, value: undefined }),
+    };
+
+    const retryConfig = makeConfig({
+      spoolDir,
+      enableExport: false,
+      enableIndexUpdate: true,
+      maxRetries: 2,
+      retryBaseDelayMs: 1,
+      retryMaxJitterMs: 0,
+      sleepFn,
+    });
+
+    const retryDeps = { ...deps, qmdAdapter: alwaysFailAdapter as never };
+    const result = await runCycle(retryConfig, retryDeps, logger);
+
+    expect(result.indexUpdate).not.toBeNull();
+    expect(result.indexUpdate!.ok).toBe(false);
+    expect(result.indexUpdate!.error).toContain('qmd unreachable');
+    expect(attempts).toBe(3); // 1 initial + 2 retries
+  });
+
+  it('index update does not retry permanent (non-transient) errors', async () => {
+    let attempts = 0;
+
+    const permanentFailAdapter = {
+      ensureCollections: async () => {
+        attempts++;
+        return { ok: false as const, error: { message: 'TypeError: cannot read properties' } };
+      },
+      update: async () => ({ ok: true as const, value: undefined }),
+    };
+
+    const retryConfig = makeConfig({
+      spoolDir,
+      enableExport: false,
+      enableIndexUpdate: true,
+      maxRetries: 3,
+      retryBaseDelayMs: 10,
+      retryMaxJitterMs: 0,
+      sleepFn: async (_ms: number) => {},
+    });
+
+    const retryDeps = { ...deps, qmdAdapter: permanentFailAdapter as never };
+    const result = await runCycle(retryConfig, retryDeps, logger);
+
+    expect(result.indexUpdate!.ok).toBe(false);
+    expect(result.indexUpdate!.error).toContain('TypeError');
+    expect(attempts).toBe(1); // no retry for permanent errors
+  });
 });

--- a/apps/edge-daemon/src/__tests__/fixtures.ts
+++ b/apps/edge-daemon/src/__tests__/fixtures.ts
@@ -90,6 +90,10 @@ export function makeConfig(overrides?: Partial<DaemonConfig>): DaemonConfig {
     exportTargetId: 'kb-export-default',
     supersessionThreshold: 0.6,
     pidFilePath: '/tmp/daemon-test-' + randomUUID() + '.pid',
+    maxRetries: 0, // no retries in tests by default — avoids delay
+    retryBaseDelayMs: 0,
+    retryMaxJitterMs: 0,
+    sleepFn: async (_ms: number) => {}, // no-op sleep — deterministic
     nowFn: () => NOW,
     ...overrides,
   };

--- a/apps/edge-daemon/src/__tests__/retry.test.ts
+++ b/apps/edge-daemon/src/__tests__/retry.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi } from 'vitest';
+import { classifyError, withRetry } from '../retry.js';
+
+describe('classifyError', () => {
+  it('classifies ECONNREFUSED as transient', () => {
+    const err = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:4000'), {
+      code: 'ECONNREFUSED',
+    });
+    expect(classifyError(err)).toBe('transient');
+  });
+
+  it('classifies ETIMEDOUT as transient', () => {
+    const err = Object.assign(new Error('connect ETIMEDOUT'), { code: 'ETIMEDOUT' });
+    expect(classifyError(err)).toBe('transient');
+  });
+
+  it('classifies qmd not found as transient', () => {
+    expect(classifyError(new Error('qmd not found in PATH'))).toBe('transient');
+    expect(classifyError(new Error('qmd process not found'))).toBe('transient');
+  });
+
+  it('classifies qmd unreachable as transient', () => {
+    expect(classifyError(new Error('qmd unreachable'))).toBe('transient');
+    expect(classifyError(new Error('qmd service unreachable on port 4000'))).toBe('transient');
+  });
+
+  it('classifies non-fast-forward as transient', () => {
+    expect(classifyError(new Error('error: failed to push some refs (non-fast-forward)'))).toBe(
+      'transient',
+    );
+  });
+
+  it('classifies failed to push as transient', () => {
+    expect(classifyError(new Error('failed to push refs to origin'))).toBe('transient');
+  });
+
+  it('classifies generic errors as permanent', () => {
+    expect(classifyError(new Error('SyntaxError: unexpected token'))).toBe('permanent');
+    expect(classifyError(new Error('ENOENT: no such file'))).toBe('permanent');
+    expect(classifyError(new Error('TypeError: cannot read property'))).toBe('permanent');
+  });
+
+  it('classifies non-Error values as permanent', () => {
+    expect(classifyError('some string error')).toBe('permanent');
+    expect(classifyError(42)).toBe('permanent');
+    expect(classifyError(null)).toBe('permanent');
+  });
+
+  it('requires both qmd + keyword for transient qmd classification', () => {
+    expect(classifyError(new Error('not found'))).toBe('permanent');
+    expect(classifyError(new Error('unreachable'))).toBe('permanent');
+    expect(classifyError(new Error('qmd is great'))).toBe('permanent');
+  });
+});
+
+describe('withRetry', () => {
+  const noopSleep = async (_ms: number) => {};
+
+  it('returns immediately on first-attempt success', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+    const result = await withRetry(fn, {
+      maxRetries: 3,
+      baseDelayMs: 100,
+      maxJitterMs: 0,
+      sleepFn: noopSleep,
+    });
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries transient errors up to maxRetries then succeeds', async () => {
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    let calls = 0;
+    const fn = vi.fn().mockImplementation(async () => {
+      calls++;
+      if (calls < 3) {
+        const err = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+        throw err;
+      }
+      return 'done';
+    });
+
+    const result = await withRetry(fn, {
+      maxRetries: 3,
+      baseDelayMs: 10,
+      maxJitterMs: 0,
+      sleepFn,
+    });
+
+    expect(result).toBe('done');
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(sleepFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after exhausting all retries on persistent transient error', async () => {
+    const err = Object.assign(new Error('qmd unreachable'), { code: undefined });
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(
+      withRetry(fn, {
+        maxRetries: 2,
+        baseDelayMs: 10,
+        maxJitterMs: 0,
+        sleepFn: noopSleep,
+      }),
+    ).rejects.toThrow('qmd unreachable');
+
+    expect(fn).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
+  });
+
+  it('does not retry permanent errors', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('SyntaxError: bad json'));
+
+    await expect(
+      withRetry(fn, {
+        maxRetries: 3,
+        baseDelayMs: 10,
+        maxJitterMs: 0,
+        sleepFn: noopSleep,
+      }),
+    ).rejects.toThrow('SyntaxError: bad json');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies exponential backoff delays between retries', async () => {
+    const sleepCalls: number[] = [];
+    const sleepFn = async (ms: number) => {
+      sleepCalls.push(ms);
+    };
+
+    const err = Object.assign(new Error('qmd not found'), {});
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(
+      withRetry(fn, {
+        maxRetries: 3,
+        baseDelayMs: 100,
+        maxJitterMs: 0,
+        sleepFn,
+      }),
+    ).rejects.toThrow();
+
+    expect(sleepCalls).toHaveLength(3);
+    expect(sleepCalls[0]).toBe(100); // 100 * 2^0
+    expect(sleepCalls[1]).toBe(200); // 100 * 2^1
+    expect(sleepCalls[2]).toBe(400); // 100 * 2^2
+  });
+
+  it('adds jitter within expected range', async () => {
+    const sleepCalls: number[] = [];
+    const sleepFn = async (ms: number) => {
+      sleepCalls.push(ms);
+    };
+
+    const err = Object.assign(new Error('failed to push refs'), {});
+    const fn = vi.fn().mockRejectedValue(err);
+
+    await expect(
+      withRetry(fn, {
+        maxRetries: 1,
+        baseDelayMs: 100,
+        maxJitterMs: 50,
+        sleepFn,
+      }),
+    ).rejects.toThrow();
+
+    expect(sleepCalls).toHaveLength(1);
+    expect(sleepCalls[0]).toBeGreaterThanOrEqual(100);
+    expect(sleepCalls[0]).toBeLessThanOrEqual(150);
+  });
+
+  it('flaky mock: fails N-1 times then succeeds', async () => {
+    const maxRetries = 4;
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    let attempt = 0;
+
+    const flaky = vi.fn().mockImplementation(async () => {
+      attempt++;
+      if (attempt < maxRetries) {
+        throw Object.assign(new Error('qmd unreachable'), {});
+      }
+      return `success on attempt ${attempt}`;
+    });
+
+    const result = await withRetry(flaky, {
+      maxRetries,
+      baseDelayMs: 1,
+      maxJitterMs: 0,
+      sleepFn,
+    });
+
+    expect(result).toBe(`success on attempt ${maxRetries}`);
+    expect(flaky).toHaveBeenCalledTimes(maxRetries);
+    expect(sleepFn).toHaveBeenCalledTimes(maxRetries - 1);
+  });
+});

--- a/apps/edge-daemon/src/config.ts
+++ b/apps/edge-daemon/src/config.ts
@@ -13,6 +13,9 @@ const DEFAULTS = {
   exportOutputDir: 'kb-export/',
   exportTargetId: 'kb-export-default',
   supersessionThreshold: 0.6,
+  maxRetries: 3,
+  retryBaseDelayMs: 500,
+  retryMaxJitterMs: 200,
 } as const;
 
 /**
@@ -32,6 +35,9 @@ const DEFAULTS = {
  *   DAEMON_EXPORT_TARGET   — export target identifier
  *   DAEMON_SUPERSESSION_THRESHOLD — Jaccard threshold (default 0.6)
  *   DAEMON_PID_FILE        — PID file path
+ *   DAEMON_MAX_RETRIES     — max retries for transient errors (default 3)
+ *   DAEMON_RETRY_BASE_DELAY — base backoff delay in ms (default 500)
+ *   DAEMON_RETRY_MAX_JITTER — max jitter in ms added to backoff (default 200)
  */
 export function loadDaemonConfig(
   env: Record<string, string | undefined> = process.env,
@@ -67,6 +73,9 @@ export function loadDaemonConfig(
       env['DAEMON_SUPERSESSION_THRESHOLD'] ?? String(DEFAULTS.supersessionThreshold),
     ),
     pidFilePath: env['DAEMON_PID_FILE'] ?? resolveTeamKbPath('daemon.pid'),
+    maxRetries: parsePositiveInt(env['DAEMON_MAX_RETRIES'], DEFAULTS.maxRetries),
+    retryBaseDelayMs: parsePositiveInt(env['DAEMON_RETRY_BASE_DELAY'], DEFAULTS.retryBaseDelayMs),
+    retryMaxJitterMs: parsePositiveInt(env['DAEMON_RETRY_MAX_JITTER'], DEFAULTS.retryMaxJitterMs),
   };
 }
 

--- a/apps/edge-daemon/src/cycle.ts
+++ b/apps/edge-daemon/src/cycle.ts
@@ -7,6 +7,7 @@ import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
 import type { DaemonConfig, DaemonDependencies, CycleResult, DaemonLogger } from './types.js';
 import { runStalenessSweep } from './staleness.js';
 import { writeFeedback } from './feedback.js';
+import { withRetry } from './retry.js';
 
 /**
  * Check if enterprise managed settings disable memory capture.
@@ -138,18 +139,27 @@ export async function runCycle(
     }
   }
 
-  // Step 3: Git export
+  // Step 3: Git export — retried on transient push conflicts
   if (config.enableExport) {
     try {
-      result.export = runExport(
-        deps.memoryRepo,
-        deps.exportStateRepo,
+      result.export = await withRetry(
+        async () =>
+          runExport(
+            deps.memoryRepo,
+            deps.exportStateRepo,
+            {
+              outputDir: config.exportOutputDir,
+              targetId: config.exportTargetId,
+              tenantId: config.tenantId,
+            },
+            nowFn,
+          ),
         {
-          outputDir: config.exportOutputDir,
-          targetId: config.exportTargetId,
-          tenantId: config.tenantId,
+          maxRetries: config.maxRetries,
+          baseDelayMs: config.retryBaseDelayMs,
+          maxJitterMs: config.retryMaxJitterMs,
+          sleepFn: config.sleepFn,
         },
-        nowFn,
       );
       logger.info(
         `Export: ${result.export.written.length} written, ${result.export.archived.length} archived`,
@@ -160,23 +170,28 @@ export async function runCycle(
     }
   }
 
-  // Step 4: qmd index update — offline resilient
+  // Step 4: qmd index update — offline resilient, retried on transient qmd errors
   if (config.enableIndexUpdate && deps.qmdAdapter) {
+    const retryOpts = {
+      maxRetries: config.maxRetries,
+      baseDelayMs: config.retryBaseDelayMs,
+      maxJitterMs: config.retryMaxJitterMs,
+      sleepFn: config.sleepFn,
+    };
     try {
-      const ensureResult = await deps.qmdAdapter.ensureCollections();
-      if (!ensureResult.ok) {
-        result.indexUpdate = { ok: false, error: ensureResult.error.message };
-        logger.warn(`Index ensureCollections failed: ${ensureResult.error.message}`);
-      } else {
-        const updateResult = await deps.qmdAdapter.update();
-        if (updateResult.ok) {
-          result.indexUpdate = { ok: true };
-          logger.info('Index update complete');
-        } else {
-          result.indexUpdate = { ok: false, error: updateResult.error.message };
-          logger.warn(`Index update failed: ${updateResult.error.message}`);
+      await withRetry(async () => {
+        const ensureResult = await deps.qmdAdapter!.ensureCollections();
+        if (!ensureResult.ok) {
+          const e = new Error(ensureResult.error.message);
+          throw e;
         }
-      }
+        const updateResult = await deps.qmdAdapter!.update();
+        if (!updateResult.ok) {
+          throw new Error(updateResult.error.message);
+        }
+      }, retryOpts);
+      result.indexUpdate = { ok: true };
+      logger.info('Index update complete');
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       result.indexUpdate = { ok: false, error: msg };

--- a/apps/edge-daemon/src/retry.ts
+++ b/apps/edge-daemon/src/retry.ts
@@ -1,0 +1,65 @@
+import { setTimeout } from 'node:timers/promises';
+
+export type ErrorClass = 'transient' | 'permanent';
+
+/**
+ * Classify an error as transient (eligible for retry) or permanent.
+ *
+ * Transient criteria:
+ *   - Node network errors: ECONNREFUSED, ETIMEDOUT
+ *   - qmd-unreachable: message contains "qmd" and ("not found" or "unreachable")
+ *   - Git push conflicts: message contains "non-fast-forward" or "failed to push"
+ */
+export function classifyError(err: unknown): ErrorClass {
+  const msg = err instanceof Error ? err.message : String(err);
+  const code =
+    err != null && typeof err === 'object' ? ((err as NodeJS.ErrnoException).code ?? '') : '';
+
+  if (code === 'ECONNREFUSED' || code === 'ETIMEDOUT') return 'transient';
+
+  const lower = msg.toLowerCase();
+  if (lower.includes('qmd') && (lower.includes('not found') || lower.includes('unreachable'))) {
+    return 'transient';
+  }
+  if (lower.includes('non-fast-forward') || lower.includes('failed to push')) {
+    return 'transient';
+  }
+
+  return 'permanent';
+}
+
+export interface RetryOptions {
+  maxRetries: number;
+  baseDelayMs: number;
+  maxJitterMs: number;
+  nowFn?: () => string;
+  sleepFn?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Execute `fn` with exponential backoff + uniform random jitter on transient errors.
+ *
+ * Backoff formula: delay = baseDelayMs * 2^attempt + rand(0, maxJitterMs)
+ * Permanent errors are rethrown immediately without retry.
+ * Throws the last error after maxRetries exhausted.
+ */
+export async function withRetry<T>(fn: () => Promise<T>, opts: RetryOptions): Promise<T> {
+  const sleep = opts.sleepFn ?? ((ms: number) => setTimeout(ms));
+  let lastErr: unknown;
+
+  for (let attempt = 0; attempt <= opts.maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (classifyError(err) === 'permanent') throw err;
+      if (attempt === opts.maxRetries) break;
+
+      const backoff = opts.baseDelayMs * Math.pow(2, attempt);
+      const jitter = Math.floor(Math.random() * (opts.maxJitterMs + 1));
+      await sleep(backoff + jitter);
+    }
+  }
+
+  throw lastErr;
+}

--- a/apps/edge-daemon/src/types.ts
+++ b/apps/edge-daemon/src/types.ts
@@ -36,8 +36,16 @@ export interface DaemonConfig {
   supersessionThreshold: number;
   /** PID file path for locking. Default ~/.teamkb/daemon.pid. */
   pidFilePath: string;
+  /** Maximum retry attempts for transient step errors. Default 3. */
+  maxRetries: number;
+  /** Base delay in ms for exponential backoff. Default 500. */
+  retryBaseDelayMs: number;
+  /** Maximum random jitter added to backoff delay in ms. Default 200. */
+  retryMaxJitterMs: number;
   /** Injectable clock for deterministic tests. */
   nowFn?: () => string;
+  /** Injectable sleep for deterministic retry tests. */
+  sleepFn?: (ms: number) => Promise<void>;
 }
 
 /** Repository dependencies injected into the daemon */


### PR DESCRIPTION
## Summary

- Adds `apps/edge-daemon/src/retry.ts` with `withRetry<T>(fn, opts)` and `classifyError(err)` helpers; transient classification covers `ECONNREFUSED`, `ETIMEDOUT`, qmd-unreachable messages, and git push conflict messages; everything else is permanent and bypasses retry.
- Extends `DaemonConfig` (`types.ts`) with `maxRetries`, `retryBaseDelayMs`, `retryMaxJitterMs`, and injectable `sleepFn` for deterministic test timing; new env vars `DAEMON_MAX_RETRIES`, `DAEMON_RETRY_BASE_DELAY`, `DAEMON_RETRY_MAX_JITTER` parsed in `config.ts` with safe defaults (3 / 500ms / 200ms).
- `cycle.ts` Step 3 (git export) and Step 4 (qmd index update) now wrap their async work in `withRetry`; non-transient throws propagate immediately; transient errors delay with `baseDelayMs * 2^attempt + rand(0, maxJitterMs)` before the next attempt.
- `fixtures.ts` defaults `maxRetries: 0` and `sleepFn: no-op` so existing cycle tests stay fast and deterministic.
- 16 new tests in `retry.test.ts` (classify + withRetry coverage) and 3 new tests in `cycle.test.ts` (flaky adapter succeeds on final attempt, exhausts retries, skips retry for permanent errors).

## Backoff formula

`delay = baseDelayMs * 2^attempt + Math.floor(Math.random() * (maxJitterMs + 1))`

Attempt 0 = first failure; attempt index matches the sleep count so `maxRetries: 3` means up to 4 total calls with 3 sleeps.

## Test plan

- [ ] `pnpm vitest run apps/edge-daemon/src/__tests__/retry.test.ts` — 16/16 pass
- [ ] `pnpm --filter @qmd-team-intent-kb/edge-daemon typecheck` — clean
- [ ] `pnpm --filter @qmd-team-intent-kb/edge-daemon lint` — clean
- [ ] `pnpm format:check` — clean
- [ ] `better-sqlite3` native binding failures in `cycle.test.ts`, `staleness.test.ts`, `daemon.test.ts`, `cli.test.ts` are pre-existing sandbox constraints, not regressions introduced by this PR

Closes bead qmd-team-intent-kb-1x6.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)