### PR TITLE
fix(ci): restore Gemini review prompt + MCP server stripped by PR #34

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -4,8 +4,6 @@
 # Requires these GitHub repo variables (set via scripts/gcp-setup.sh):
 #   WIF_PROVIDER, WIF_SERVICE_ACCOUNT, GCP_PROJECT_ID,
 #   GOOGLE_CLOUD_LOCATION, GOOGLE_GENAI_USE_VERTEXAI
-#
-# Copy this file to .github/workflows/gemini-review.yml in each wild-* repo.
 
 name: Gemini Code Review
 
@@ -19,15 +17,27 @@ permissions:
   pull-requests: write
   id-token: write # Required for WIF
 
+concurrency:
+  group: 'gemini-review-${{ github.event.pull_request.number }}'
+  cancel-in-progress: true
+
 jobs:
   gemini-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 7
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: google-github-actions/run-gemini-cli@v0
+      - name: 'Gemini PR Review'
+        uses: google-github-actions/run-gemini-cli@v0
+        env:
+          GITHUB_TOKEN: '${{ github.token }}'
+          ISSUE_TITLE: '${{ github.event.pull_request.title }}'
+          ISSUE_BODY: '${{ github.event.pull_request.body }}'
+          PULL_REQUEST_NUMBER: '${{ github.event.pull_request.number }}'
+          REPOSITORY: '${{ github.repository }}'
         with:
           gcp_workload_identity_provider: ${{ vars.WIF_PROVIDER }}
           gcp_service_account: ${{ vars.WIF_SERVICE_ACCOUNT }}
@@ -35,14 +45,32 @@ jobs:
           gcp_location: ${{ vars.GOOGLE_CLOUD_LOCATION }}
           use_vertex_ai: ${{ vars.GOOGLE_GENAI_USE_VERTEXAI }}
           gemini_model: gemini-2.5-pro
-          settings: |
+          workflow_name: 'gemini-review'
+          prompt: '/gemini-review'
+          settings: |-
             {
+              "model": {
+                "maxSessionTurns": 25
+              },
+              "mcpServers": {
+                "github": {
+                  "command": "docker",
+                  "args": [
+                    "run", "-i", "--rm",
+                    "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+                    "ghcr.io/github/github-mcp-server:v0.27.0"
+                  ],
+                  "includeTools": [
+                    "add_comment_to_pending_review",
+                    "pull_request_read",
+                    "pull_request_review_write"
+                  ],
+                  "env": {
+                    "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+                  }
+                }
+              },
               "tools": {
-                "includeTools": [
-                  "add_comment_to_pending_review",
-                  "pull_request_read",
-                  "pull_request_review_write"
-                ],
                 "core": [
                   "run_shell_command(cat)",
                   "run_shell_command(echo)",


### PR DESCRIPTION
## Summary
- PR #34 migrated to shared wild-ecosystem GCP project but inadvertently stripped the `prompt:` input and `mcpServers.github` config. Every `gemini-review` SUCCESS since has been a ghost green light — zero review bodies, zero inline comments.
- Restores the working template from 6e25c27 (pre-#34) while keeping the wild-ecosystem WIF bindings from #34.

## Changes
- Added `prompt: '/gemini-review'`
- Added `mcpServers.github` with `add_comment_to_pending_review`, `pull_request_read`, `pull_request_review_write`
- Added `env` block the MCP server needs (`GITHUB_TOKEN`, PR number, title, body, repo)
- Added concurrency group + 7-min timeout
- Set `"maxSessionTurns": 25` per the pre-#34 settings

Closes bead qmd-team-intent-kb-y6i.

## Test plan
- [x] yaml lints clean (workflow syntax)
- [ ] On merge, subsequent PRs will receive actual Gemini review bodies. Verify on next PR.