### PR TITLE
chore(quality): remove defensive try/catch that hides errors

### DIFF
--- a/apps/mcp-server/src/tools/import.ts
+++ b/apps/mcp-server/src/tools/import.ts
@@ -55,13 +55,8 @@ export async function importFiles(
   const base = input.basePath ?? process.cwd();
   const pattern = join(base, input.glob);
 
-  let matchedFiles: string[];
-  try {
-    // Use fast-glob which works in Node 20+ (node:fs/promises glob requires Node 22)
-    matchedFiles = await fg(pattern, { onlyFiles: true, absolute: true });
-  } catch {
-    matchedFiles = [];
-  }
+  // Use fast-glob which works in Node 20+ (node:fs/promises glob requires Node 22)
+  const matchedFiles = await fg(pattern, { onlyFiles: true, absolute: true });
 
   const outcomes: FileImportOutcome[] = [];
   let queued = 0;


### PR DESCRIPTION
## Summary

- Removes the `try/catch` in `importFiles()` that silently swallowed fast-glob errors and fell back to `matchedFiles = []`
- All other try/catch blocks in the codebase are **KEEP** — they either back the Result pattern at system boundaries, isolate steps in a multi-step daemon cycle, probe for optional capabilities (FTS5, qmd binary), or handle expected I/O failures (missing directories, stale PID files)
- Net: **before 56 try/catch blocks, after 55** (1 removed)

---

## Full try/catch classification table

| File | Decision | Reason |
|---|---|---|
| `packages/qmd-adapter/src/health/health-check.ts` | KEEP | External subprocess — executor.execute() can throw on spawn failure; health check must never throw |
| `packages/qmd-adapter/src/executor/real-executor.ts` (execute) | KEEP | subprocess exec; maps non-zero exit codes to structured result |
| `packages/qmd-adapter/src/executor/real-executor.ts` (isAvailable) | KEEP | Subprocess probe; boolean return is the contract |
| `packages/store/src/repositories/memory-repository.ts` | KEEP | FTS5 capability probe; SQLite throws when virtual table absent |
| `packages/store/src/database.ts` | KEEP | Best-effort chmod; not supported on all platforms |
| `packages/claude-runtime/src/capture/git-context.ts` | KEEP | External git subprocess; null return on failure is the contract |
| `packages/repo-resolver/src/monorepo.ts` | KEEP | fs + JSON.parse on user files; null return is the contract |
| `packages/repo-resolver/src/tenant.ts` | KEEP | fs + JSON.parse on config file; null return is the contract |
| `packages/repo-resolver/src/resolver.ts` | KEEP | Result-pattern boundary — converts `realpath` I/O exception to typed `ResolverError` |
| `packages/claude-runtime/src/spool/failure-bucket.ts` | KEEP | Result-pattern boundary — fs write; error returned to caller |
| `packages/claude-runtime/src/spool/redaction-audit.ts` | KEEP | Result-pattern boundary — fs write; error returned to caller |
| `packages/claude-runtime/src/spool/spool-reader.ts` (readSpoolFile) | KEEP | Result-pattern boundary — fs read + JSON.parse on user spool files |
| `packages/claude-runtime/src/spool/spool-reader.ts` (listSpoolFiles) | KEEP | Result-pattern boundary — fs readdir |
| `packages/claude-runtime/src/spool/spool-writer.ts` (outer) | KEEP | Result-pattern boundary — fs write |
| `packages/claude-runtime/src/spool/spool-writer.ts` (inner chmod) | KEEP | Best-effort chmod; not supported on all platforms |
| `apps/api/src/routes/candidates.ts` (×3 handlers) | KEEP | Converts `ApiError` domain exceptions to HTTP status codes before Fastify's generic 500 handler |
| `apps/api/src/routes/memories.ts` (×3 handlers) | KEEP | Same `ApiError` → HTTP translation pattern |
| `apps/api/src/routes/policies.ts` (×5 handlers) | KEEP | Same `ApiError` → HTTP translation pattern |
| `apps/api/src/routes/search.ts` | KEEP | Same `ApiError` → HTTP translation pattern |
| `apps/api/src/services/health-service.ts` | KEEP | DB probe; degraded status is the contract |
| `apps/mcp-server/src/index.ts` (shutdown) | KEEP | Process exit handler — errors logged, exit(1) |
| `apps/mcp-server/src/tools/import.ts` (glob) | **REMOVED** | Swallowed fast-glob errors silently; callers need to know the pattern was invalid |
| `apps/mcp-server/src/tools/import.ts` (readFile per-file) | KEEP | Per-file failure reported in outcome; batch continues |
| `apps/mcp-server/src/tools/sync.ts` (runQmdEmbed) | KEEP | Subprocess exec — rethrows with context |
| `apps/mcp-server/src/tools/sync.ts` (isQmdAvailable) | KEEP | Binary probe; boolean return is the contract |
| `apps/mcp-server/src/tools/transition.ts` | KEEP | try/finally only — ensures db.close(); no error swallowing |
| `apps/mcp-server/src/tools/status.ts` (readFeedback readdirSync) | KEEP | Directory may not exist yet; empty-array return is the contract |
| `apps/mcp-server/src/tools/status.ts` (readFeedback readFileSync) | KEEP | Skip corrupt feedback files; observability tool must not crash |
| `apps/mcp-server/src/tools/status.ts` (getStatus outer) | KEEP | DB may not exist yet on fresh install; empty counts is the contract |
| `apps/edge-daemon/src/daemon.ts` (executeCycle) | KEEP | Last-resort daemon resilience; runCycle already isolates each step |
| `apps/edge-daemon/src/daemon.ts` (runOnce) | KEEP | try/finally only — ensures _cycleInFlight flag reset |
| `apps/edge-daemon/src/cycle.ts` (isMemoryCaptureEnabled) | KEEP | Config file may be absent/corrupt; safe default is the contract |
| `apps/edge-daemon/src/cycle.ts` (repo-resolver) | KEEP | Graceful degradation: resolver failure disables scope-filtering for this cycle |
| `apps/edge-daemon/src/cycle.ts` (ingest step) | KEEP | Step isolation — daemon must continue to next step |
| `apps/edge-daemon/src/cycle.ts` (curation step) | KEEP | Step isolation |
| `apps/edge-daemon/src/cycle.ts` (curation feedback write) | KEEP | Best-effort feedback write; curation result is not affected |
| `apps/edge-daemon/src/cycle.ts` (staleness step) | KEEP | Step isolation |
| `apps/edge-daemon/src/cycle.ts` (export step) | KEEP | Step isolation |
| `apps/edge-daemon/src/cycle.ts` (index-update step) | KEEP | Step isolation |
| `apps/edge-daemon/src/staleness.ts` (per-memory) | KEEP | Per-record failure should not stop the sweep |
| `apps/edge-daemon/src/feedback.ts` (readdirSync) | KEEP | Directory may not exist yet |
| `apps/edge-daemon/src/feedback.ts` (readFileSync per-file) | KEEP | Skip corrupt feedback files |
| `apps/edge-daemon/src/feedback.ts` (pruneFeedbackFiles) | KEEP | Best-effort pruning; bounded directory is not critical |
| `apps/edge-daemon/src/lock.ts` (readPidFile) | KEEP | fs read; file may have been removed between existsSync and read |
| `apps/edge-daemon/src/lock.ts` (isProcessRunning) | KEEP | `process.kill(pid, 0)` throws ESRCH when pid is gone; that's the detection mechanism |
| `apps/edge-daemon/src/main.ts` | KEEP | Config load failure → process.exit(1) |
| `apps/edge-daemon/src/cli.ts` (cmdStart) | KEEP | Converts thrown Error to exit code 1 |
| `apps/edge-daemon/src/cli.ts` (cmdStop SIGTERM) | KEEP | `process.kill` can throw EPERM; converts to exit code 1 with message |
| `apps/edge-daemon/src/cli.ts` (cmdRunOnce) | KEEP | Converts thrown Error to exit code 1 |
| Test files (various) | KEEP | Test infrastructure: cleanup in afterEach, expect-throw assertions |

---

## Critical assessment of error-handling style

**What's working well:** The codebase uses the `Result<T, E>` pattern consistently at spool/store boundaries (failure-bucket, spool-reader, spool-writer, redaction-audit, resolver). These are correct and should not be changed. The daemon's step-isolation pattern (each pipeline step catches its own errors and records them in `CycleResult`) is also sound — it ensures a broken export or failed qmd index update does not abort the entire cycle, which is the right behaviour for a background daemon.

**One genuine hide:** The removed glob catch was the only case where an exception was silently converted to a semantically incorrect empty result. The caller (MCP `teamkb_import` tool) would report `queued: 0, failed: 0` even when the glob pattern itself was malformed — the user would see a success-looking response with no files processed.

**Type safety:** All `catch (e)` blocks already narrow correctly via `e instanceof Error ? e.message : String(e)`. `strict: true` in tsconfig.base.json enables `useUnknownInCatchVariables`, so explicit `: unknown` annotations would be redundant.

**Mild concern — `status.ts` / `feedback.ts` JSON.parse without validation:** The `readFeedback` functions call `JSON.parse(line) as FeedbackEntry` without Zod validation. This is silent type-casting of potentially corrupt data. Not a try/catch issue, but worth noting as a future hardening opportunity.

---

## Propagation changes that affect observability

**`importFiles()` in `apps/mcp-server/src/tools/import.ts`:** If fast-glob throws (e.g., invalid glob syntax), the error now propagates to the MCP tool handler. The MCP SDK will surface it as a tool error response to the Claude Code client. Previously it produced a silent `{ queued: 0, failed: 0 }` success response. **Operators should be aware:** any Claude Code session calling `teamkb_import` with a syntactically invalid glob pattern will now receive an explicit error rather than a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)