### PR TITLE
chore(tests): extract shared NOW + makeMemory fixtures

### DIFF
--- a/apps/mcp-server/src/__tests__/fixtures.ts
+++ b/apps/mcp-server/src/__tests__/fixtures.ts
@@ -1,0 +1,30 @@
+import { randomUUID } from 'node:crypto';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
+
+export const FIXED_NOW = '2026-01-15T10:00:00.000Z';
+
+export function makeMemory(overrides?: Partial<CuratedMemory>): CuratedMemory {
+  const content = overrides?.content ?? 'Use Result<T,E> for fallible operations';
+  return {
+    id: randomUUID(),
+    candidateId: randomUUID(),
+    source: 'mcp',
+    content,
+    title: 'Error handling convention',
+    category: 'convention',
+    trustLevel: 'high',
+    sensitivity: 'internal',
+    author: { type: 'ai', id: 'mcp-server' },
+    tenantId: 'test-tenant',
+    metadata: { filePaths: [], tags: [] },
+    lifecycle: 'active',
+    contentHash: computeContentHash(content),
+    policyEvaluations: [],
+    promotedAt: FIXED_NOW,
+    promotedBy: { type: 'human', id: 'user-1', name: 'Test User' },
+    updatedAt: FIXED_NOW,
+    version: 1,
+    ...overrides,
+  } satisfies CuratedMemory;
+}

--- a/apps/mcp-server/src/__tests__/status.test.ts
+++ b/apps/mcp-server/src/__tests__/status.test.ts
@@ -4,37 +4,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { createDatabase, createTestDatabase, MemoryRepository } from '@qmd-team-intent-kb/store';
-import { computeContentHash } from '@qmd-team-intent-kb/common';
-import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
 import { getStatus } from '../tools/status.js';
 import type { McpServerConfig } from '../config.js';
-
-const NOW = '2026-01-15T10:00:00.000Z';
-
-function makeMemory(overrides?: Partial<CuratedMemory>): CuratedMemory {
-  const content = 'Use Result<T,E> for fallible operations';
-  return {
-    id: randomUUID(),
-    candidateId: randomUUID(),
-    source: 'mcp',
-    content,
-    title: 'Error handling convention',
-    category: 'convention',
-    trustLevel: 'high',
-    sensitivity: 'internal',
-    author: { type: 'ai', id: 'mcp-server' },
-    tenantId: 'test-tenant',
-    metadata: { filePaths: [], tags: [] },
-    lifecycle: 'active',
-    contentHash: computeContentHash(content),
-    policyEvaluations: [],
-    promotedAt: NOW,
-    promotedBy: { type: 'human', id: 'user-1', name: 'Test User' },
-    updatedAt: NOW,
-    version: 1,
-    ...overrides,
-  } satisfies CuratedMemory;
-}
+import { makeMemory } from './fixtures.js';
 
 describe('getStatus() — empty DB', () => {
   let tmpDir: string;

--- a/apps/mcp-server/src/__tests__/transition.test.ts
+++ b/apps/mcp-server/src/__tests__/transition.test.ts
@@ -5,38 +5,12 @@ import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { createDatabase } from '@qmd-team-intent-kb/store';
 import { MemoryRepository } from '@qmd-team-intent-kb/store';
-import { computeContentHash } from '@qmd-team-intent-kb/common';
 import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
 import { applyTransition } from '../tools/transition.js';
 import type { McpServerConfig } from '../config.js';
+import { FIXED_NOW, makeMemory } from './fixtures.js';
 
-const FIXED_NOW = '2026-01-15T10:00:00.000Z';
 const nowFn = () => FIXED_NOW;
-
-function makeMemory(overrides?: Partial<CuratedMemory>): CuratedMemory {
-  const content = 'Always validate inputs with Zod schemas';
-  return {
-    id: randomUUID(),
-    candidateId: randomUUID(),
-    source: 'mcp',
-    content,
-    title: 'Input validation pattern',
-    category: 'pattern',
-    trustLevel: 'high',
-    sensitivity: 'internal',
-    author: { type: 'ai', id: 'mcp-server' },
-    tenantId: 'test-tenant',
-    metadata: { filePaths: [], tags: [] },
-    lifecycle: 'active',
-    contentHash: computeContentHash(content),
-    policyEvaluations: [],
-    promotedAt: FIXED_NOW,
-    promotedBy: { type: 'human', id: 'user-1', name: 'Test User' },
-    updatedAt: FIXED_NOW,
-    version: 1,
-    ...overrides,
-  } satisfies CuratedMemory;
-}
 
 describe('applyTransition()', () => {
   let tmpDir: string;

--- a/packages/store/src/__tests__/fixtures.ts
+++ b/packages/store/src/__tests__/fixtures.ts
@@ -7,7 +7,7 @@ import type {
   AuditEvent,
 } from '@qmd-team-intent-kb/schema';
 
-const NOW = '2026-01-15T10:00:00.000Z';
+export const NOW = '2026-01-15T10:00:00.000Z';
 export const HASH_A = 'a'.repeat(64);
 export const HASH_B = 'b'.repeat(64);
 

--- a/packages/store/src/__tests__/memory-repository.test.ts
+++ b/packages/store/src/__tests__/memory-repository.test.ts
@@ -3,9 +3,8 @@ import { randomUUID } from 'node:crypto';
 import type Database from 'better-sqlite3';
 import { createTestDatabase } from '../database.js';
 import { MemoryRepository } from '../repositories/memory-repository.js';
-import { makeMemory, HASH_A, HASH_B } from './fixtures.js';
+import { makeMemory, HASH_A, HASH_B, NOW } from './fixtures.js';
 
-const NOW = '2026-01-15T10:00:00.000Z';
 const LATER = '2026-02-01T12:00:00.000Z';
 
 describe('MemoryRepository', () => {


### PR DESCRIPTION
## Summary
Two tiny test-fixture dedup wins from the Wave C follow-ups.

- **b26 (store)**: \`packages/store/src/__tests__/fixtures.ts\` now exports \`NOW\` (was a local const). \`memory-repository.test.ts\` imports it instead of redeclaring.
- **3vl (mcp-server)**: new \`apps/mcp-server/src/__tests__/fixtures.ts\` extracts the \`makeMemory\` factory that was duplicated in \`status.test.ts\` + \`transition.test.ts\`. Both call sites now import from the shared fixture.

Closes beads qmd-team-intent-kb-b26 and qmd-team-intent-kb-3vl.

## Test plan
- [x] \`pnpm --filter @qmd-team-intent-kb/mcp-server typecheck\` clean
- [x] \`pnpm --filter @qmd-team-intent-kb/store typecheck\` clean
- [ ] CI validate green