### PR TITLE
chore(edge-daemon): remove unused RetryOptions.nowFn field

### DIFF
--- a/apps/edge-daemon/src/retry.ts
+++ b/apps/edge-daemon/src/retry.ts
@@ -32,7 +32,6 @@ interface RetryOptions {
   maxRetries: number;
   baseDelayMs: number;
   maxJitterMs: number;
-  nowFn?: () => string;
   sleepFn?: (ms: number) => Promise<void>;
 }
 


### PR DESCRIPTION
Copy-paste artifact from the deterministic-time pattern elsewhere. `withRetry()` never reads it; `RetryOptions` is module-private with no external consumers.

Closes bead qmd-team-intent-kb-ae3.

## Test plan
- [x] typecheck clean
- [ ] CI validate green