### PR TITLE
refactor(schema tests): replace 'as Record<string, unknown>' delete pattern with typed alternatives

### DIFF
--- a/packages/schema/src/__tests__/audit-event.test.ts
+++ b/packages/schema/src/__tests__/audit-event.test.ts
@@ -26,15 +26,13 @@ describe('AuditEvent', () => {
   });
 
   it('defaults details to empty object', () => {
-    const input = makeAuditEvent();
-    delete (input as Record<string, unknown>)['details'];
+    const { details: _removed, ...input } = makeAuditEvent();
     const result = AuditEvent.parse(input);
     expect(result.details).toEqual({});
   });
 
   it('accepts optional reason', () => {
-    const input = makeAuditEvent();
-    delete (input as Record<string, unknown>)['reason'];
+    const { reason: _removed, ...input } = makeAuditEvent();
     const result = AuditEvent.parse(input);
     expect(result.reason).toBeUndefined();
   });
@@ -53,26 +51,22 @@ describe('AuditEvent', () => {
   });
 
   it('rejects missing action', () => {
-    const input = makeAuditEvent();
-    delete (input as Record<string, unknown>)['action'];
+    const { action: _removed, ...input } = makeAuditEvent();
     expect(() => AuditEvent.parse(input)).toThrow();
   });
 
   it('rejects missing memoryId', () => {
-    const input = makeAuditEvent();
-    delete (input as Record<string, unknown>)['memoryId'];
+    const { memoryId: _removed, ...input } = makeAuditEvent();
     expect(() => AuditEvent.parse(input)).toThrow();
   });
 
   it('rejects missing tenantId', () => {
-    const input = makeAuditEvent();
-    delete (input as Record<string, unknown>)['tenantId'];
+    const { tenantId: _removed, ...input } = makeAuditEvent();
     expect(() => AuditEvent.parse(input)).toThrow();
   });
 
   it('rejects missing actor', () => {
-    const input = makeAuditEvent();
-    delete (input as Record<string, unknown>)['actor'];
+    const { actor: _removed, ...input } = makeAuditEvent();
     expect(() => AuditEvent.parse(input)).toThrow();
   });
 

--- a/packages/schema/src/__tests__/curated-memory.test.ts
+++ b/packages/schema/src/__tests__/curated-memory.test.ts
@@ -69,22 +69,19 @@ describe('CuratedMemory', () => {
   });
 
   it('defaults sensitivity to internal', () => {
-    const input = makeCuratedMemory();
-    delete (input as Record<string, unknown>)['sensitivity'];
+    const { sensitivity: _removed, ...input } = makeCuratedMemory();
     const result = CuratedMemory.parse(input);
     expect(result.sensitivity).toBe('internal');
   });
 
   it('defaults version to 1', () => {
-    const input = makeCuratedMemory();
-    delete (input as Record<string, unknown>)['version'];
+    const { version: _removed, ...input } = makeCuratedMemory();
     const result = CuratedMemory.parse(input);
     expect(result.version).toBe(1);
   });
 
   it('defaults policyEvaluations to empty array', () => {
-    const input = makeCuratedMemory();
-    delete (input as Record<string, unknown>)['policyEvaluations'];
+    const { policyEvaluations: _removed, ...input } = makeCuratedMemory();
     const result = CuratedMemory.parse(input);
     expect(result.policyEvaluations).toEqual([]);
   });

--- a/packages/schema/src/__tests__/governance-policy.test.ts
+++ b/packages/schema/src/__tests__/governance-policy.test.ts
@@ -87,28 +87,24 @@ describe('GovernancePolicy', () => {
   });
 
   it('defaults enabled to true', () => {
-    const input = makeGovernancePolicy();
-    delete (input as Record<string, unknown>)['enabled'];
+    const { enabled: _removed, ...input } = makeGovernancePolicy();
     const result = GovernancePolicy.parse(input);
     expect(result.enabled).toBe(true);
   });
 
   it('defaults version to 1', () => {
-    const input = makeGovernancePolicy();
-    delete (input as Record<string, unknown>)['version'];
+    const { version: _removed, ...input } = makeGovernancePolicy();
     const result = GovernancePolicy.parse(input);
     expect(result.version).toBe(1);
   });
 
   it('rejects missing name', () => {
-    const input = makeGovernancePolicy();
-    delete (input as Record<string, unknown>)['name'];
+    const { name: _removed, ...input } = makeGovernancePolicy();
     expect(() => GovernancePolicy.parse(input)).toThrow();
   });
 
   it('rejects missing tenantId', () => {
-    const input = makeGovernancePolicy();
-    delete (input as Record<string, unknown>)['tenantId'];
+    const { tenantId: _removed, ...input } = makeGovernancePolicy();
     expect(() => GovernancePolicy.parse(input)).toThrow();
   });
 

--- a/packages/schema/src/__tests__/memory-candidate.test.ts
+++ b/packages/schema/src/__tests__/memory-candidate.test.ts
@@ -28,36 +28,31 @@ describe('MemoryCandidate', () => {
   });
 
   it('defaults trustLevel to medium', () => {
-    const input = makeMemoryCandidate();
-    delete (input as Record<string, unknown>)['trustLevel'];
+    const { trustLevel: _removed, ...input } = makeMemoryCandidate();
     const result = MemoryCandidate.parse(input);
     expect(result.trustLevel).toBe('medium');
   });
 
   it('defaults metadata to empty', () => {
-    const input = makeMemoryCandidate();
-    delete (input as Record<string, unknown>)['metadata'];
+    const { metadata: _removed, ...input } = makeMemoryCandidate();
     const result = MemoryCandidate.parse(input);
     expect(result.metadata.filePaths).toEqual([]);
     expect(result.metadata.tags).toEqual([]);
   });
 
   it('defaults prePolicyFlags to all false', () => {
-    const input = makeMemoryCandidate();
-    delete (input as Record<string, unknown>)['prePolicyFlags'];
+    const { prePolicyFlags: _removed, ...input } = makeMemoryCandidate();
     const result = MemoryCandidate.parse(input);
     expect(result.prePolicyFlags.potentialSecret).toBe(false);
   });
 
   it('rejects missing required id', () => {
-    const input = makeMemoryCandidate();
-    delete (input as Record<string, unknown>)['id'];
+    const { id: _removed, ...input } = makeMemoryCandidate();
     expect(() => MemoryCandidate.parse(input)).toThrow();
   });
 
   it('rejects missing required content', () => {
-    const input = makeMemoryCandidate();
-    delete (input as Record<string, unknown>)['content'];
+    const { content: _removed, ...input } = makeMemoryCandidate();
     expect(() => MemoryCandidate.parse(input)).toThrow();
   });
 

--- a/packages/schema/src/__tests__/search.test.ts
+++ b/packages/schema/src/__tests__/search.test.ts
@@ -140,8 +140,7 @@ describe('SearchResult', () => {
   });
 
   it('rejects missing query', () => {
-    const input = makeSearchResult();
-    delete (input as Record<string, unknown>)['query'];
+    const { query: _removed, ...input } = makeSearchResult();
     expect(() => SearchResult.parse(input)).toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- Replaces all 19 occurrences of `delete (input as Record<string, unknown>)[field]` with cast-free rest-destructure: `const { [field]: _removed, ...input } = fixture()`
- Affects 5 files: `memory-candidate.test.ts` (5 occurrences), `audit-event.test.ts` (6), `governance-policy.test.ts` (4), `curated-memory.test.ts` (3), `search.test.ts` (1)
- No schema definitions changed — this is a pure test-pattern refactor
- All fixture factories already returned `Record<string, unknown>`, so the casts were entirely redundant
- Strict `noUnusedLocals` compliance maintained by using `_removed` binding names per project ESLint convention

## Test plan

- [x] `pnpm --filter @qmd-team-intent-kb/schema typecheck` — passes (0 errors)
- [x] `pnpm --filter @qmd-team-intent-kb/schema test` — 230/230 tests pass (8 test files)
- [x] `pnpm format:check` — all files already Prettier-clean (no reformatting needed)
- [x] `pnpm lint` — no ESLint errors
- [x] `pnpm typecheck` — full composite build passes
- [x] Pre-existing `better-sqlite3` native-binding failures in sandbox are unrelated to this change

Closes bead `qmd-team-intent-kb-uph`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)