### PR TITLE
chore(quality): consolidate shared type definitions

### DIFF
--- a/packages/claude-runtime/src/secrets/content-classifier.ts
+++ b/packages/claude-runtime/src/secrets/content-classifier.ts
@@ -1,9 +1,16 @@
 import { scanForSecrets } from './secret-scanner.js';
 import { SECRET_PATTERNS, PII_PATTERNS } from './patterns.js';
+import type { Sensitivity } from '@qmd-team-intent-kb/schema';
 import type { SecretMatch } from '../types.js';
 
-/** Sensitivity levels ordered from most to least restrictive */
-export type SensitivityLevel = 'restricted' | 'confidential' | 'internal' | 'public';
+/**
+ * Sensitivity levels ordered from most to least restrictive.
+ * Alias for {@link Sensitivity} from `@qmd-team-intent-kb/schema` — the two
+ * types are structurally identical and consolidated here.
+ *
+ * @deprecated Use `Sensitivity` from `@qmd-team-intent-kb/schema` directly.
+ */
+export type SensitivityLevel = Sensitivity;
 
 /** Result of content classification */
 export interface ContentClassification {
@@ -52,7 +59,7 @@ export function classifyContent(content: string): ContentClassification {
     matchedPatterns.push('internal-path');
   }
 
-  let sensitivityLevel: SensitivityLevel = 'public';
+  let sensitivityLevel: Sensitivity = 'public';
 
   if (hasInternalPaths) {
     sensitivityLevel = 'internal';

--- a/packages/policy-engine/src/rules/sensitivity-gate-rule.ts
+++ b/packages/policy-engine/src/rules/sensitivity-gate-rule.ts
@@ -1,8 +1,9 @@
 import { classifyContent } from '@qmd-team-intent-kb/claude-runtime';
-import type { SensitivityLevel } from '@qmd-team-intent-kb/claude-runtime';
 import { Sensitivity } from '@qmd-team-intent-kb/schema';
 import type { MemoryCandidate, PolicyRule } from '@qmd-team-intent-kb/schema';
 import type { EvaluationContext, RuleResult } from '../types.js';
+
+type SensitivityLevel = Sensitivity;
 
 const VALID_LEVELS = new Set<string>(Sensitivity.options);
 


### PR DESCRIPTION
## Critical Assessment of Type Placement Hygiene

Overall the codebase has strong discipline: domain types live in `packages/schema`, infrastructure primitives in `packages/common`, and app-local types stay in their respective `types.ts` files. The dependency graph invariant (schema → common → packages → apps) is consistently respected.

**The single HIGH-confidence violation** was `SensitivityLevel` in `packages/claude-runtime/src/secrets/content-classifier.ts` — a hand-written string union `'restricted' | 'confidential' | 'internal' | 'public'` that is structurally identical to the `Sensitivity` Zod enum already defined in `packages/schema/src/enums.ts`. Worse, `packages/policy-engine/src/rules/sensitivity-gate-rule.ts` imported **both** `SensitivityLevel` from `claude-runtime` and the Zod `Sensitivity` from `schema` in the same file (using `.options` for runtime validation and `SensitivityLevel` for the type annotation), proving the divergence was unintentional.

## Moves / Consolidations / Skips

| Type | Action | Reason |
|---|---|---|
| `SensitivityLevel` (`claude-runtime`) | **MERGED** into `Sensitivity` (`schema`) via alias `type SensitivityLevel = Sensitivity` | Identical shape; `claude-runtime` already depends on `schema`; zero dep-graph impact |
| `sensitivity-gate-rule.ts` | **Updated** to drop `SensitivityLevel` import from `claude-runtime`; local alias keeps readability | Eliminates the cross-package redundancy at the callsite |
| `GitContext` (`claude-runtime`) vs `RepoContext` (`repo-resolver`) | **SKIP** | Different shapes — `GitContext` is a flattened capture-time struct with `tenantId`/`userName`; `RepoContext` is the full resolver output with `isMonorepo`/`workspaceRoot`. Intentionally different. |
| `DaemonLogger` (`edge-daemon`) | **SKIP** | App-local interface; nothing in packages uses it |
| `CurationResult.outcome` vs `PipelineResult.outcome` literal unions | **SKIP** | Different domains; `CurationResult` is the curator's public API, `PipelineResult` is the policy-engine's internal result |
| All `reporting/src/types.ts` interfaces | **SKIP** | Pure reporting-layer shapes; no structural overlap with schema types |
| `RuleResult`, `EvaluationContext`, `PipelineResult` (`policy-engine`) | **SKIP** | Policy-engine–specific; correct location |

## Deprecation / Follow-Up Beads

- `SensitivityLevel` is retained as a `@deprecated` re-export from `claude-runtime/src/index.ts` for backward compatibility. A follow-up bead should delete the alias once all callers (currently only the `policy-engine` local alias, which already migrated) are confirmed gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)