### PR TITLE
fix(edge-daemon): move pino-pretty to dependencies (prod crash fix)

### DIFF
--- a/apps/edge-daemon/package.json
+++ b/apps/edge-daemon/package.json
@@ -27,10 +27,10 @@
     "@qmd-team-intent-kb/git-exporter": "workspace:*",
     "@qmd-team-intent-kb/qmd-adapter": "workspace:*",
     "@qmd-team-intent-kb/repo-resolver": "workspace:*",
-    "pino": "^9.0.0"
+    "pino": "^9.0.0",
+    "pino-pretty": "^13.0.0"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.0",
-    "pino-pretty": "^13.0.0"
+    "@types/better-sqlite3": "^7.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,13 +104,13 @@ importers:
       pino:
         specifier: ^9.0.0
         version: 9.14.0
+      pino-pretty:
+        specifier: ^13.0.0
+        version: 13.1.3
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.0
         version: 7.6.13
-      pino-pretty:
-        specifier: ^13.0.0
-        version: 13.1.3
 
   apps/git-exporter:
     dependencies:


### PR DESCRIPTION
## Summary
- `PinoDaemonLogger.buildPino()` requires \`pino-pretty\` at runtime when \`DAEMON_LOG_PRETTY=1\`. In devDependencies it gets pruned by \`pnpm deploy --prod\` (used by the Dockerfile), so any production operator setting that env crashes the process.
- Fix: promote pino-pretty to dependencies. ~30KB package — trivial cost vs a production crash.

Closes bead qmd-team-intent-kb-aq7.

## Test plan
- [x] \`pnpm install\` regenerates lockfile cleanly
- [ ] CI validate green