### PR TITLE
chore(test-fixtures): simplify makeCandidateWithHash (Gemini follow-up on #80)

### DIFF
--- a/packages/test-fixtures/src/make-candidate.ts
+++ b/packages/test-fixtures/src/make-candidate.ts
@@ -34,8 +34,6 @@ export function makeCandidateWithHash(overrides?: Record<string, unknown>): {
   candidate: MemoryCandidate;
   contentHash: string;
 } {
-  const content =
-    typeof overrides?.['content'] === 'string' ? overrides['content'] : DEFAULT_CONTENT;
   const candidate = makeCandidate(overrides);
-  return { candidate, contentHash: computeContentHash(content) };
+  return { candidate, contentHash: computeContentHash(candidate.content) };
 }


### PR DESCRIPTION
Post-merge Gemini comment on PR #80 flagged that `makeCandidateWithHash` duplicated the DEFAULT_CONTENT fallback already handled inside `makeCandidate`. Fix: create candidate first, then `computeContentHash(candidate.content)`.

Closes bead qmd-team-intent-kb-pk6.

## Test plan
- [x] typecheck clean
- [ ] CI validate green (no test changes — shared fixtures used by 1160+ tests)