### PR TITLE
refactor(api tests): extract shared HTTP assertion helpers

### DIFF
--- a/apps/api/src/__tests__/assertions.ts
+++ b/apps/api/src/__tests__/assertions.ts
@@ -1,0 +1,32 @@
+import type { FastifyInstance } from 'fastify';
+
+/** HTTP methods accepted by Fastify's inject helper */
+type InjectMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
+
+/** Parsed result of a test HTTP request */
+export interface InjectResult {
+  /** HTTP status code returned by the handler */
+  status: number;
+  /** Response body parsed as JSON (`unknown` — narrow with `as T` or structural matchers) */
+  body: unknown;
+}
+
+/**
+ * Fire a single Fastify inject request and return the status code plus the
+ * parsed JSON body in one step.  This removes the repetitive three-line
+ * pattern of `app.inject → statusCode → json()` from every test case.
+ *
+ * @example
+ * const res = await injectJson(app, 'POST', '/api/candidates', makeCandidate());
+ * expect(res.status).toBe(201);
+ * expect((res.body as { id: string }).id).toBe(expected);
+ */
+export async function injectJson(
+  app: FastifyInstance,
+  method: InjectMethod,
+  url: string,
+  payload?: Record<string, unknown>,
+): Promise<InjectResult> {
+  const res = await app.inject({ method, url, payload });
+  return { status: res.statusCode, body: res.json() };
+}

--- a/apps/api/src/__tests__/assertions.ts
+++ b/apps/api/src/__tests__/assertions.ts
@@ -28,5 +28,6 @@ export async function injectJson(
   payload?: Record<string, unknown>,
 ): Promise<InjectResult> {
   const res = await app.inject({ method, url, payload });
-  return { status: res.statusCode, body: res.json() };
+  const body = res.body.length > 0 ? res.json() : null;
+  return { status: res.statusCode, body };
 }

--- a/apps/api/src/__tests__/assertions.ts
+++ b/apps/api/src/__tests__/assertions.ts
@@ -4,30 +4,39 @@ import type { FastifyInstance } from 'fastify';
 type InjectMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
 
 /** Parsed result of a test HTTP request */
-export interface InjectResult {
+export interface InjectResult<T = unknown> {
   /** HTTP status code returned by the handler */
   status: number;
-  /** Response body parsed as JSON (`unknown` — narrow with `as T` or structural matchers) */
-  body: unknown;
+  /** Response body parsed as JSON, typed as T (default `unknown` — narrow at the call site) */
+  body: T;
 }
 
 /**
  * Fire a single Fastify inject request and return the status code plus the
- * parsed JSON body in one step.  This removes the repetitive three-line
- * pattern of `app.inject → statusCode → json()` from every test case.
+ * parsed JSON body in one step.  Removes the repetitive three-line pattern
+ * of `app.inject → statusCode → json()` from every test case.
+ *
+ * The body type defaults to `unknown`; callers pass a type argument when
+ * they want structural typing without a later cast.
  *
  * @example
- * const res = await injectJson(app, 'POST', '/api/candidates', makeCandidate());
+ * const res = await injectJson<{ id: string }>(app, 'POST', '/api/candidates', body);
  * expect(res.status).toBe(201);
- * expect((res.body as { id: string }).id).toBe(expected);
+ * expect(res.body.id).toBe(expected);
+ *
+ * @example
+ * // Empty-body responses (e.g. 204 DELETE) return body as null
+ * const res = await injectJson(app, 'DELETE', '/api/policies/abc');
+ * expect(res.status).toBe(204);
+ * expect(res.body).toBeNull();
  */
-export async function injectJson(
+export async function injectJson<T = unknown>(
   app: FastifyInstance,
   method: InjectMethod,
   url: string,
   payload?: Record<string, unknown>,
-): Promise<InjectResult> {
+): Promise<InjectResult<T>> {
   const res = await app.inject({ method, url, payload });
-  const body = res.body.length > 0 ? res.json() : null;
+  const body = (res.body.length > 0 ? res.json() : null) as T;
   return { status: res.statusCode, body };
 }

--- a/apps/api/src/__tests__/candidates.test.ts
+++ b/apps/api/src/__tests__/candidates.test.ts
@@ -5,6 +5,7 @@ import type Database from 'better-sqlite3';
 import { createTestDatabase } from '@qmd-team-intent-kb/store';
 import { buildApp } from '../app.js';
 import { makeCandidate, NOW } from './fixtures.js';
+import { injectJson } from './assertions.js';
 
 describe('/api/candidates', () => {
   let db: Database.Database;
@@ -25,54 +26,39 @@ describe('/api/candidates', () => {
 
   it('POST creates a candidate and returns 201', async () => {
     const body = makeCandidate();
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/candidates',
-      payload: body,
-    });
-    expect(res.statusCode).toBe(201);
-    const created = res.json<{ id: string; status: string }>();
+    const res = await injectJson(app, 'POST', '/api/candidates', body);
+    expect(res.status).toBe(201);
+    const created = res.body as { id: string; status: string };
     expect(created.id).toBe(body['id']);
     expect(created.status).toBe('inbox');
   });
 
   it('POST with invalid data returns 400', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/candidates',
-      payload: { title: 'Missing required fields' },
+    const res = await injectJson(app, 'POST', '/api/candidates', {
+      title: 'Missing required fields',
     });
-    expect(res.statusCode).toBe(400);
-    const body = res.json<{ error: string }>();
-    expect(body.error).toMatch(/Invalid candidate/);
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toMatch(/Invalid candidate/);
   });
 
   it('POST with missing required fields returns 400', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/candidates',
-      payload: { id: randomUUID(), status: 'inbox' },
+    const res = await injectJson(app, 'POST', '/api/candidates', {
+      id: randomUUID(),
+      status: 'inbox',
     });
-    expect(res.statusCode).toBe(400);
+    expect(res.status).toBe(400);
   });
 
   it('POST computes and stores a content hash', async () => {
     const content = 'Unique content for hash test';
     const body = makeCandidate({ content });
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/candidates',
-      payload: body,
-    });
-    expect(res.statusCode).toBe(201);
+    const res = await injectJson(app, 'POST', '/api/candidates', body);
+    expect(res.status).toBe(201);
     // Verify the candidate is retrievable (hash stored internally)
-    const candidate = res.json<{ id: string }>();
-    const getRes = await app.inject({
-      method: 'GET',
-      url: `/api/candidates/${candidate.id}`,
-    });
-    expect(getRes.statusCode).toBe(200);
-    expect(getRes.json<{ content: string }>().content).toBe(content);
+    const candidate = res.body as { id: string };
+    const getRes = await injectJson(app, 'GET', `/api/candidates/${candidate.id}`);
+    expect(getRes.status).toBe(200);
+    expect((getRes.body as { content: string }).content).toBe(content);
   });
 
   it('POST accepts duplicate candidates with different IDs', async () => {
@@ -80,11 +66,11 @@ describe('/api/candidates', () => {
     const first = makeCandidate({ content });
     const second = makeCandidate({ content, id: randomUUID() });
 
-    const r1 = await app.inject({ method: 'POST', url: '/api/candidates', payload: first });
-    const r2 = await app.inject({ method: 'POST', url: '/api/candidates', payload: second });
+    const r1 = await injectJson(app, 'POST', '/api/candidates', first);
+    const r2 = await injectJson(app, 'POST', '/api/candidates', second);
 
-    expect(r1.statusCode).toBe(201);
-    expect(r2.statusCode).toBe(201);
+    expect(r1.status).toBe(201);
+    expect(r2.status).toBe(201);
   });
 
   it('POST with full metadata fields succeeds', async () => {
@@ -102,9 +88,9 @@ describe('/api/candidates', () => {
         duplicateSuspect: true,
       },
     });
-    const res = await app.inject({ method: 'POST', url: '/api/candidates', payload: body });
-    expect(res.statusCode).toBe(201);
-    const created = res.json<{ metadata: { filePaths: string[] } }>();
+    const res = await injectJson(app, 'POST', '/api/candidates', body);
+    expect(res.status).toBe(201);
+    const created = res.body as { metadata: { filePaths: string[] } };
     expect(created.metadata.filePaths).toEqual(['src/api.ts', 'src/auth.ts']);
   });
 
@@ -114,21 +100,15 @@ describe('/api/candidates', () => {
     const body = makeCandidate();
     await app.inject({ method: 'POST', url: '/api/candidates', payload: body });
 
-    const res = await app.inject({
-      method: 'GET',
-      url: `/api/candidates/${body['id'] as string}`,
-    });
-    expect(res.statusCode).toBe(200);
-    expect(res.json<{ id: string }>().id).toBe(body['id']);
+    const res = await injectJson(app, 'GET', `/api/candidates/${body['id'] as string}`);
+    expect(res.status).toBe(200);
+    expect((res.body as { id: string }).id).toBe(body['id']);
   });
 
   it('GET /:id for non-existent returns 404', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      url: `/api/candidates/${randomUUID()}`,
-    });
-    expect(res.statusCode).toBe(404);
-    expect(res.json<{ error: string }>().error).toMatch(/not found/i);
+    const res = await injectJson(app, 'GET', `/api/candidates/${randomUUID()}`);
+    expect(res.status).toBe(404);
+    expect((res.body as { error: string }).error).toMatch(/not found/i);
   });
 
   // ---- GET /api/candidates -------------------------------------------------
@@ -139,26 +119,23 @@ describe('/api/candidates', () => {
     await app.inject({ method: 'POST', url: '/api/candidates', payload: alpha });
     await app.inject({ method: 'POST', url: '/api/candidates', payload: beta });
 
-    const res = await app.inject({
-      method: 'GET',
-      url: '/api/candidates?tenantId=team-alpha',
-    });
-    expect(res.statusCode).toBe(200);
-    const list = res.json<Array<{ tenantId: string }>>();
+    const res = await injectJson(app, 'GET', '/api/candidates?tenantId=team-alpha');
+    expect(res.status).toBe(200);
+    const list = res.body as Array<{ tenantId: string }>;
     expect(list.every((c) => c.tenantId === 'team-alpha')).toBe(true);
     expect(list.length).toBeGreaterThanOrEqual(1);
   });
 
   it('GET list without tenantId returns 400', async () => {
-    const res = await app.inject({ method: 'GET', url: '/api/candidates' });
-    expect(res.statusCode).toBe(400);
-    expect(res.json<{ error: string }>().error).toMatch(/tenantId/);
+    const res = await injectJson(app, 'GET', '/api/candidates');
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toMatch(/tenantId/);
   });
 
   it('POST preserves capturedAt timestamp exactly', async () => {
     const body = makeCandidate({ capturedAt: NOW });
-    const res = await app.inject({ method: 'POST', url: '/api/candidates', payload: body });
-    expect(res.statusCode).toBe(201);
-    expect(res.json<{ capturedAt: string }>().capturedAt).toBe(NOW);
+    const res = await injectJson(app, 'POST', '/api/candidates', body);
+    expect(res.status).toBe(201);
+    expect((res.body as { capturedAt: string }).capturedAt).toBe(NOW);
   });
 });

--- a/apps/api/src/__tests__/policies.test.ts
+++ b/apps/api/src/__tests__/policies.test.ts
@@ -5,6 +5,7 @@ import type Database from 'better-sqlite3';
 import { createTestDatabase } from '@qmd-team-intent-kb/store';
 import { buildApp } from '../app.js';
 import { makePolicy, NOW } from './fixtures.js';
+import { injectJson, type InjectResult } from './assertions.js';
 
 describe('/api/policies', () => {
   let db: Database.Database;
@@ -21,13 +22,11 @@ describe('/api/policies', () => {
     db.close();
   });
 
-  async function createPolicy(overrides?: Record<string, unknown>) {
+  async function createPolicy(
+    overrides?: Record<string, unknown>,
+  ): Promise<{ res: InjectResult; body: Record<string, unknown> }> {
     const body = makePolicy(overrides);
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/policies',
-      payload: body,
-    });
+    const res = await injectJson(app, 'POST', '/api/policies', body);
     return { res, body };
   }
 
@@ -35,48 +34,36 @@ describe('/api/policies', () => {
 
   it('POST creates a policy and returns 201', async () => {
     const { res, body } = await createPolicy();
-    expect(res.statusCode).toBe(201);
-    expect(res.json<{ id: string }>().id).toBe(body['id']);
+    expect(res.status).toBe(201);
+    expect((res.body as { id: string }).id).toBe(body['id']);
   });
 
   it('POST with invalid data returns 400', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/policies',
-      payload: { name: 'Missing required fields' },
+    const res = await injectJson(app, 'POST', '/api/policies', {
+      name: 'Missing required fields',
     });
-    expect(res.statusCode).toBe(400);
-    expect(res.json<{ error: string }>().error).toMatch(/Invalid policy/);
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toMatch(/Invalid policy/);
   });
 
   it('POST with missing rules returns 400', async () => {
-    const res = await app.inject({
-      method: 'POST',
-      url: '/api/policies',
-      payload: makePolicy({ rules: [] }), // min(1) — empty rules invalid
-    });
-    expect(res.statusCode).toBe(400);
+    const res = await injectJson(app, 'POST', '/api/policies', makePolicy({ rules: [] })); // min(1) — empty rules invalid
+    expect(res.status).toBe(400);
   });
 
   // ---- GET /api/policies/:id -----------------------------------------------
 
   it('GET /:id returns the stored policy', async () => {
     const { body } = await createPolicy();
-    const res = await app.inject({
-      method: 'GET',
-      url: `/api/policies/${body['id'] as string}`,
-    });
-    expect(res.statusCode).toBe(200);
-    expect(res.json<{ id: string }>().id).toBe(body['id']);
+    const res = await injectJson(app, 'GET', `/api/policies/${body['id'] as string}`);
+    expect(res.status).toBe(200);
+    expect((res.body as { id: string }).id).toBe(body['id']);
   });
 
   it('GET /:id for non-existent returns 404', async () => {
-    const res = await app.inject({
-      method: 'GET',
-      url: `/api/policies/${randomUUID()}`,
-    });
-    expect(res.statusCode).toBe(404);
-    expect(res.json<{ error: string }>().error).toMatch(/not found/i);
+    const res = await injectJson(app, 'GET', `/api/policies/${randomUUID()}`);
+    expect(res.status).toBe(404);
+    expect((res.body as { error: string }).error).toMatch(/not found/i);
   });
 
   // ---- GET /api/policies ---------------------------------------------------
@@ -85,20 +72,17 @@ describe('/api/policies', () => {
     await createPolicy({ tenantId: 'team-alpha' });
     await createPolicy({ tenantId: 'team-beta', id: randomUUID(), name: 'Beta Policy' });
 
-    const res = await app.inject({
-      method: 'GET',
-      url: '/api/policies?tenantId=team-alpha',
-    });
-    expect(res.statusCode).toBe(200);
-    const list = res.json<Array<{ tenantId: string }>>();
+    const res = await injectJson(app, 'GET', '/api/policies?tenantId=team-alpha');
+    expect(res.status).toBe(200);
+    const list = res.body as Array<{ tenantId: string }>;
     expect(list.every((p) => p.tenantId === 'team-alpha')).toBe(true);
     expect(list.length).toBeGreaterThanOrEqual(1);
   });
 
   it('GET list without tenantId returns 400', async () => {
-    const res = await app.inject({ method: 'GET', url: '/api/policies' });
-    expect(res.statusCode).toBe(400);
-    expect(res.json<{ error: string }>().error).toMatch(/tenantId/);
+    const res = await injectJson(app, 'GET', '/api/policies');
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toMatch(/tenantId/);
   });
 
   it('multiple policies for the same tenant are all returned', async () => {
@@ -107,12 +91,9 @@ describe('/api/policies', () => {
     await createPolicy({ tenantId: tenant, id: randomUUID(), name: 'Policy Two' });
     await createPolicy({ tenantId: tenant, id: randomUUID(), name: 'Policy Three' });
 
-    const res = await app.inject({
-      method: 'GET',
-      url: `/api/policies?tenantId=${tenant}`,
-    });
-    expect(res.statusCode).toBe(200);
-    expect(res.json<unknown[]>().length).toBe(3);
+    const res = await injectJson(app, 'GET', `/api/policies?tenantId=${tenant}`);
+    expect(res.status).toBe(200);
+    expect((res.body as unknown[]).length).toBe(3);
   });
 
   // ---- PUT /api/policies/:id -----------------------------------------------
@@ -125,59 +106,40 @@ describe('/api/policies', () => {
       updatedAt: '2026-06-01T00:00:00.000Z',
     });
 
-    const res = await app.inject({
-      method: 'PUT',
-      url: `/api/policies/${body['id'] as string}`,
-      payload: updated,
-    });
-    expect(res.statusCode).toBe(200);
-    expect(res.json<{ name: string }>().name).toBe('Updated Policy Name');
+    const res = await injectJson(app, 'PUT', `/api/policies/${body['id'] as string}`, updated);
+    expect(res.status).toBe(200);
+    expect((res.body as { name: string }).name).toBe('Updated Policy Name');
   });
 
   it('PUT /:id with invalid data returns 400', async () => {
     const { body } = await createPolicy();
-    const res = await app.inject({
-      method: 'PUT',
-      url: `/api/policies/${body['id'] as string}`,
-      payload: { name: 'No rules provided' },
+    const res = await injectJson(app, 'PUT', `/api/policies/${body['id'] as string}`, {
+      name: 'No rules provided',
     });
-    expect(res.statusCode).toBe(400);
+    expect(res.status).toBe(400);
   });
 
   it('PUT /:id for non-existent returns 404', async () => {
-    const res = await app.inject({
-      method: 'PUT',
-      url: `/api/policies/${randomUUID()}`,
-      payload: makePolicy(),
-    });
-    expect(res.statusCode).toBe(404);
+    const res = await injectJson(app, 'PUT', `/api/policies/${randomUUID()}`, makePolicy());
+    expect(res.status).toBe(404);
   });
 
   // ---- DELETE /api/policies/:id --------------------------------------------
 
   it('DELETE /:id removes the policy and returns 204', async () => {
     const { body } = await createPolicy();
-    const res = await app.inject({
-      method: 'DELETE',
-      url: `/api/policies/${body['id'] as string}`,
-    });
-    expect(res.statusCode).toBe(204);
+    const res = await injectJson(app, 'DELETE', `/api/policies/${body['id'] as string}`);
+    expect(res.status).toBe(204);
 
     // Confirm it no longer exists
-    const getRes = await app.inject({
-      method: 'GET',
-      url: `/api/policies/${body['id'] as string}`,
-    });
-    expect(getRes.statusCode).toBe(404);
+    const getRes = await injectJson(app, 'GET', `/api/policies/${body['id'] as string}`);
+    expect(getRes.status).toBe(404);
   });
 
   it('DELETE /:id for non-existent returns 404', async () => {
-    const res = await app.inject({
-      method: 'DELETE',
-      url: `/api/policies/${randomUUID()}`,
-    });
-    expect(res.statusCode).toBe(404);
-    expect(res.json<{ error: string }>().error).toMatch(/not found/i);
+    const res = await injectJson(app, 'DELETE', `/api/policies/${randomUUID()}`);
+    expect(res.status).toBe(404);
+    expect((res.body as { error: string }).error).toMatch(/not found/i);
   });
 
   it('policy createdAt timestamp is preserved on update', async () => {
@@ -189,12 +151,8 @@ describe('/api/policies', () => {
       updatedAt: '2026-07-01T00:00:00.000Z',
     });
 
-    const res = await app.inject({
-      method: 'PUT',
-      url: `/api/policies/${body['id'] as string}`,
-      payload: updated,
-    });
-    expect(res.statusCode).toBe(200);
-    expect(res.json<{ createdAt: string }>().createdAt).toBe(NOW);
+    const res = await injectJson(app, 'PUT', `/api/policies/${body['id'] as string}`, updated);
+    expect(res.status).toBe(200);
+    expect((res.body as { createdAt: string }).createdAt).toBe(NOW);
   });
 });


### PR DESCRIPTION
## Summary

- Introduces `apps/api/src/__tests__/assertions.ts` with `injectJson(app, method, url, payload?)` returning `{ status: number; body: unknown }` — eliminates the repeated three-line `app.inject → statusCode → json()` pattern flagged by jscpd (~120 tokens, 3 clones)
- `candidates.test.ts` and `policies.test.ts` now call `injectJson` for all assertion-bearing requests; bare `app.inject` is retained only for pure-setup calls where the response is discarded
- The local `createPolicy` helper in `policies.test.ts` is updated to call `injectJson` and returns `InjectResult` from `assertions.ts`, preserving the existing helper's ergonomics
- No test semantics changed — same cases, same assertions, same count (11 in candidates, 14 in policies)
- LOC before: candidates 164, policies 200 (total 364). LOC after: candidates 141, policies 158 (total 299) — net **-65 lines**

## Test plan

- [ ] `pnpm --filter @qmd-team-intent-kb/api typecheck` — passes (zero TS errors)
- [ ] `pnpm format:check` — passes (all files already Prettier-compliant)
- [ ] `pnpm lint` — passes clean
- [ ] `pnpm --filter @qmd-team-intent-kb/api test` — all 25 tests in candidates + policies fail only with pre-existing `better-sqlite3` native binding error (worktree sandbox limitation, not introduced by this PR)
- [ ] Test counts unchanged: 11 tests in candidates.test.ts, 14 in policies.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)