### PR TITLE
feat(edge-daemon): HTTP health endpoint (/healthz + /last-cycle)

### DIFF
--- a/apps/edge-daemon/src/__tests__/health-server.test.ts
+++ b/apps/edge-daemon/src/__tests__/health-server.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { request } from 'node:http';
+import { HealthServer } from '../health-server.js';
+import type { DaemonState, CycleResult } from '../types.js';
+
+function httpGet(port: number, path: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = request({ hostname: '127.0.0.1', port, path, method: 'GET' }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (chunk: Buffer) => chunks.push(chunk));
+      res.on('end', () => {
+        resolve({
+          status: res.statusCode ?? 0,
+          body: Buffer.concat(chunks).toString('utf8'),
+        });
+      });
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+const CYCLE_RESULT: CycleResult = {
+  startedAt: '2026-01-15T10:00:00.000Z',
+  completedAt: '2026-01-15T10:00:01.000Z',
+  ingest: { ingested: 2, errors: [] },
+  curation: null,
+  staleness: null,
+  export: null,
+  indexUpdate: null,
+};
+
+describe('HealthServer', () => {
+  let server: HealthServer;
+  let state: DaemonState;
+  let lastCycle: CycleResult | null;
+
+  beforeEach(async () => {
+    state = 'running';
+    lastCycle = null;
+
+    server = new HealthServer({
+      port: 0,
+      getState: () => state,
+      getLastCycleResult: () => lastCycle,
+    });
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  describe('/healthz', () => {
+    it('returns 200 with status ok while running', async () => {
+      state = 'running';
+      const res = await httpGet(server.port, '/healthz');
+      expect(res.status).toBe(200);
+      expect(JSON.parse(res.body)).toEqual({ status: 'ok' });
+    });
+
+    it('returns 503 with status stopping while stopping', async () => {
+      state = 'stopping';
+      const res = await httpGet(server.port, '/healthz');
+      expect(res.status).toBe(503);
+      expect(JSON.parse(res.body)).toEqual({ status: 'stopping' });
+    });
+
+    it('returns 200 for idle state (not stopping)', async () => {
+      state = 'idle';
+      const res = await httpGet(server.port, '/healthz');
+      expect(res.status).toBe(200);
+      expect(JSON.parse(res.body)).toEqual({ status: 'ok' });
+    });
+  });
+
+  describe('/last-cycle', () => {
+    it('returns 404 when no cycle has run', async () => {
+      lastCycle = null;
+      const res = await httpGet(server.port, '/last-cycle');
+      expect(res.status).toBe(404);
+      expect(JSON.parse(res.body)).toEqual({ error: 'no cycle has run' });
+    });
+
+    it('returns 200 with serialized CycleResult when a cycle has run', async () => {
+      lastCycle = CYCLE_RESULT;
+      const res = await httpGet(server.port, '/last-cycle');
+      expect(res.status).toBe(200);
+      expect(JSON.parse(res.body)).toEqual(CYCLE_RESULT);
+    });
+
+    it('reflects the most recent cycle result', async () => {
+      lastCycle = CYCLE_RESULT;
+      const res1 = await httpGet(server.port, '/last-cycle');
+      expect(JSON.parse(res1.body)).toEqual(CYCLE_RESULT);
+
+      const updated: CycleResult = { ...CYCLE_RESULT, startedAt: '2026-01-16T00:00:00.000Z' };
+      lastCycle = updated;
+      const res2 = await httpGet(server.port, '/last-cycle');
+      expect(JSON.parse(res2.body)).toEqual(updated);
+    });
+  });
+
+  describe('unknown routes', () => {
+    it('returns 404 for an unknown path', async () => {
+      const res = await httpGet(server.port, '/unknown');
+      expect(res.status).toBe(404);
+      expect(JSON.parse(res.body)).toEqual({ error: 'not found' });
+    });
+
+    it('returns 404 for root path', async () => {
+      const res = await httpGet(server.port, '/');
+      expect(res.status).toBe(404);
+      expect(JSON.parse(res.body)).toEqual({ error: 'not found' });
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('stop() resolves cleanly', async () => {
+      const srv = new HealthServer({
+        port: 0,
+        getState: () => 'running' as DaemonState,
+        getLastCycleResult: () => null,
+      });
+      await srv.start();
+      await expect(srv.stop()).resolves.toBeUndefined();
+    });
+
+    it('stop() on a never-started server resolves cleanly', async () => {
+      const srv = new HealthServer({
+        port: 0,
+        getState: () => 'running' as DaemonState,
+        getLastCycleResult: () => null,
+      });
+      await expect(srv.stop()).resolves.toBeUndefined();
+    });
+
+    it('exposes the assigned port after start', async () => {
+      expect(server.port).toBeGreaterThan(0);
+    });
+  });
+});

--- a/apps/edge-daemon/src/config.ts
+++ b/apps/edge-daemon/src/config.ts
@@ -32,6 +32,7 @@ const DEFAULTS = {
  *   DAEMON_EXPORT_TARGET   — export target identifier
  *   DAEMON_SUPERSESSION_THRESHOLD — Jaccard threshold (default 0.6)
  *   DAEMON_PID_FILE        — PID file path
+ *   DAEMON_HEALTH_PORT     — HTTP health server port (default 0 = disabled)
  */
 export function loadDaemonConfig(
   env: Record<string, string | undefined> = process.env,
@@ -67,6 +68,7 @@ export function loadDaemonConfig(
       env['DAEMON_SUPERSESSION_THRESHOLD'] ?? String(DEFAULTS.supersessionThreshold),
     ),
     pidFilePath: env['DAEMON_PID_FILE'] ?? resolveTeamKbPath('daemon.pid'),
+    healthPort: parseNonNegativeInt(env['DAEMON_HEALTH_PORT'], 0),
   };
 }
 
@@ -74,6 +76,13 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (value === undefined) return fallback;
   const parsed = parseInt(value, 10);
   if (Number.isNaN(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+function parseNonNegativeInt(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 0) return fallback;
   return parsed;
 }
 

--- a/apps/edge-daemon/src/daemon.ts
+++ b/apps/edge-daemon/src/daemon.ts
@@ -7,6 +7,7 @@ import type {
 } from './types.js';
 import { acquireLock, releaseLock } from './lock.js';
 import { runCycle } from './cycle.js';
+import { HealthServer } from './health-server.js';
 
 /**
  * Edge Daemon — polls the spool directory, runs curation, and syncs the index.
@@ -24,6 +25,7 @@ export class EdgeDaemon {
   private _cycleInFlight = false;
   private _stopResolve: (() => void) | null = null;
   private readonly _signalHandlers: Array<{ signal: NodeJS.Signals; handler: () => void }> = [];
+  private _healthServer: HealthServer | null = null;
 
   constructor(
     private readonly config: DaemonConfig,
@@ -44,7 +46,7 @@ export class EdgeDaemon {
    *
    * @throws Error if the lock cannot be acquired (another instance running).
    */
-  start(): void {
+  async start(): Promise<void> {
     if (this._state !== 'idle') {
       throw new Error(`Cannot start daemon in state '${this._state}'`);
     }
@@ -57,6 +59,17 @@ export class EdgeDaemon {
     }
 
     this._state = 'running';
+
+    if ((this.config.healthPort ?? 0) > 0) {
+      this._healthServer = new HealthServer({
+        port: this.config.healthPort!,
+        getState: () => this._state,
+        getLastCycleResult: () => this._lastCycleResult,
+      });
+      await this._healthServer.start();
+      this.logger.info(`Health server listening on port ${this._healthServer.port}`);
+    }
+
     this.registerSignalHandlers();
     this.logger.info(
       `Daemon started (tenant=${this.config.tenantId}, poll=${this.config.pollIntervalMs}ms)`,
@@ -92,6 +105,12 @@ export class EdgeDaemon {
     }
 
     this.removeSignalHandlers();
+
+    if (this._healthServer !== null) {
+      await this._healthServer.stop();
+      this._healthServer = null;
+    }
+
     releaseLock(this.config.pidFilePath);
     this._state = 'stopped';
     this.logger.info('Daemon stopped');

--- a/apps/edge-daemon/src/daemon.ts
+++ b/apps/edge-daemon/src/daemon.ts
@@ -46,7 +46,7 @@ export class EdgeDaemon {
    *
    * @throws Error if the lock cannot be acquired (another instance running).
    */
-  async start(): Promise<void> {
+  start(): void {
     if (this._state !== 'idle') {
       throw new Error(`Cannot start daemon in state '${this._state}'`);
     }
@@ -66,8 +66,13 @@ export class EdgeDaemon {
         getState: () => this._state,
         getLastCycleResult: () => this._lastCycleResult,
       });
-      await this._healthServer.start();
-      this.logger.info(`Health server listening on port ${this._healthServer.port}`);
+      this._healthServer
+        .start()
+        .then(() => this.logger.info(`Health server listening on port ${this._healthServer!.port}`))
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          this.logger.error(`Health server failed to start: ${msg}`);
+        });
     }
 
     this.registerSignalHandlers();

--- a/apps/edge-daemon/src/health-server.ts
+++ b/apps/edge-daemon/src/health-server.ts
@@ -1,0 +1,82 @@
+import { createServer, type Server } from 'node:http';
+import type { CycleResult, DaemonState } from './types.js';
+
+export interface HealthServerOptions {
+  port: number;
+  getState: () => DaemonState;
+  getLastCycleResult: () => CycleResult | null;
+}
+
+export class HealthServer {
+  private readonly _options: HealthServerOptions;
+  private _server: Server | null = null;
+  private _assignedPort = 0;
+
+  constructor(options: HealthServerOptions) {
+    this._options = options;
+  }
+
+  get port(): number {
+    return this._assignedPort;
+  }
+
+  start(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const server = createServer((req, res) => {
+        const url = req.url ?? '/';
+
+        if (url === '/healthz') {
+          const state = this._options.getState();
+          const stopping = state === 'stopping';
+          const statusCode = stopping ? 503 : 200;
+          const body = JSON.stringify({ status: stopping ? 'stopping' : 'ok' });
+          res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+          res.end(body);
+          return;
+        }
+
+        if (url === '/last-cycle') {
+          const result = this._options.getLastCycleResult();
+          if (result === null) {
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'no cycle has run' }));
+          } else {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(result, null, 2));
+          }
+          return;
+        }
+
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+      });
+
+      server.once('error', reject);
+
+      server.listen(this._options.port, '127.0.0.1', () => {
+        const addr = server.address();
+        this._assignedPort =
+          typeof addr === 'object' && addr !== null ? addr.port : this._options.port;
+        this._server = server;
+        resolve();
+      });
+    });
+  }
+
+  stop(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (this._server === null) {
+        resolve();
+        return;
+      }
+      this._server.close((err) => {
+        if (err) {
+          reject(err);
+        } else {
+          this._server = null;
+          resolve();
+        }
+      });
+    });
+  }
+}

--- a/apps/edge-daemon/src/index.ts
+++ b/apps/edge-daemon/src/index.ts
@@ -15,5 +15,7 @@ export { ConsoleDaemonLogger, NullLogger } from './health.js';
 export { runCycle } from './cycle.js';
 export { runStalenessSweep } from './staleness.js';
 export { EdgeDaemon } from './daemon.js';
+export { HealthServer } from './health-server.js';
+export type { HealthServerOptions } from './health-server.js';
 export { writeFeedback, readRecentFeedback, getFeedbackPath } from './feedback.js';
 export type { FeedbackEntry } from './feedback.js';

--- a/apps/edge-daemon/src/types.ts
+++ b/apps/edge-daemon/src/types.ts
@@ -36,6 +36,8 @@ export interface DaemonConfig {
   supersessionThreshold: number;
   /** PID file path for locking. Default ~/.teamkb/daemon.pid. */
   pidFilePath: string;
+  /** HTTP health server port. 0 = disabled. Default 0. */
+  healthPort?: number;
   /** Injectable clock for deterministic tests. */
   nowFn?: () => string;
 }


### PR DESCRIPTION
## Summary

- Adds `HealthServer` class (`apps/edge-daemon/src/health-server.ts`) — pure Node `http`, no Fastify; exposes `/healthz` (200 ok / 503 stopping) and `/last-cycle` (200 CycleResult JSON / 404 no cycle yet)
- Wires `HealthServer` into `EdgeDaemon.start()` / `stop()` lifecycle — server starts after lock acquisition, stops before lock release
- Parses `DAEMON_HEALTH_PORT` env in `loadDaemonConfig()` — `0` (default) disables the server entirely
- Extends `DaemonConfig` with optional `healthPort?: number` field
- Exports `HealthServer` and `HealthServerOptions` from the package index

## Test plan

- [x] `/healthz` returns `200 { "status": "ok" }` when daemon state is `running` or `idle`
- [x] `/healthz` returns `503 { "status": "stopping" }` when daemon state is `stopping`
- [x] `/last-cycle` returns `404` when no cycle has run
- [x] `/last-cycle` returns `200` with serialized `CycleResult` after a cycle runs
- [x] `/last-cycle` reflects the latest result when the getter changes
- [x] Unknown routes return `404 { "error": "not found" }`
- [x] `stop()` resolves cleanly; `stop()` on a never-started server is a no-op
- [x] Ephemeral port (`port: 0`) is used in all tests; actual assigned port exposed via `server.port`
- [x] 11/11 new tests pass; typecheck and lint clean; prettier formatted before commit

Closes bead qmd-team-intent-kb-1x6.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)