### PR TITLE
refactor(store): replace repository casts with Zod-on-read validation

### DIFF
--- a/packages/store/src/__tests__/candidate-repository.test.ts
+++ b/packages/store/src/__tests__/candidate-repository.test.ts
@@ -6,6 +6,8 @@ import { createTestDatabase } from '../database.js';
 import { CandidateRepository } from '../repositories/candidate-repository.js';
 import { makeCandidate } from './fixtures.js';
 
+const NOW = '2026-01-15T10:00:00.000Z';
+
 describe('CandidateRepository', () => {
   let db: Database.Database;
   let repo: CandidateRepository;
@@ -144,5 +146,58 @@ describe('CandidateRepository — aggregation queries', () => {
     });
     repo.insert(c2, h2);
     expect(repo.countByTenant()['team-alpha']).toBe(2);
+  });
+});
+
+describe('CandidateRepository — Zod-on-read malformed row rejection', () => {
+  let db: Database.Database;
+  let repo: CandidateRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new CandidateRepository(db);
+  });
+
+  it('throws a descriptive error when author_json contains invalid JSON', () => {
+    // Insert a row with malformed author_json directly via raw SQL to simulate DB corruption
+    const id = randomUUID();
+    db.prepare(
+      `
+      INSERT INTO candidates (
+        id, status, source, content, title, category,
+        trust_level, author_json, tenant_id,
+        metadata_json, pre_policy_flags_json, content_hash, captured_at
+      ) VALUES (
+        ?, 'inbox', 'claude_session', 'Some content', 'Some title', 'convention',
+        'medium', 'NOT_VALID_JSON', 'team-alpha',
+        '{}', '{}', ?, ?
+      )
+    `,
+    ).run(id, 'a'.repeat(64), NOW);
+
+    expect(() => repo.findById(id)).toThrowError(
+      /candidates row id=.+: author_json is not valid JSON/,
+    );
+  });
+
+  it('throws a descriptive error when status contains an invalid enum value', () => {
+    // Insert a row with an invalid status value to simulate DB schema drift or manual edit
+    const id = randomUUID();
+    const validAuthor = JSON.stringify({ type: 'ai', id: 'session-1', name: 'Claude' });
+    db.prepare(
+      `
+      INSERT INTO candidates (
+        id, status, source, content, title, category,
+        trust_level, author_json, tenant_id,
+        metadata_json, pre_policy_flags_json, content_hash, captured_at
+      ) VALUES (
+        ?, 'INVALID_STATUS_VALUE', 'claude_session', 'Some content', 'Some title', 'convention',
+        'medium', ?, 'team-alpha',
+        '{}', '{}', ?, ?
+      )
+    `,
+    ).run(id, validAuthor, 'b'.repeat(64), NOW);
+
+    expect(() => repo.findById(id)).toThrowError(/candidates row id=.+ failed domain validation/);
   });
 });

--- a/packages/store/src/__tests__/memory-repository.test.ts
+++ b/packages/store/src/__tests__/memory-repository.test.ts
@@ -444,3 +444,67 @@ describe('MemoryRepository — searchByText', () => {
     expect(results).toHaveLength(0);
   });
 });
+
+describe('MemoryRepository — Zod-on-read malformed row rejection', () => {
+  let db: Database.Database;
+  let repo: MemoryRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new MemoryRepository(db);
+  });
+
+  it('throws a descriptive error when policy_evaluations_json contains invalid JSON', () => {
+    // Insert a row with malformed policy_evaluations_json to simulate DB corruption
+    const id = randomUUID();
+    const validAuthor = JSON.stringify({ type: 'ai', id: 'session-1', name: 'Claude' });
+    db.prepare(
+      `
+      INSERT INTO curated_memories (
+        id, candidate_id, source, content, title, category,
+        trust_level, sensitivity, author_json, tenant_id,
+        metadata_json, lifecycle, content_hash,
+        policy_evaluations_json, supersession_json,
+        promoted_at, promoted_by_json, updated_at, version
+      ) VALUES (
+        ?, ?, 'claude_session', 'Some content', 'Some title', 'pattern',
+        'high', 'internal', ?, 'team-alpha',
+        '{}', 'active', ?,
+        'NOT_VALID_JSON', NULL,
+        ?, ?, ?, 1
+      )
+    `,
+    ).run(id, randomUUID(), validAuthor, HASH_A, NOW, validAuthor, NOW);
+
+    expect(() => repo.findById(id)).toThrowError(
+      /curated_memories row id=.+: policy_evaluations_json is not valid JSON/,
+    );
+  });
+
+  it('throws a descriptive error when lifecycle contains an invalid enum value', () => {
+    // Insert a row with an unrecognised lifecycle value to simulate schema drift
+    const id = randomUUID();
+    const validAuthor = JSON.stringify({ type: 'human', id: 'user-1', name: 'Test User' });
+    db.prepare(
+      `
+      INSERT INTO curated_memories (
+        id, candidate_id, source, content, title, category,
+        trust_level, sensitivity, author_json, tenant_id,
+        metadata_json, lifecycle, content_hash,
+        policy_evaluations_json, supersession_json,
+        promoted_at, promoted_by_json, updated_at, version
+      ) VALUES (
+        ?, ?, 'claude_session', 'Some content', 'Some title', 'pattern',
+        'high', 'internal', ?, 'team-alpha',
+        '{}', 'INVALID_LIFECYCLE', ?,
+        '[]', NULL,
+        ?, ?, ?, 1
+      )
+    `,
+    ).run(id, randomUUID(), validAuthor, HASH_B, NOW, validAuthor, NOW);
+
+    expect(() => repo.findById(id)).toThrowError(
+      /curated_memories row id=.+ failed domain validation/,
+    );
+  });
+});

--- a/packages/store/src/repositories/audit-repository.ts
+++ b/packages/store/src/repositories/audit-repository.ts
@@ -1,29 +1,71 @@
+import { z } from 'zod';
 import type Database from 'better-sqlite3';
-import type { AuditEvent } from '@qmd-team-intent-kb/schema';
+import { AuditEvent } from '@qmd-team-intent-kb/schema';
 
-/** Raw SQLite row shape for the audit_events table */
-interface AuditRow {
-  id: string;
-  action: string;
-  memory_id: string;
-  tenant_id: string;
-  actor_json: string;
-  reason: string | null;
-  details_json: string;
-  timestamp: string;
-}
+/**
+ * Zod schema for the raw SQLite row returned by better-sqlite3.
+ * Validates the flat DB representation before domain parsing.
+ */
+const AuditRowSchema = z.object({
+  id: z.string(),
+  action: z.string(),
+  memory_id: z.string(),
+  tenant_id: z.string(),
+  actor_json: z.string(),
+  reason: z.string().nullable(),
+  details_json: z.string(),
+  timestamp: z.string(),
+});
 
-function rowToEvent(row: AuditRow): AuditEvent {
-  return {
-    id: row.id,
-    action: row.action as AuditEvent['action'],
-    memoryId: row.memory_id,
-    tenantId: row.tenant_id,
-    actor: JSON.parse(row.actor_json) as AuditEvent['actor'],
-    reason: row.reason ?? undefined,
-    details: JSON.parse(row.details_json) as AuditEvent['details'],
-    timestamp: row.timestamp,
-  };
+/**
+ * Parse a raw SQLite row into a validated AuditEvent domain object.
+ * Throws a descriptive error if the row fails validation.
+ *
+ * @param row - unknown value from better-sqlite3 .get()/.all()
+ * @returns validated AuditEvent
+ * @throws Error with row id and Zod issue details if parsing fails
+ */
+function rowToEvent(row: unknown): AuditEvent {
+  const flatResult = AuditRowSchema.safeParse(row);
+  if (!flatResult.success) {
+    const issues = flatResult.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+    throw new Error(`audit_events row failed flat validation: ${issues.join('; ')}`);
+  }
+  const flat = flatResult.data;
+
+  let actor: unknown;
+  let details: unknown;
+
+  try {
+    actor = JSON.parse(flat.actor_json);
+  } catch (e) {
+    throw new Error(`audit_events row id=${flat.id}: actor_json is not valid JSON: ${String(e)}`);
+  }
+  try {
+    details = JSON.parse(flat.details_json);
+  } catch (e) {
+    throw new Error(`audit_events row id=${flat.id}: details_json is not valid JSON: ${String(e)}`);
+  }
+
+  const domainResult = AuditEvent.safeParse({
+    id: flat.id,
+    action: flat.action,
+    memoryId: flat.memory_id,
+    tenantId: flat.tenant_id,
+    actor,
+    reason: flat.reason ?? undefined,
+    details,
+    timestamp: flat.timestamp,
+  });
+
+  if (!domainResult.success) {
+    const issues = domainResult.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+    throw new Error(
+      `audit_events row id=${flat.id} failed domain validation: ${issues.join('; ')}`,
+    );
+  }
+
+  return domainResult.data;
 }
 
 /**
@@ -89,19 +131,19 @@ export class AuditRepository {
 
   /** Return all events associated with the given memory, in chronological order. */
   findByMemory(memoryId: string): AuditEvent[] {
-    const rows = this.stmtFindByMemory.all(memoryId) as AuditRow[];
+    const rows = this.stmtFindByMemory.all(memoryId);
     return rows.map(rowToEvent);
   }
 
   /** Return all events for the given tenant, in chronological order. */
   findByTenant(tenantId: string): AuditEvent[] {
-    const rows = this.stmtFindByTenant.all(tenantId) as AuditRow[];
+    const rows = this.stmtFindByTenant.all(tenantId);
     return rows.map(rowToEvent);
   }
 
   /** Return all events of the given action type, in chronological order. */
   findByAction(action: string): AuditEvent[] {
-    const rows = this.stmtFindByAction.all(action) as AuditRow[];
+    const rows = this.stmtFindByAction.all(action);
     return rows.map(rowToEvent);
   }
 
@@ -117,7 +159,7 @@ export class AuditRepository {
 
   /** Find events within a time range (ISO string comparison) */
   findInRange(startDate: string, endDate: string): AuditEvent[] {
-    const rows = this.stmtFindInRange.all(startDate, endDate) as AuditRow[];
+    const rows = this.stmtFindInRange.all(startDate, endDate);
     return rows.map(rowToEvent);
   }
 

--- a/packages/store/src/repositories/candidate-repository.ts
+++ b/packages/store/src/repositories/candidate-repository.ts
@@ -1,39 +1,87 @@
+import { z } from 'zod';
 import type Database from 'better-sqlite3';
-import type { MemoryCandidate } from '@qmd-team-intent-kb/schema';
+import { MemoryCandidate } from '@qmd-team-intent-kb/schema';
 
-/** Raw SQLite row shape for the candidates table */
-interface CandidateRow {
-  id: string;
-  status: string;
-  source: string;
-  content: string;
-  title: string;
-  category: string;
-  trust_level: string;
-  author_json: string;
-  tenant_id: string;
-  metadata_json: string;
-  pre_policy_flags_json: string;
-  content_hash: string;
-  captured_at: string;
-  created_at: string;
-}
+/**
+ * Zod schema for the raw SQLite row returned by better-sqlite3.
+ * Validates the flat DB representation before domain parsing.
+ */
+const CandidateRowSchema = z.object({
+  id: z.string(),
+  status: z.string(),
+  source: z.string(),
+  content: z.string(),
+  title: z.string(),
+  category: z.string(),
+  trust_level: z.string(),
+  author_json: z.string(),
+  tenant_id: z.string(),
+  metadata_json: z.string(),
+  pre_policy_flags_json: z.string(),
+  content_hash: z.string(),
+  captured_at: z.string(),
+  created_at: z.string(),
+});
 
-function rowToCandidate(row: CandidateRow): MemoryCandidate {
-  return {
-    id: row.id,
-    status: row.status as MemoryCandidate['status'],
-    source: row.source as MemoryCandidate['source'],
-    content: row.content,
-    title: row.title,
-    category: row.category as MemoryCandidate['category'],
-    trustLevel: row.trust_level as MemoryCandidate['trustLevel'],
-    author: JSON.parse(row.author_json) as MemoryCandidate['author'],
-    tenantId: row.tenant_id,
-    metadata: JSON.parse(row.metadata_json) as MemoryCandidate['metadata'],
-    prePolicyFlags: JSON.parse(row.pre_policy_flags_json) as MemoryCandidate['prePolicyFlags'],
-    capturedAt: row.captured_at,
-  };
+/**
+ * Parse a raw SQLite row into a validated MemoryCandidate domain object.
+ * Throws a descriptive error if the row fails validation.
+ *
+ * @param row - unknown value from better-sqlite3 .get()/.all()
+ * @returns validated MemoryCandidate
+ * @throws Error with row id and Zod issue details if parsing fails
+ */
+function rowToCandidate(row: unknown): MemoryCandidate {
+  const flatResult = CandidateRowSchema.safeParse(row);
+  if (!flatResult.success) {
+    const issues = flatResult.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+    throw new Error(`candidates row failed flat validation: ${issues.join('; ')}`);
+  }
+  const flat = flatResult.data;
+
+  let author: unknown;
+  let metadata: unknown;
+  let prePolicyFlags: unknown;
+
+  try {
+    author = JSON.parse(flat.author_json);
+  } catch (e) {
+    throw new Error(`candidates row id=${flat.id}: author_json is not valid JSON: ${String(e)}`);
+  }
+  try {
+    metadata = JSON.parse(flat.metadata_json);
+  } catch (e) {
+    throw new Error(`candidates row id=${flat.id}: metadata_json is not valid JSON: ${String(e)}`);
+  }
+  try {
+    prePolicyFlags = JSON.parse(flat.pre_policy_flags_json);
+  } catch (e) {
+    throw new Error(
+      `candidates row id=${flat.id}: pre_policy_flags_json is not valid JSON: ${String(e)}`,
+    );
+  }
+
+  const domainResult = MemoryCandidate.safeParse({
+    id: flat.id,
+    status: flat.status,
+    source: flat.source,
+    content: flat.content,
+    title: flat.title,
+    category: flat.category,
+    trustLevel: flat.trust_level,
+    author,
+    tenantId: flat.tenant_id,
+    metadata,
+    prePolicyFlags,
+    capturedAt: flat.captured_at,
+  });
+
+  if (!domainResult.success) {
+    const issues = domainResult.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+    throw new Error(`candidates row id=${flat.id} failed domain validation: ${issues.join('; ')}`);
+  }
+
+  return domainResult.data;
 }
 
 /**
@@ -104,13 +152,13 @@ export class CandidateRepository {
 
   /** Find a candidate by its primary key, or return null if not found. */
   findById(id: string): MemoryCandidate | null {
-    const row = this.stmtFindById.get(id) as CandidateRow | undefined;
+    const row = this.stmtFindById.get(id);
     return row !== undefined ? rowToCandidate(row) : null;
   }
 
   /** Return all candidates belonging to the given tenant. */
   findByTenant(tenantId: string): MemoryCandidate[] {
-    const rows = this.stmtFindByTenant.all(tenantId) as CandidateRow[];
+    const rows = this.stmtFindByTenant.all(tenantId);
     return rows.map(rowToCandidate);
   }
 
@@ -119,7 +167,7 @@ export class CandidateRepository {
    * Useful for duplicate detection before insertion.
    */
   findByContentHash(hash: string): MemoryCandidate | null {
-    const row = this.stmtFindByHash.get(hash) as CandidateRow | undefined;
+    const row = this.stmtFindByHash.get(hash);
     return row !== undefined ? rowToCandidate(row) : null;
   }
 

--- a/packages/store/src/repositories/export-state-repository.ts
+++ b/packages/store/src/repositories/export-state-repository.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type Database from 'better-sqlite3';
 
 /** The last-export tracking record for a single export target */
@@ -7,18 +8,35 @@ export interface ExportState {
   updatedAt: string;
 }
 
-/** Raw SQLite row shape for the export_state table */
-interface ExportStateRow {
-  target_id: string;
-  last_exported_at: string;
-  updated_at: string;
-}
+/**
+ * Zod schema for the raw SQLite row returned by better-sqlite3.
+ * Validates the flat DB representation before mapping to ExportState.
+ */
+const ExportStateRowSchema = z.object({
+  target_id: z.string(),
+  last_exported_at: z.string(),
+  updated_at: z.string(),
+});
 
-function rowToState(row: ExportStateRow): ExportState {
+/**
+ * Parse a raw SQLite row into a validated ExportState object.
+ * Throws a descriptive error if the row fails validation.
+ *
+ * @param row - unknown value from better-sqlite3 .get()
+ * @returns validated ExportState
+ * @throws Error with column details if parsing fails
+ */
+function rowToState(row: unknown): ExportState {
+  const result = ExportStateRowSchema.safeParse(row);
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+    throw new Error(`export_state row failed validation: ${issues.join('; ')}`);
+  }
+  const flat = result.data;
   return {
-    targetId: row.target_id,
-    lastExportedAt: row.last_exported_at,
-    updatedAt: row.updated_at,
+    targetId: flat.target_id,
+    lastExportedAt: flat.last_exported_at,
+    updatedAt: flat.updated_at,
   };
 }
 
@@ -47,7 +65,7 @@ export class ExportStateRepository {
 
   /** Return the export state for the given target, or null if never exported. */
   get(targetId: string): ExportState | null {
-    const row = this.stmtGet.get(targetId) as ExportStateRow | undefined;
+    const row = this.stmtGet.get(targetId);
     return row !== undefined ? rowToState(row) : null;
   }
 

--- a/packages/store/src/repositories/memory-repository.ts
+++ b/packages/store/src/repositories/memory-repository.ts
@@ -1,58 +1,124 @@
+import { z } from 'zod';
 import type Database from 'better-sqlite3';
-import type { CuratedMemory, MemoryLifecycleState } from '@qmd-team-intent-kb/schema';
+import { CuratedMemory } from '@qmd-team-intent-kb/schema';
+import type { MemoryLifecycleState } from '@qmd-team-intent-kb/schema';
 
-/** Raw SQLite row shape for the curated_memories table */
-interface MemoryRow {
-  id: string;
-  candidate_id: string;
-  source: string;
-  content: string;
-  title: string;
-  category: string;
-  trust_level: string;
-  sensitivity: string;
-  author_json: string;
-  tenant_id: string;
-  metadata_json: string;
-  lifecycle: string;
-  content_hash: string;
-  policy_evaluations_json: string;
-  supersession_json: string | null;
-  promoted_at: string;
-  promoted_by_json: string;
-  updated_at: string;
-  version: number;
-}
+/**
+ * Zod schema for the raw SQLite row returned by better-sqlite3.
+ * Validates the flat DB representation before domain parsing.
+ */
+const MemoryRowSchema = z.object({
+  id: z.string(),
+  candidate_id: z.string(),
+  source: z.string(),
+  content: z.string(),
+  title: z.string(),
+  category: z.string(),
+  trust_level: z.string(),
+  sensitivity: z.string(),
+  author_json: z.string(),
+  tenant_id: z.string(),
+  metadata_json: z.string(),
+  lifecycle: z.string(),
+  content_hash: z.string(),
+  policy_evaluations_json: z.string(),
+  supersession_json: z.string().nullable(),
+  promoted_at: z.string(),
+  promoted_by_json: z.string(),
+  updated_at: z.string(),
+  version: z.number(),
+});
 
-function rowToMemory(row: MemoryRow): CuratedMemory {
-  const base = {
-    id: row.id,
-    candidateId: row.candidate_id,
-    source: row.source as CuratedMemory['source'],
-    content: row.content,
-    title: row.title,
-    category: row.category as CuratedMemory['category'],
-    trustLevel: row.trust_level as CuratedMemory['trustLevel'],
-    sensitivity: row.sensitivity as CuratedMemory['sensitivity'],
-    author: JSON.parse(row.author_json) as CuratedMemory['author'],
-    tenantId: row.tenant_id,
-    metadata: JSON.parse(row.metadata_json) as CuratedMemory['metadata'],
-    lifecycle: row.lifecycle as CuratedMemory['lifecycle'],
-    contentHash: row.content_hash,
-    policyEvaluations: JSON.parse(
-      row.policy_evaluations_json,
-    ) as CuratedMemory['policyEvaluations'],
-    supersession:
-      row.supersession_json !== null
-        ? (JSON.parse(row.supersession_json) as CuratedMemory['supersession'])
-        : undefined,
-    promotedAt: row.promoted_at,
-    promotedBy: JSON.parse(row.promoted_by_json) as CuratedMemory['promotedBy'],
-    updatedAt: row.updated_at,
-    version: row.version,
-  };
+/**
+ * Parse a raw SQLite row into a validated CuratedMemory domain object.
+ * Throws a descriptive error if the row fails validation.
+ *
+ * @param row - unknown value from better-sqlite3 .get()/.all()
+ * @returns validated CuratedMemory
+ * @throws Error with row id and Zod issue details if parsing fails
+ */
+function rowToMemory(row: unknown): CuratedMemory {
+  const flatResult = MemoryRowSchema.safeParse(row);
+  if (!flatResult.success) {
+    const issues = flatResult.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+    throw new Error(`curated_memories row failed flat validation: ${issues.join('; ')}`);
+  }
+  const flat = flatResult.data;
 
-  return base as CuratedMemory;
+  let author: unknown;
+  let metadata: unknown;
+  let policyEvaluations: unknown;
+  let supersession: unknown;
+  let promotedBy: unknown;
+
+  try {
+    author = JSON.parse(flat.author_json);
+  } catch (e) {
+    throw new Error(
+      `curated_memories row id=${flat.id}: author_json is not valid JSON: ${String(e)}`,
+    );
+  }
+  try {
+    metadata = JSON.parse(flat.metadata_json);
+  } catch (e) {
+    throw new Error(
+      `curated_memories row id=${flat.id}: metadata_json is not valid JSON: ${String(e)}`,
+    );
+  }
+  try {
+    policyEvaluations = JSON.parse(flat.policy_evaluations_json);
+  } catch (e) {
+    throw new Error(
+      `curated_memories row id=${flat.id}: policy_evaluations_json is not valid JSON: ${String(e)}`,
+    );
+  }
+  if (flat.supersession_json !== null) {
+    try {
+      supersession = JSON.parse(flat.supersession_json);
+    } catch (e) {
+      throw new Error(
+        `curated_memories row id=${flat.id}: supersession_json is not valid JSON: ${String(e)}`,
+      );
+    }
+  }
+  try {
+    promotedBy = JSON.parse(flat.promoted_by_json);
+  } catch (e) {
+    throw new Error(
+      `curated_memories row id=${flat.id}: promoted_by_json is not valid JSON: ${String(e)}`,
+    );
+  }
+
+  const domainResult = CuratedMemory.safeParse({
+    id: flat.id,
+    candidateId: flat.candidate_id,
+    source: flat.source,
+    content: flat.content,
+    title: flat.title,
+    category: flat.category,
+    trustLevel: flat.trust_level,
+    sensitivity: flat.sensitivity,
+    author,
+    tenantId: flat.tenant_id,
+    metadata,
+    lifecycle: flat.lifecycle,
+    contentHash: flat.content_hash,
+    policyEvaluations,
+    supersession,
+    promotedAt: flat.promoted_at,
+    promotedBy,
+    updatedAt: flat.updated_at,
+    version: flat.version,
+  });
+
+  if (!domainResult.success) {
+    const issues = domainResult.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+    throw new Error(
+      `curated_memories row id=${flat.id} failed domain validation: ${issues.join('; ')}`,
+    );
+  }
+
+  return domainResult.data;
 }
 
 /**
@@ -237,13 +303,13 @@ export class MemoryRepository {
 
   /** Find a memory by its primary key, or return null if not found. */
   findById(id: string): CuratedMemory | null {
-    const row = this.stmtFindById.get(id) as MemoryRow | undefined;
+    const row = this.stmtFindById.get(id);
     return row !== undefined ? rowToMemory(row) : null;
   }
 
   /** Return all curated memories belonging to the given tenant. */
   findByTenant(tenantId: string): CuratedMemory[] {
-    const rows = this.stmtFindByTenant.all(tenantId) as MemoryRow[];
+    const rows = this.stmtFindByTenant.all(tenantId);
     return rows.map(rowToMemory);
   }
 
@@ -252,13 +318,13 @@ export class MemoryRepository {
    * Useful for duplicate detection before promotion.
    */
   findByContentHash(hash: string): CuratedMemory | null {
-    const row = this.stmtFindByHash.get(hash) as MemoryRow | undefined;
+    const row = this.stmtFindByHash.get(hash);
     return row !== undefined ? rowToMemory(row) : null;
   }
 
   /** Return all memories in the given lifecycle state. */
   findByLifecycle(lifecycle: MemoryLifecycleState): CuratedMemory[] {
-    const rows = this.stmtFindByLifecycle.all(lifecycle) as MemoryRow[];
+    const rows = this.stmtFindByLifecycle.all(lifecycle);
     return rows.map(rowToMemory);
   }
 
@@ -345,13 +411,13 @@ export class MemoryRepository {
 
   /** Find active memories not updated since the given ISO date */
   findStale(olderThan: string): CuratedMemory[] {
-    const rows = this.stmtFindStale.all(olderThan) as MemoryRow[];
+    const rows = this.stmtFindStale.all(olderThan);
     return rows.map(rowToMemory);
   }
 
   /** Find memories by tenant and lifecycle state */
   findByTenantAndLifecycle(tenantId: string, lifecycle: MemoryLifecycleState): CuratedMemory[] {
-    const rows = this.stmtFindByTenantAndLifecycle.all(tenantId, lifecycle) as MemoryRow[];
+    const rows = this.stmtFindByTenantAndLifecycle.all(tenantId, lifecycle);
     return rows.map(rowToMemory);
   }
 
@@ -388,7 +454,7 @@ export class MemoryRepository {
       ORDER BY rank
       LIMIT 100
     `;
-    const rows = this.db.prepare(sql).all(params) as MemoryRow[];
+    const rows = this.db.prepare(sql).all(params);
     return rows.map(rowToMemory);
   }
 
@@ -404,7 +470,7 @@ export class MemoryRepository {
     appendOptionalFilters(conditions, params, tenantId, categories, '');
 
     const sql = `SELECT * FROM curated_memories WHERE ${conditions.join(' AND ')} LIMIT 100`;
-    const rows = this.db.prepare(sql).all(params) as MemoryRow[];
+    const rows = this.db.prepare(sql).all(params);
     return rows.map(rowToMemory);
   }
 }

--- a/packages/store/src/repositories/policy-repository.ts
+++ b/packages/store/src/repositories/policy-repository.ts
@@ -1,29 +1,66 @@
+import { z } from 'zod';
 import type Database from 'better-sqlite3';
-import type { GovernancePolicy } from '@qmd-team-intent-kb/schema';
+import { GovernancePolicy } from '@qmd-team-intent-kb/schema';
 
-/** Raw SQLite row shape for the governance_policies table */
-interface PolicyRow {
-  id: string;
-  name: string;
-  tenant_id: string;
-  rules_json: string;
-  enabled: number;
-  version: number;
-  created_at: string;
-  updated_at: string;
-}
+/**
+ * Zod schema for the raw SQLite row returned by better-sqlite3.
+ * Validates the flat DB representation before domain parsing.
+ */
+const PolicyRowSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  tenant_id: z.string(),
+  rules_json: z.string(),
+  enabled: z.number(),
+  version: z.number(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
 
-function rowToPolicy(row: PolicyRow): GovernancePolicy {
-  return {
-    id: row.id,
-    name: row.name,
-    tenantId: row.tenant_id,
-    rules: JSON.parse(row.rules_json) as GovernancePolicy['rules'],
-    enabled: row.enabled !== 0,
-    version: row.version,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-  };
+/**
+ * Parse a raw SQLite row into a validated GovernancePolicy domain object.
+ * Throws a descriptive error if the row fails validation.
+ *
+ * @param row - unknown value from better-sqlite3 .get()/.all()
+ * @returns validated GovernancePolicy
+ * @throws Error with row id and Zod issue details if parsing fails
+ */
+function rowToPolicy(row: unknown): GovernancePolicy {
+  const flatResult = PolicyRowSchema.safeParse(row);
+  if (!flatResult.success) {
+    const issues = flatResult.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+    throw new Error(`governance_policies row failed flat validation: ${issues.join('; ')}`);
+  }
+  const flat = flatResult.data;
+
+  let rules: unknown;
+  try {
+    rules = JSON.parse(flat.rules_json);
+  } catch (e) {
+    throw new Error(
+      `governance_policies row id=${flat.id}: rules_json is not valid JSON: ${String(e)}`,
+    );
+  }
+
+  const domainResult = GovernancePolicy.safeParse({
+    id: flat.id,
+    name: flat.name,
+    tenantId: flat.tenant_id,
+    rules,
+    enabled: flat.enabled !== 0,
+    version: flat.version,
+    createdAt: flat.created_at,
+    updatedAt: flat.updated_at,
+  });
+
+  if (!domainResult.success) {
+    const issues = domainResult.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+    throw new Error(
+      `governance_policies row id=${flat.id} failed domain validation: ${issues.join('; ')}`,
+    );
+  }
+
+  return domainResult.data;
 }
 
 /**
@@ -86,13 +123,13 @@ export class PolicyRepository {
 
   /** Find a policy by its primary key, or return null if not found. */
   findById(id: string): GovernancePolicy | null {
-    const row = this.stmtFindById.get(id) as PolicyRow | undefined;
+    const row = this.stmtFindById.get(id);
     return row !== undefined ? rowToPolicy(row) : null;
   }
 
   /** Return all policies belonging to the given tenant. */
   findByTenant(tenantId: string): GovernancePolicy[] {
-    const rows = this.stmtFindByTenant.all(tenantId) as PolicyRow[];
+    const rows = this.stmtFindByTenant.all(tenantId);
     return rows.map(rowToPolicy);
   }
 


### PR DESCRIPTION
## Summary

- **Before**: ~40 `as <T>` casts in 5 store repositories silently widened `unknown` DB rows to domain types — invalid enum values, malformed JSON, and schema drift all passed through undetected.
- **After**: Each row-to-domain mapper validates the flat SQLite row via a `*RowSchema`, parses JSON columns with per-column try/catch (throwing with `row id=<id>: <column> is not valid JSON`), then runs the domain Zod schema's `.safeParse()` with full issue details in the error message.
- **Cast count**: ~40 domain-mapping/row casts removed → 0 domain casts remaining. ~17 aggregation-only `as { cnt: number }` / `as Array<{ ... }>` casts retained (transient scalar projections with no domain Zod schema).

## Performance note

All domain-mapping paths use `.safeParse()` (never `.parse()` — no throw on success path, error object on failure). Zod v3 `.safeParse()` on small flat objects adds ~1–5 µs per row. For `findAll`-style queries, worst-case ~1k rows × 5 µs = ~5 ms overhead, which is acceptable for this read profile. No hot-path opt-out implemented; the correctness guarantee is worth the cost. If a future profiling pass identifies a specific query as a bottleneck, a sampling approach can be added at that point.

## Repositories where Zod-on-read was rejected

- `ExportState` (export-state-repository): no domain Zod schema exists (local interface, 3 flat string columns, no JSON). Added a `ExportStateRowSchema` flat-row validator for the single `.get()` call — this covers schema drift without needing a domain schema.

## Test plan

- [x] 86 pre-existing store tests pass unchanged
- [x] 4 new malformed-row tests added:
  - `CandidateRepository`: throws on invalid JSON in `author_json`; throws on invalid enum in `status`
  - `MemoryRepository`: throws on invalid JSON in `policy_evaluations_json`; throws on invalid enum in `lifecycle`
- [x] `pnpm --filter @qmd-team-intent-kb/store typecheck` passes
- [x] `pnpm --filter @qmd-team-intent-kb/store test` passes (90/90)
- [x] `pnpm format` applied — 5 repository files reformatted, 2 test files reformatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)