### PR TITLE
feat(edge-daemon): configurable health-server bind host (DAEMON_HEALTH_HOST)

### DIFF
--- a/000-docs/027-OD-OPSM-edge-daemon-runbook.md
+++ b/000-docs/027-OD-OPSM-edge-daemon-runbook.md
@@ -153,6 +153,8 @@ Source: `apps/edge-daemon/src/config.ts`
 | `DAEMON_EXPORT_TARGET`          | No       | `kb-export-default`                | Export target identifier passed to git-exporter.                                        |
 | `DAEMON_SUPERSESSION_THRESHOLD` | No       | `0.6`                              | Jaccard similarity threshold above which a new candidate supersedes an existing memory. |
 | `DAEMON_PID_FILE`               | No       | `~/.qmd-team-intent-kb/daemon.pid` | Path of the PID lock file. Must be writable by the daemon user.                         |
+| `DAEMON_HEALTH_PORT`            | No       | `0` (disabled)                     | Port for the embedded HTTP health server. 0 = disabled.                                 |
+| `DAEMON_HEALTH_HOST`            | No       | `127.0.0.1`                        | Bind host for the HTTP health server. Set to `0.0.0.0` inside Docker/Kubernetes.        |
 
 `DAEMON_TENANT_ID` is the only required variable. The daemon exits immediately
 with code 1 if it is absent.
@@ -172,6 +174,11 @@ subcommand and a PID lock file. Pick the check that fits your environment.
 Set `DAEMON_HEALTH_PORT` to a non-zero port to enable the embedded HTTP
 server. Default is `0` (disabled).
 
+| Variable             | Default     | Description                                                                     |
+| -------------------- | ----------- | ------------------------------------------------------------------------------- |
+| `DAEMON_HEALTH_PORT` | `0` (off)   | Port for the embedded HTTP health server. Set to a non-zero value to enable it. |
+| `DAEMON_HEALTH_HOST` | `127.0.0.1` | Host/address the health server binds to (see trade-off below).                  |
+
 | Route             | Running                    | Stopping                      | No cycle yet                     |
 | ----------------- | -------------------------- | ----------------------------- | -------------------------------- |
 | `GET /healthz`    | `200` `{"status":"ok"}`    | `503` `{"status":"stopping"}` | `200` `{"status":"ok"}`          |
@@ -181,14 +188,49 @@ server. Default is `0` (disabled).
 # Enable on install
 echo "DAEMON_HEALTH_PORT=9100" >> /etc/edge-daemon.env
 
-# Liveness probe
+# Liveness probe (default loopback bind)
 curl -fsS http://127.0.0.1:9100/healthz
 ```
 
-Unknown routes return `404 {"error":"not found"}`. The server binds
-`127.0.0.1` by default — inside Docker/Kubernetes you'll need to either
-port-forward via `docker run -p` or make the bind host configurable (see
-follow-up work in bead `qmd-team-intent-kb-dwe`).
+Unknown routes return `404 {"error":"not found"}`.
+
+#### `127.0.0.1` vs `0.0.0.0` — bind host trade-off
+
+The default bind host is `127.0.0.1` (loopback). This means the health
+endpoint is reachable only from within the same host — it is not accessible
+from other machines or from outside a container. This is the safest default
+for bare-metal and VM deployments where exposing an unauthenticated HTTP
+endpoint on a network interface would be undesirable.
+
+Inside a **Docker container** or **Kubernetes pod**, `127.0.0.1` is the
+container's own loopback interface. External liveness/readiness probes
+issued by the kubelet or Docker health-check mechanisms cannot reach it.
+The Dockerfile therefore sets `ENV DAEMON_HEALTH_HOST=0.0.0.0` so the
+server binds all container interfaces by default. Map the port to the host
+with `-p 9100:9100` (Docker) or a `containerPort` / `livenessProbe.httpGet`
+declaration (Kubernetes).
+
+On bare-metal or VM deployments where `DAEMON_HEALTH_HOST` is unset (or set
+to the empty string), the daemon falls back to `127.0.0.1` — existing
+behaviour is fully preserved.
+
+```sh
+# Docker: bind all interfaces and expose port 9100
+docker run -d \
+  -e DAEMON_TENANT_ID=my-team \
+  -e DAEMON_HEALTH_PORT=9100 \
+  -p 9100:9100 \
+  edge-daemon:latest
+# DAEMON_HEALTH_HOST defaults to 0.0.0.0 inside the image.
+
+# Kubernetes liveness probe (values.yaml / Pod spec excerpt)
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 9100
+  initialDelaySeconds: 5
+  periodSeconds: 10
+```
 
 ### Quick status check (any environment)
 

--- a/apps/edge-daemon/deploy/Dockerfile
+++ b/apps/edge-daemon/deploy/Dockerfile
@@ -83,6 +83,15 @@ ENV DAEMON_STALE_DAYS=90
 ENV DAEMON_SPOOL_DIR=/var/lib/edge-daemon/spool
 ENV DAEMON_EXPORT_DIR=/var/lib/edge-daemon/kb-export
 ENV DAEMON_PID_FILE=/var/lib/edge-daemon/daemon.pid
+# Inside a container the health server must bind to 0.0.0.0 so external
+# liveness/readiness probes can reach it.  The default outside Docker is
+# 127.0.0.1 (loopback-only).  Override at runtime if you need a different
+# interface (e.g. a specific non-loopback IP).
+ENV DAEMON_HEALTH_HOST=0.0.0.0
+# Operators should also set DAEMON_HEALTH_PORT to a non-zero value to enable
+# the HTTP health endpoint.  Default (0) leaves it disabled.
+# EXPOSE documents the conventional port; set DAEMON_HEALTH_PORT to match.
+EXPOSE 9100
 
 RUN mkdir -p /var/lib/edge-daemon/spool /var/lib/edge-daemon/kb-export \
     && chown -R edge-daemon:edge-daemon /var/lib/edge-daemon

--- a/apps/edge-daemon/src/__tests__/config.test.ts
+++ b/apps/edge-daemon/src/__tests__/config.test.ts
@@ -92,4 +92,43 @@ describe('loadDaemonConfig', () => {
     expect(config.enableStalenessSweep).toBe(true);
     expect(config.staleDays).toBe(90);
   });
+
+  describe('DAEMON_HEALTH_HOST', () => {
+    it('defaults to 127.0.0.1 when unset', () => {
+      const config = loadDaemonConfig({ DAEMON_TENANT_ID: 'team' });
+      expect(config.healthHost).toBe('127.0.0.1');
+    });
+
+    it('accepts a custom host value', () => {
+      const config = loadDaemonConfig({
+        DAEMON_TENANT_ID: 'team',
+        DAEMON_HEALTH_HOST: '0.0.0.0',
+      });
+      expect(config.healthHost).toBe('0.0.0.0');
+    });
+
+    it('trims whitespace from the host value', () => {
+      const config = loadDaemonConfig({
+        DAEMON_TENANT_ID: 'team',
+        DAEMON_HEALTH_HOST: '  0.0.0.0  ',
+      });
+      expect(config.healthHost).toBe('0.0.0.0');
+    });
+
+    it('falls back to 127.0.0.1 when value is an empty string', () => {
+      const config = loadDaemonConfig({
+        DAEMON_TENANT_ID: 'team',
+        DAEMON_HEALTH_HOST: '',
+      });
+      expect(config.healthHost).toBe('127.0.0.1');
+    });
+
+    it('falls back to 127.0.0.1 when value is whitespace-only', () => {
+      const config = loadDaemonConfig({
+        DAEMON_TENANT_ID: 'team',
+        DAEMON_HEALTH_HOST: '   ',
+      });
+      expect(config.healthHost).toBe('127.0.0.1');
+    });
+  });
 });

--- a/apps/edge-daemon/src/__tests__/daemon-lifecycle.test.ts
+++ b/apps/edge-daemon/src/__tests__/daemon-lifecycle.test.ts
@@ -71,6 +71,7 @@ function makeLifecycleConfig(overrides?: Partial<DaemonConfig>): DaemonConfig {
     supersessionThreshold: 0.6,
     pidFilePath: join(tmpdir(), `daemon-lifecycle-test-${randomUUID()}.pid`),
     scopeByRepo: false,
+    healthHost: '127.0.0.1',
     maxRetries: 0,
     retryBaseDelayMs: 0,
     retryMaxJitterMs: 0,

--- a/apps/edge-daemon/src/__tests__/fixtures.ts
+++ b/apps/edge-daemon/src/__tests__/fixtures.ts
@@ -91,6 +91,7 @@ export function makeConfig(overrides?: Partial<DaemonConfig>): DaemonConfig {
     supersessionThreshold: 0.6,
     pidFilePath: '/tmp/daemon-test-' + randomUUID() + '.pid',
     scopeByRepo: false,
+    healthHost: '127.0.0.1',
     maxRetries: 0, // no retries in tests by default — avoids delay
     retryBaseDelayMs: 0,
     retryMaxJitterMs: 0,

--- a/apps/edge-daemon/src/__tests__/health-server.test.ts
+++ b/apps/edge-daemon/src/__tests__/health-server.test.ts
@@ -139,4 +139,48 @@ describe('HealthServer', () => {
       expect(server.port).toBeGreaterThan(0);
     });
   });
+
+  describe('host option', () => {
+    it('starts successfully with explicit host set to 127.0.0.1', async () => {
+      const srv = new HealthServer({
+        port: 0,
+        host: '127.0.0.1',
+        getState: () => 'running' as const,
+        getLastCycleResult: () => null,
+      });
+      await srv.start();
+      expect(srv.port).toBeGreaterThan(0);
+      const res = await httpGet(srv.port, '/healthz');
+      expect(res.status).toBe(200);
+      await srv.stop();
+    });
+
+    it('starts successfully without a host option (defaults to 127.0.0.1)', async () => {
+      const srv = new HealthServer({
+        port: 0,
+        getState: () => 'running' as const,
+        getLastCycleResult: () => null,
+      });
+      await srv.start();
+      expect(srv.port).toBeGreaterThan(0);
+      const res = await httpGet(srv.port, '/healthz');
+      expect(res.status).toBe(200);
+      await srv.stop();
+    });
+
+    it('starts successfully with host set to 0.0.0.0 and is reachable via 127.0.0.1', async () => {
+      const srv = new HealthServer({
+        port: 0,
+        host: '0.0.0.0',
+        getState: () => 'running' as const,
+        getLastCycleResult: () => null,
+      });
+      await srv.start();
+      expect(srv.port).toBeGreaterThan(0);
+      // When bound to 0.0.0.0, loopback connections still work
+      const res = await httpGet(srv.port, '/healthz');
+      expect(res.status).toBe(200);
+      await srv.stop();
+    });
+  });
 });

--- a/apps/edge-daemon/src/config.ts
+++ b/apps/edge-daemon/src/config.ts
@@ -38,6 +38,7 @@ const DEFAULTS = {
  *   DAEMON_PID_FILE        — PID file path
  *   DAEMON_SCOPE_BY_REPO   — 'true'/'false' (default false)
  *   DAEMON_HEALTH_PORT     — HTTP health server port (default 0 = disabled)
+ *   DAEMON_HEALTH_HOST     — HTTP health server bind host (default '127.0.0.1'; use '0.0.0.0' in Docker/K8s)
  *   DAEMON_MAX_RETRIES     — max retries for transient errors (default 3)
  *   DAEMON_RETRY_BASE_DELAY — base backoff delay in ms (default 500)
  *   DAEMON_RETRY_MAX_JITTER — max jitter in ms added to backoff (default 200)
@@ -78,6 +79,7 @@ export function loadDaemonConfig(
     pidFilePath: env['DAEMON_PID_FILE'] ?? resolveTeamKbPath('daemon.pid'),
     scopeByRepo: parseBool(env['DAEMON_SCOPE_BY_REPO'], DEFAULTS.scopeByRepo),
     healthPort: parseNonNegativeInt(env['DAEMON_HEALTH_PORT'], 0),
+    healthHost: parseNonEmptyString(env['DAEMON_HEALTH_HOST'], '127.0.0.1'),
     maxRetries: parsePositiveInt(env['DAEMON_MAX_RETRIES'], DEFAULTS.maxRetries),
     retryBaseDelayMs: parsePositiveInt(env['DAEMON_RETRY_BASE_DELAY'], DEFAULTS.retryBaseDelayMs),
     retryMaxJitterMs: parsePositiveInt(env['DAEMON_RETRY_MAX_JITTER'], DEFAULTS.retryMaxJitterMs),
@@ -96,6 +98,13 @@ function parseNonNegativeInt(value: string | undefined, fallback: number): numbe
   const parsed = parseInt(value, 10);
   if (Number.isNaN(parsed) || parsed < 0) return fallback;
   return parsed;
+}
+
+function parseNonEmptyString(value: string | undefined, fallback: string): string {
+  if (value === undefined) return fallback;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return fallback;
+  return trimmed;
 }
 
 function parseBool(value: string | undefined, fallback: boolean): boolean {

--- a/apps/edge-daemon/src/config.ts
+++ b/apps/edge-daemon/src/config.ts
@@ -101,10 +101,8 @@ function parseNonNegativeInt(value: string | undefined, fallback: number): numbe
 }
 
 function parseNonEmptyString(value: string | undefined, fallback: string): string {
-  if (value === undefined) return fallback;
-  const trimmed = value.trim();
-  if (trimmed.length === 0) return fallback;
-  return trimmed;
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : fallback;
 }
 
 function parseBool(value: string | undefined, fallback: boolean): boolean {

--- a/apps/edge-daemon/src/daemon.ts
+++ b/apps/edge-daemon/src/daemon.ts
@@ -64,6 +64,7 @@ export class EdgeDaemon {
     if ((this.config.healthPort ?? 0) > 0) {
       this._healthServer = new HealthServer({
         port: this.config.healthPort!,
+        host: this.config.healthHost,
         getState: () => this._state,
         getLastCycleResult: () => this._lastCycleResult,
       });

--- a/apps/edge-daemon/src/health-server.ts
+++ b/apps/edge-daemon/src/health-server.ts
@@ -3,6 +3,8 @@ import type { CycleResult, DaemonState } from './types.js';
 
 export interface HealthServerOptions {
   port: number;
+  /** Host/address to bind to. Default '127.0.0.1'. Pass '0.0.0.0' inside Docker/Kubernetes. */
+  host?: string;
   getState: () => DaemonState;
   getLastCycleResult: () => CycleResult | null;
 }
@@ -53,7 +55,7 @@ export class HealthServer {
 
       server.once('error', reject);
 
-      server.listen(this._options.port, '127.0.0.1', () => {
+      server.listen(this._options.port, this._options.host ?? '127.0.0.1', () => {
         const addr = server.address();
         this._assignedPort =
           typeof addr === 'object' && addr !== null ? addr.port : this._options.port;

--- a/apps/edge-daemon/src/types.ts
+++ b/apps/edge-daemon/src/types.ts
@@ -40,6 +40,8 @@ export interface DaemonConfig {
   scopeByRepo: boolean;
   /** HTTP health server port. 0 = disabled. Default 0. */
   healthPort?: number;
+  /** Host/address the HTTP health server binds to. Default '127.0.0.1'. Use '0.0.0.0' inside Docker/Kubernetes so external probes can reach it. */
+  healthHost: string;
   /** Maximum retry attempts for transient step errors. Default 3. */
   maxRetries: number;
   /** Base delay in ms for exponential backoff. Default 500. */


### PR DESCRIPTION
## Summary

- Add `DAEMON_HEALTH_HOST` env var (default `127.0.0.1`) to `DaemonConfig` and `loadDaemonConfig()` — `parseNonEmptyString` trims and falls back to the default on empty/whitespace input
- `HealthServer` gains an optional `host` option on its constructor passed directly to `server.listen()`, defaulting to `127.0.0.1`
- `EdgeDaemon` passes `host: this.config.healthHost` when constructing `HealthServer`
- Dockerfile sets `ENV DAEMON_HEALTH_HOST=0.0.0.0` and adds `EXPOSE 9100` so external liveness probes work inside containers without operator intervention
- Runbook (`000-docs/027-OD-OPSM-edge-daemon-runbook.md`) documents the `127.0.0.1` vs `0.0.0.0` trade-off with Docker and Kubernetes example snippets

## Test plan

- [ ] `pnpm vitest run apps/edge-daemon/src/__tests__/health-server.test.ts` — 14 tests pass (includes 3 new `host option` cases: explicit `127.0.0.1`, omitted host default, and `0.0.0.0` reachable via loopback)
- [ ] `pnpm vitest run apps/edge-daemon/src/__tests__/config.test.ts` — passes (includes 5 new `DAEMON_HEALTH_HOST` cases: unset default, custom value, whitespace trim, empty-string fallback, whitespace-only fallback)
- [ ] `pnpm format:check` — passes (all files clean)
- [ ] `pnpm lint` — passes (no new lint errors)
- [ ] `pnpm typecheck` — no new TS errors beyond pre-existing better-sqlite3/unbuilt-workspace-package issues on main
- [ ] Pre-existing `better-sqlite3` sandbox test failures are unchanged (native binding not compiled in worktree — same as main)

Closes bead qmd-team-intent-kb-dwe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)