### PR TITLE
improve(edge-daemon): surface repo-scope unscoped-candidate count

### DIFF
--- a/apps/edge-daemon/src/__tests__/repo-scope.test.ts
+++ b/apps/edge-daemon/src/__tests__/repo-scope.test.ts
@@ -39,7 +39,7 @@ describe('filterByRepoScope', () => {
     expect(warns[0]?.message).toContain('repo-scope');
   });
 
-  it('keeps candidates that have no repoUrl (pre-tagging passthrough)', () => {
+  it('keeps candidates that have no repoUrl (pre-tagging passthrough) and counts them as unscoped', () => {
     const noUrl = makeCandidate({ metadata: { filePaths: [], tags: [] } });
     const logger = new RecordingLogger();
 
@@ -47,6 +47,11 @@ describe('filterByRepoScope', () => {
 
     expect(result.kept).toHaveLength(1);
     expect(result.skipped).toBe(0);
+    expect(result.unscoped).toBe(1);
+    // Operator-visible info log when anything bypasses scoping.
+    const infos = logger.messages.filter((m) => m.level === 'info');
+    expect(infos).toHaveLength(1);
+    expect(infos[0]?.message).toContain('bypassed scoping');
   });
 
   it('normalizes trailing .git before comparing', () => {

--- a/apps/edge-daemon/src/repo-scope.ts
+++ b/apps/edge-daemon/src/repo-scope.ts
@@ -5,6 +5,13 @@ import type { DaemonLogger } from './types.js';
 interface RepoScopeResult {
   kept: MemoryCandidate[];
   skipped: number;
+  /**
+   * Candidates kept despite having no `metadata.repoUrl`. They bypassed
+   * scoping entirely — the flag's isolation is weaker than the name implies.
+   * Operators enabling `scopeByRepo=true` need visibility into how many
+   * candidates are unscoped per cycle.
+   */
+  unscoped: number;
 }
 
 /**
@@ -22,12 +29,14 @@ export function filterByRepoScope(
 ): RepoScopeResult {
   const kept: MemoryCandidate[] = [];
   let skipped = 0;
+  let unscoped = 0;
 
   for (const candidate of candidates) {
     const candidateUrl = candidate.metadata.repoUrl;
 
     if (!candidateUrl) {
       kept.push(candidate);
+      unscoped++;
       continue;
     }
 
@@ -41,7 +50,11 @@ export function filterByRepoScope(
     }
   }
 
-  return { kept, skipped };
+  if (unscoped > 0) {
+    logger.info(`[repo-scope] ${unscoped} candidate(s) kept without repoUrl (bypassed scoping)`);
+  }
+
+  return { kept, skipped, unscoped };
 }
 
 /** Normalize a remote URL for comparison: trim whitespace, strip trailing .git */


### PR DESCRIPTION
Adds `unscoped` field to `RepoScopeResult` tracking candidates kept with no `metadata.repoUrl` (they bypassed scoping). Emits an info log per cycle when `unscoped > 0` so operators running `scopeByRepo=true` can see how weak the isolation actually is.

Closes bead qmd-team-intent-kb-8e7.

## Test plan
- [x] repo-scope tests: 7/7 pass (1 updated to assert the new counter + info log)
- [ ] CI validate green