### PR TITLE
test(repo-resolver): fixture-based test suite for edge cases

### DIFF
--- a/packages/repo-resolver/src/__tests__/fixture-cases.test.ts
+++ b/packages/repo-resolver/src/__tests__/fixture-cases.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Fixture-based integration tests for resolveRepoContext.
+ *
+ * Each test builds a real git repository in a mkdtempSync directory, runs the
+ * resolver, and asserts the outcome. Fixtures are torn down after each test.
+ *
+ * Bead: qmd-team-intent-kb-mbd.7
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { realpathSync } from 'node:fs';
+import { basename } from 'node:path';
+import { resolveRepoContext } from '../resolver.js';
+import {
+  makeBareRepo,
+  makeNonGitDir,
+  makeNxWorkspace,
+  makeRepoDetached,
+  makeRepoNoRemote,
+  makeRepoWithPnpmWorkspace,
+  makeRepoWithRemote,
+  makeRepoWithSubmodule,
+  makeRepoWithWorktree,
+  type Fixture,
+} from './fixtures.js';
+
+// ---------------------------------------------------------------------------
+// Fixture tracking — all fixtures registered here are cleaned up afterEach.
+// ---------------------------------------------------------------------------
+
+const fixtures: Fixture[] = [];
+
+function track<T extends Fixture>(fx: T): T {
+  fixtures.push(fx);
+  return fx;
+}
+
+afterEach(() => {
+  while (fixtures.length > 0) {
+    fixtures.pop()?.cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 1: Plain repo — single git repo, single remote, normal branch
+// ---------------------------------------------------------------------------
+
+describe('fixture 1: plain repo with remote and branch', () => {
+  it('resolves repoRoot, repoName, remoteUrl, branch, and commitSha', async () => {
+    const fx = track(makeRepoWithRemote());
+    const result = await resolveRepoContext(fx.dir, { cache: null });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const ctx = result.value;
+    expect(ctx.repoRoot).toBe(realpathSync(fx.dir));
+    expect(ctx.repoName).toBe(basename(realpathSync(fx.dir)).toLowerCase());
+    expect(ctx.remoteUrl).toBe('https://github.com/acme/widget.git');
+    expect(ctx.branch).toBe('main');
+    expect(ctx.commitSha).toMatch(/^[0-9a-f]{40}$/);
+    expect(ctx.isMonorepo).toBe(false);
+    expect(ctx.workspaceRoot).toBeNull();
+    expect(ctx.workspacePackage).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 2: pnpm workspace with nested package — invoke from packages/foo
+// ---------------------------------------------------------------------------
+
+describe('fixture 2: pnpm workspace with nested package', () => {
+  it('detects isMonorepo=true and workspacePackage when invoked from inner package', async () => {
+    const fx = track(makeRepoWithPnpmWorkspace());
+    const result = await resolveRepoContext(fx.innerDir, { cache: null });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const ctx = result.value;
+    expect(ctx.isMonorepo).toBe(true);
+    expect(ctx.workspaceRoot).toBe(realpathSync(fx.dir));
+    expect(ctx.workspacePackage).toBe('@scope/inner');
+    // repoRoot still points at the git root, not the inner package.
+    expect(ctx.repoRoot).toBe(realpathSync(fx.dir));
+  });
+
+  it('detects isMonorepo=true with null workspacePackage when invoked from workspace root', async () => {
+    const fx = track(makeRepoWithPnpmWorkspace());
+    const result = await resolveRepoContext(fx.dir, { cache: null });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const ctx = result.value;
+    expect(ctx.isMonorepo).toBe(true);
+    expect(ctx.workspaceRoot).toBe(realpathSync(fx.dir));
+    // cwd === workspaceRoot so workspacePackage must be null.
+    expect(ctx.workspacePackage).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 3: nx workspace — nx.json at root + packages/* layout
+// ---------------------------------------------------------------------------
+
+describe('fixture 3: nx workspace', () => {
+  it('detects isMonorepo=true when invoked from inside packages/foo', async () => {
+    const fx = track(makeNxWorkspace());
+    const result = await resolveRepoContext(fx.innerDir, { cache: null });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const ctx = result.value;
+    expect(ctx.isMonorepo).toBe(true);
+    expect(ctx.workspaceRoot).toBe(realpathSync(fx.dir));
+    expect(ctx.workspacePackage).toBe('@nx-scope/foo');
+  });
+
+  it('detects isMonorepo=true with null workspacePackage when at nx root', async () => {
+    const fx = track(makeNxWorkspace());
+    const result = await resolveRepoContext(fx.dir, { cache: null });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const ctx = result.value;
+    expect(ctx.isMonorepo).toBe(true);
+    expect(ctx.workspaceRoot).toBe(realpathSync(fx.dir));
+    expect(ctx.workspacePackage).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 4: Detached HEAD — repo checked out at a commit (no branch)
+// ---------------------------------------------------------------------------
+
+describe('fixture 4: detached HEAD', () => {
+  it('succeeds with branch=null and a valid commitSha', async () => {
+    const fx = track(makeRepoDetached());
+    const result = await resolveRepoContext(fx.dir, { cache: null });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const ctx = result.value;
+    expect(ctx.branch).toBeNull();
+    expect(ctx.commitSha).toMatch(/^[0-9a-f]{40}$/);
+    expect(ctx.repoRoot).toBe(realpathSync(fx.dir));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 5: Bare repo — git init --bare (no working tree)
+// ---------------------------------------------------------------------------
+
+describe('fixture 5: bare repo', () => {
+  it('returns a BareRepo error', async () => {
+    const fx = track(makeBareRepo());
+    const result = await resolveRepoContext(fx.dir, { cache: null });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe('BareRepo');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 6: Non-git cwd — mkdtempSync outside any git repo
+// ---------------------------------------------------------------------------
+
+describe('fixture 6: non-git directory', () => {
+  it('returns a NotAGitRepo error with the canonical cwd', async () => {
+    const fx = track(makeNonGitDir());
+    const result = await resolveRepoContext(fx.dir, { cache: null });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe('NotAGitRepo');
+    // The error must carry the canonical cwd so callers can surface it.
+    // Guard the discriminated-union narrowing so TypeScript knows we have
+    // a NotAGitRepo variant before accessing `.cwd`.
+    if (result.error.kind !== 'NotAGitRepo') return;
+    expect(result.error.cwd).toBe(realpathSync(fx.dir));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 7: Submodule — repo with a submodule, invoked from inside it
+// ---------------------------------------------------------------------------
+
+describe('fixture 7: git submodule', () => {
+  it('resolves successfully when invoked from inside the submodule working tree', async () => {
+    const fx = track(makeRepoWithSubmodule());
+    const result = await resolveRepoContext(fx.submoduleDir, { cache: null });
+
+    // The submodule directory is a valid git working tree — the resolver
+    // should succeed and report its own repoRoot (the submodule root, not
+    // the parent repo root).
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const ctx = result.value;
+    expect(ctx.repoRoot).toBe(realpathSync(fx.submoduleDir));
+    expect(ctx.commitSha).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it('resolves the parent repo when invoked from the parent working tree root', async () => {
+    const fx = track(makeRepoWithSubmodule());
+    const result = await resolveRepoContext(fx.dir, { cache: null });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.repoRoot).toBe(realpathSync(fx.dir));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 8: Git worktree — invoke from the linked worktree
+// ---------------------------------------------------------------------------
+
+describe('fixture 8: git worktree', () => {
+  it('resolves from a linked worktree with correct branch and repoRoot', async () => {
+    const fx = track(makeRepoWithWorktree());
+    const result = await resolveRepoContext(fx.worktreeDir, { cache: null });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const ctx = result.value;
+    // The worktree's repoRoot resolves to the linked worktree directory itself.
+    expect(ctx.repoRoot).toBe(realpathSync(fx.worktreeDir));
+    expect(ctx.branch).toBe('wt-branch');
+    expect(ctx.commitSha).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it('resolves from the primary working tree independently', async () => {
+    const fx = track(makeRepoWithWorktree());
+    const resultPrimary = await resolveRepoContext(fx.dir, { cache: null });
+    const resultLinked = await resolveRepoContext(fx.worktreeDir, { cache: null });
+
+    expect(resultPrimary.ok).toBe(true);
+    expect(resultLinked.ok).toBe(true);
+    if (!resultPrimary.ok || !resultLinked.ok) return;
+
+    // Each worktree has its own branch.
+    expect(resultPrimary.value.branch).toBe('main');
+    expect(resultLinked.value.branch).toBe('wt-branch');
+    // repoRoots differ (each worktree has its own working tree root).
+    expect(resultPrimary.value.repoRoot).not.toBe(resultLinked.value.repoRoot);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fixture 9: No remote configured — git init without git remote add
+// ---------------------------------------------------------------------------
+
+describe('fixture 9: no remote configured', () => {
+  it('resolves successfully with remoteUrl=null', async () => {
+    const fx = track(makeRepoNoRemote());
+    const result = await resolveRepoContext(fx.dir, { cache: null });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const ctx = result.value;
+    expect(ctx.remoteUrl).toBeNull();
+    expect(ctx.branch).toBe('main');
+    expect(ctx.commitSha).toMatch(/^[0-9a-f]{40}$/);
+  });
+});

--- a/packages/repo-resolver/src/__tests__/fixtures.ts
+++ b/packages/repo-resolver/src/__tests__/fixtures.ts
@@ -8,18 +8,21 @@ export interface Fixture {
   cleanup: () => void;
 }
 
-function exec(cwd: string, cmd: string): void {
-  execSync(cmd, {
+/** Git environment vars to ensure CI identity is set consistently. */
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: 'Test',
+  GIT_AUTHOR_EMAIL: 'test@example.com',
+  GIT_COMMITTER_NAME: 'Test',
+  GIT_COMMITTER_EMAIL: 'test@example.com',
+};
+
+function exec(cwd: string, cmd: string): string {
+  return execSync(cmd, {
     cwd,
     stdio: 'pipe',
-    env: {
-      ...process.env,
-      GIT_AUTHOR_NAME: 'Test',
-      GIT_AUTHOR_EMAIL: 'test@example.com',
-      GIT_COMMITTER_NAME: 'Test',
-      GIT_COMMITTER_EMAIL: 'test@example.com',
-    },
-  });
+    env: GIT_ENV,
+  }).toString('utf8');
 }
 
 function makeTmp(prefix: string): Fixture {
@@ -31,6 +34,8 @@ function makeTmp(prefix: string): Fixture {
 export function makeRepoWithRemote(): Fixture {
   const fx = makeTmp('repo-resolver-plain-');
   exec(fx.dir, 'git init -q -b main');
+  exec(fx.dir, 'git config user.email test@example.com');
+  exec(fx.dir, 'git config user.name Test');
   exec(fx.dir, 'git remote add origin https://github.com/acme/widget.git');
   exec(fx.dir, 'git commit -q --allow-empty -m init');
   return fx;
@@ -40,6 +45,8 @@ export function makeRepoWithRemote(): Fixture {
 export function makeRepoNoRemote(): Fixture {
   const fx = makeTmp('repo-resolver-noremote-');
   exec(fx.dir, 'git init -q -b main');
+  exec(fx.dir, 'git config user.email test@example.com');
+  exec(fx.dir, 'git config user.name Test');
   exec(fx.dir, 'git commit -q --allow-empty -m init');
   return fx;
 }
@@ -48,6 +55,8 @@ export function makeRepoNoRemote(): Fixture {
 export function makeRepoNoCommits(): Fixture {
   const fx = makeTmp('repo-resolver-nocommits-');
   exec(fx.dir, 'git init -q -b main');
+  exec(fx.dir, 'git config user.email test@example.com');
+  exec(fx.dir, 'git config user.name Test');
   return fx;
 }
 
@@ -64,6 +73,8 @@ export function makeBareRepo(): Fixture {
 export function makeRepoDetached(): Fixture {
   const fx = makeTmp('repo-resolver-detached-');
   exec(fx.dir, 'git init -q -b main');
+  exec(fx.dir, 'git config user.email test@example.com');
+  exec(fx.dir, 'git config user.name Test');
   exec(fx.dir, 'git commit -q --allow-empty -m init');
   exec(fx.dir, 'git checkout -q --detach HEAD');
   return fx;
@@ -81,6 +92,8 @@ export function makeNonGitDir(): Fixture {
 export function makeRepoWithPnpmWorkspace(): Fixture & { innerDir: string } {
   const fx = makeTmp('repo-resolver-pnpm-');
   exec(fx.dir, 'git init -q -b main');
+  exec(fx.dir, 'git config user.email test@example.com');
+  exec(fx.dir, 'git config user.name Test');
   exec(fx.dir, 'git commit -q --allow-empty -m init');
   writeFileSync(join(fx.dir, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n');
   writeFileSync(join(fx.dir, 'package.json'), JSON.stringify({ name: 'root' }));
@@ -88,4 +101,100 @@ export function makeRepoWithPnpmWorkspace(): Fixture & { innerDir: string } {
   mkdirSync(innerDir, { recursive: true });
   writeFileSync(join(innerDir, 'package.json'), JSON.stringify({ name: '@scope/inner' }));
   return { ...fx, innerDir };
+}
+
+/**
+ * nx workspace with nx.json at root and a package under packages/foo.
+ * Invoking the resolver from inside packages/foo should detect isMonorepo=true.
+ */
+export function makeNxWorkspace(): Fixture & { innerDir: string } {
+  const fx = makeTmp('repo-resolver-nx-');
+  exec(fx.dir, 'git init -q -b main');
+  exec(fx.dir, 'git config user.email test@example.com');
+  exec(fx.dir, 'git config user.name Test');
+  exec(fx.dir, 'git commit -q --allow-empty -m init');
+  writeFileSync(join(fx.dir, 'nx.json'), JSON.stringify({ version: 2 }));
+  writeFileSync(join(fx.dir, 'package.json'), JSON.stringify({ name: 'nx-root' }));
+  const innerDir = join(fx.dir, 'packages', 'foo');
+  mkdirSync(innerDir, { recursive: true });
+  writeFileSync(join(innerDir, 'package.json'), JSON.stringify({ name: '@nx-scope/foo' }));
+  return { ...fx, innerDir };
+}
+
+/**
+ * Primary repo with a linked submodule. Returns the primary repo dir and
+ * the path inside the submodule working tree.
+ *
+ * The submodule itself is a separate git repo cloned from a local bare-style
+ * source repo so no network is needed.
+ */
+export function makeRepoWithSubmodule(): Fixture & { submoduleDir: string } {
+  // Build the sub-repo that will be used as the submodule source.
+  const subSrc = makeTmp('repo-resolver-sub-src-');
+  exec(subSrc.dir, 'git init -q -b main');
+  exec(subSrc.dir, 'git config user.email test@example.com');
+  exec(subSrc.dir, 'git config user.name Test');
+  writeFileSync(join(subSrc.dir, 'README.md'), '# sub\n');
+  exec(subSrc.dir, 'git add README.md');
+  exec(subSrc.dir, 'git commit -q -m "sub init"');
+
+  // Build the primary repo.
+  const fx = makeTmp('repo-resolver-submod-');
+  exec(fx.dir, 'git init -q -b main');
+  exec(fx.dir, 'git config user.email test@example.com');
+  exec(fx.dir, 'git config user.name Test');
+  exec(fx.dir, 'git commit -q --allow-empty -m init');
+
+  // Add the submodule (disable prompt; use file:// path).
+  exec(fx.dir, `git -c protocol.file.allow=always submodule add -q "${subSrc.dir}" vendor/sub`);
+  exec(fx.dir, 'git commit -q -m "add submodule"');
+
+  const submoduleDir = join(fx.dir, 'vendor', 'sub');
+
+  const originalCleanup = fx.cleanup;
+  return {
+    ...fx,
+    submoduleDir,
+    cleanup: () => {
+      originalCleanup();
+      subSrc.cleanup();
+    },
+  };
+}
+
+/**
+ * Primary repo with a linked worktree at a second temp directory.
+ * Returns the primary repo dir and the linked worktree dir.
+ */
+export function makeRepoWithWorktree(): Fixture & { worktreeDir: string } {
+  const fx = makeTmp('repo-resolver-wt-primary-');
+  exec(fx.dir, 'git init -q -b main');
+  exec(fx.dir, 'git config user.email test@example.com');
+  exec(fx.dir, 'git config user.name Test');
+  exec(fx.dir, 'git commit -q --allow-empty -m init');
+
+  // Create the branch that the linked worktree will check out.
+  exec(fx.dir, 'git branch wt-branch');
+
+  // The linked worktree must live outside the primary repo directory to
+  // avoid git complaining about nesting. Use a sibling tmp dir.
+  const wtDir = mkdtempSync(join(tmpdir(), 'repo-resolver-wt-linked-'));
+  exec(fx.dir, `git worktree add -q "${wtDir}" wt-branch`);
+
+  const originalCleanup = fx.cleanup;
+  return {
+    ...fx,
+    worktreeDir: wtDir,
+    cleanup: () => {
+      // Prune the worktree registration before removing the directory so git
+      // does not leave dangling metadata.
+      try {
+        exec(fx.dir, `git worktree remove --force "${wtDir}"`);
+      } catch {
+        // Best-effort; the directory will be removed below anyway.
+      }
+      rmSync(wtDir, { recursive: true, force: true });
+      originalCleanup();
+    },
+  };
 }


### PR DESCRIPTION
## Summary

- Adds 3 new fixture builders to `fixtures.ts` (`makeNxWorkspace`, `makeRepoWithSubmodule`, `makeRepoWithWorktree`) extending the existing 6, and hardens all existing builders with explicit `git config user.email/user.name` for CI identity
- Adds `fixture-cases.test.ts` with 18 assertions across all 9 fixture scenarios using real git repos built in `mkdtempSync` directories
- All 71 repo-resolver tests pass in under 3s; format, lint, and typecheck are clean

Closes bead qmd-team-intent-kb-mbd.7

## Fixtures covered

- **Fixture 1** — plain repo, single remote, normal branch: resolves `repoRoot`, `remoteUrl`, `branch`, `commitSha`
- **Fixture 2** — pnpm workspace with nested package: `isMonorepo=true`, correct `workspaceRoot`/`workspacePackage` from inner dir; `null` workspacePackage from workspace root
- **Fixture 3** — nx workspace (`nx.json` at root, `packages/foo`): `isMonorepo=true` from inner package and from root
- **Fixture 4** — detached HEAD: `branch=null`, valid `commitSha`
- **Fixture 5** — bare repo (`git init --bare`): returns `BareRepo` error
- **Fixture 6** — non-git directory: returns `NotAGitRepo` error carrying the canonical `cwd`
- **Fixture 7** — git submodule: resolver succeeds from inside submodule working tree; `repoRoot` is the submodule root, not the parent
- **Fixture 8** — git worktree (`git worktree add`): resolver succeeds from linked worktree, reports correct `branch`; primary and linked worktrees resolve independently with distinct `repoRoot` values
- **Fixture 9** — no remote configured: resolves successfully with `remoteUrl=null`

## Test plan

- [x] `pnpm --filter @qmd-team-intent-kb/repo-resolver test` — 71 tests pass, ~2.5s
- [x] `pnpm --filter @qmd-team-intent-kb/repo-resolver typecheck` — clean
- [x] `pnpm --filter @qmd-team-intent-kb/repo-resolver lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm validate` — repo-resolver tests pass; pre-existing `better-sqlite3` native binding failure in sandbox environment causes unrelated packages to fail (noted in bead spec, confirmed not introduced by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)