### PR TITLE
feat(publishing): add publishConfig for reusable library packages

### DIFF
--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -25,6 +25,7 @@
 
 - `008-OD-RELS-release-versioning-policy.md` — Semantic versioning and changelog policy
 - `020-OD-RELS-v1-release-checklist.md` — v1 release checklist and gates
+- `029-OD-RELS-npm-publishing-strategy.md` — Which packages are publishable to npm and how
 
 ### DR — Documentation & Reference
 
@@ -88,5 +89,6 @@
 | 025 | AA-AACR | v0.3.0-release-report       | v0.3.0 release report          |
 | 026 | AT-DSGN | repo-resolver-design        | repo-resolver package design   |
 | 027 | OD-OPSM | edge-daemon-runbook         | edge-daemon operations runbook |
+| 029 | OD-RELS | npm-publishing-strategy     | npm publishing strategy        |
 
-## Next Available Sequence: 028
+## Next Available Sequence: 030

--- a/000-docs/029-OD-RELS-npm-publishing-strategy.md
+++ b/000-docs/029-OD-RELS-npm-publishing-strategy.md
@@ -1,0 +1,70 @@
+# npm Publishing Strategy
+
+> Defines which workspace packages are reusable libraries suitable for public npm registry publication, which are deliberately kept private, and the mechanical workflow for cutting a registry release. This is infrastructure configuration — it does not commit the project to publishing on any specific timeline.
+
+---
+
+## Publishable Packages
+
+The following packages expose stable, externally reusable surfaces and carry `publishConfig.access = public`:
+
+| Package                             | Rationale                                                                                                     | External Deps        |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `@qmd-team-intent-kb/schema`        | Zod domain model and lifecycle state machine — consumers need these types to integrate with the control plane | `zod`                |
+| `@qmd-team-intent-kb/common`        | Result type, hashing, freshness scoring — primitives useful beyond this project                               | none (node builtins) |
+| `@qmd-team-intent-kb/repo-resolver` | Generic git repo context + tenant derivation utility                                                          | `zod`, `common`      |
+
+Each of these package.json files now declares:
+
+- `publishConfig.access = "public"` (explicit, even though scoped packages on unscoped-public orgs default to this)
+- `files: ["dist", "README.md"]` — ship compiled output and docs only, no sources or tests
+- `main` and `types` pointing into `dist/`
+- No `private: true` flag
+- A minimal README.md at the package root
+
+## Private (Non-publishable) Packages
+
+The following packages are kept private (`private: true`) and will be skipped by `pnpm publish -r`:
+
+| Package                              | Reason                                                                                                                                                                                                           |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@qmd-team-intent-kb/store`          | Uses `better-sqlite3` native binding and exposes repository internals tightly coupled to our schema                                                                                                              |
+| `@qmd-team-intent-kb/qmd-adapter`    | Thin wrapper around the local qmd CLI; operational glue, not a reusable library                                                                                                                                  |
+| `@qmd-team-intent-kb/claude-runtime` | Session capture and spool paths are tightly coupled to internal filesystem conventions                                                                                                                           |
+| `@qmd-team-intent-kb/test-fixtures`  | Test-only helpers — no reason to publish                                                                                                                                                                         |
+| `@qmd-team-intent-kb/policy-engine`  | Transitively depends on `claude-runtime` (secret detection, content classification). Cannot be published until that dependency is refactored behind an interface the engine itself owns. Tracked as a follow-up. |
+
+All apps under `apps/*` are also `private: true` — they are deployables, not libraries.
+
+## Known Blocker: policy-engine
+
+`packages/policy-engine` is a strong candidate for publication in principle (deterministic governance pipeline, useful as a standalone package), but it currently imports:
+
+- `classifyContent` from `@qmd-team-intent-kb/claude-runtime`
+- `scanForSecrets` from `@qmd-team-intent-kb/claude-runtime`
+
+Publishing it as-is would require also publishing `claude-runtime`, which exposes internal spool paths we want to keep unpublished. The refactor path is to define a small `ContentClassifier` / `SecretScanner` interface inside `policy-engine` (or `schema`) and inject implementations from `claude-runtime` at the app layer. Once that seam exists, `policy-engine` can be flipped to publishable in the same way as `schema` and `common`.
+
+## Publishing Workflow
+
+This repository does not publish on every release yet. When we decide to publish, the workflow is:
+
+1. Ensure `pnpm validate` is green on the branch to be released.
+2. Bump versions across the workspace (`pnpm version:bump X.Y.Z` when available, or edit the three publishable package.json files manually and keep them in lockstep with the root version per the single-version strategy in `008-OD-RELS-release-versioning-policy.md`).
+3. Build all packages: `pnpm -r build`.
+4. Dry run: `pnpm publish -r --filter='./packages/{schema,common,repo-resolver}' --dry-run --access public --no-git-checks`.
+5. Publish: `pnpm publish -r --filter='./packages/{schema,common,repo-resolver}' --access public`.
+   Packages with `private: true` are automatically skipped by pnpm.
+6. Tag the release (`git tag vX.Y.Z && git push --tags`) and draft the GitHub Release from the `CHANGELOG.md` excerpt.
+
+## Guardrails
+
+- Root `package.json` stays `private: true` forever — the monorepo root is not a shippable artifact.
+- A naive `pnpm -r publish` will not leak private packages because every non-publishable package explicitly carries `private: true`.
+- The `files` allowlist on each publishable package ensures we never accidentally ship source, tests, tsbuildinfo, or internal scripts.
+- Package READMEs are intentionally minimal. Do not backfill marketing content into them; the repository root `README.md` and `000-docs/` carry the narrative.
+
+## Related Documents
+
+- `008-OD-RELS-release-versioning-policy.md` — semver, changelog, and release cadence policy
+- `020-OD-RELS-v1-release-checklist.md` — v1 release gating checklist

--- a/000-docs/029-OD-RELS-npm-publishing-strategy.md
+++ b/000-docs/029-OD-RELS-npm-publishing-strategy.md
@@ -52,10 +52,11 @@ This repository does not publish on every release yet. When we decide to publish
 1. Ensure `pnpm validate` is green on the branch to be released.
 2. Bump versions across the workspace (`pnpm version:bump X.Y.Z` when available, or edit the three publishable package.json files manually and keep them in lockstep with the root version per the single-version strategy in `008-OD-RELS-release-versioning-policy.md`).
 3. Build all packages: `pnpm -r build`.
-4. Dry run: `pnpm publish -r --filter='./packages/{schema,common,repo-resolver}' --dry-run --access public --no-git-checks`.
-5. Publish: `pnpm publish -r --filter='./packages/{schema,common,repo-resolver}' --access public`.
-   Packages with `private: true` are automatically skipped by pnpm.
-6. Tag the release (`git tag vX.Y.Z && git push --tags`) and draft the GitHub Release from the `CHANGELOG.md` excerpt.
+4. Dry run: `pnpm publish -r --filter '@qmd-team-intent-kb/schema' --filter '@qmd-team-intent-kb/common' --filter '@qmd-team-intent-kb/repo-resolver' --dry-run --access public --no-git-checks`.
+5. Publish: `pnpm publish -r --filter '@qmd-team-intent-kb/schema' --filter '@qmd-team-intent-kb/common' --filter '@qmd-team-intent-kb/repo-resolver' --access public`.
+
+Per-package `--filter` flags avoid shell brace-expansion surprises that would occur with the quoted path-glob form `'./packages/{schema,common,repo-resolver}'`.
+Packages with `private: true` are automatically skipped by pnpm. 6. Tag the release (`git tag vX.Y.Z && git push --tags`) and draft the GitHub Release from the `CHANGELOG.md` excerpt.
 
 ## Guardrails
 

--- a/000-docs/029-OD-RELS-npm-publishing-strategy.md
+++ b/000-docs/029-OD-RELS-npm-publishing-strategy.md
@@ -54,9 +54,10 @@ This repository does not publish on every release yet. When we decide to publish
 3. Build all packages: `pnpm -r build`.
 4. Dry run: `pnpm publish -r --filter '@qmd-team-intent-kb/schema' --filter '@qmd-team-intent-kb/common' --filter '@qmd-team-intent-kb/repo-resolver' --dry-run --access public --no-git-checks`.
 5. Publish: `pnpm publish -r --filter '@qmd-team-intent-kb/schema' --filter '@qmd-team-intent-kb/common' --filter '@qmd-team-intent-kb/repo-resolver' --access public`.
+   Packages with `private: true` are automatically skipped by pnpm.
+6. Tag the release (`git tag vX.Y.Z && git push --tags`) and draft the GitHub Release from the `CHANGELOG.md` excerpt.
 
 Per-package `--filter` flags avoid shell brace-expansion surprises that would occur with the quoted path-glob form `'./packages/{schema,common,repo-resolver}'`.
-Packages with `private: true` are automatically skipped by pnpm. 6. Tag the release (`git tag vX.Y.Z && git push --tags`) and draft the GitHub Release from the `CHANGELOG.md` excerpt.
 
 ## Guardrails
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- npm publishing configuration for reusable library packages (`@qmd-team-intent-kb/schema`, `@qmd-team-intent-kb/common`, `@qmd-team-intent-kb/repo-resolver`) — `publishConfig.access = public`, `files` allowlist, and minimal package READMEs. Internal-only packages (`store`, `qmd-adapter`, `claude-runtime`, `test-fixtures`, `policy-engine`) remain `private: true`. Strategy documented in `000-docs/029-OD-RELS-npm-publishing-strategy.md`.
+
 ## [0.3.0] - 2026-03-19
 
 ### Added

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,0 +1,5 @@
+# @qmd-team-intent-kb/common
+
+Shared primitives for the qmd-team-intent-kb monorepo. Provides a `Result<T, E>` type, content hashing helpers, path utilities, and freshness scoring functions used across the platform. Depends only on Node.js built-ins.
+
+Part of the qmd-team-intent-kb monorepo; see the repository root for license and contribution details.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,10 +1,16 @@
 {
   "name": "@qmd-team-intent-kb/common",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/repo-resolver/README.md
+++ b/packages/repo-resolver/README.md
@@ -1,0 +1,5 @@
+# @qmd-team-intent-kb/repo-resolver
+
+Multi-repo context resolver. Exposes `resolveRepoContext` for deriving tenant identity, detecting monorepo boundaries, and caching repository metadata from a working directory path. Used to attribute captured memories to the correct tenant and repository across heterogeneous developer environments.
+
+Part of the qmd-team-intent-kb monorepo; see the repository root for license and contribution details.

--- a/packages/repo-resolver/package.json
+++ b/packages/repo-resolver/package.json
@@ -1,10 +1,16 @@
 {
   "name": "@qmd-team-intent-kb/repo-resolver",
   "version": "0.0.0",
-  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -1,0 +1,5 @@
+# @qmd-team-intent-kb/schema
+
+Zod domain model and lifecycle state machine for the qmd-team-intent-kb memory platform. Defines core types (`MemoryCandidate`, `CuratedMemory`, `GovernancePolicy`, `AuditEvent`, `SearchQuery`, `SearchResult`), domain enums (`MemoryLifecycleState`, `Sensitivity`, `MemoryCategory`, `TrustLevel`, `CandidateStatus`, `SearchScope`), and the lifecycle transition rules used by every other package.
+
+Part of the qmd-team-intent-kb monorepo; see the repository root for license and contribution details.

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,10 +1,16 @@
 {
   "name": "@qmd-team-intent-kb/schema",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Adds npm `publishConfig.access = public`, `files` allowlist, and minimal package READMEs to the three packages that are cleanly reusable outside this repo: `@qmd-team-intent-kb/schema`, `@qmd-team-intent-kb/common`, `@qmd-team-intent-kb/repo-resolver`.
- Keeps every other package (`store`, `qmd-adapter`, `claude-runtime`, `test-fixtures`, `policy-engine`) and every app explicitly `private: true` so an accidental `pnpm -r publish` cannot leak them.
- Documents the strategy, the policy-engine blocker (transitive dep on private `claude-runtime`), and the publish workflow in `000-docs/029-OD-RELS-npm-publishing-strategy.md`.

This is infrastructure prep only — no `npm publish` has been run.

## Why policy-engine is not yet publishable

`policy-engine` imports `scanForSecrets` and `classifyContent` from `@qmd-team-intent-kb/claude-runtime`, which stays private due to internal spool-path coupling. Flipping policy-engine publishable now would either force publishing claude-runtime as well, or break install for external consumers (unresolved `workspace:*` private dep). The doc outlines the small interface-extraction refactor that unblocks this.

## Test plan

- [x] `pnpm validate` (format:check + lint + typecheck + test) — 1162 tests passing
- [x] `git status` clean, branch pushed
- [ ] Manual spot check: `pnpm publish -r --filter='./packages/{schema,common,repo-resolver}' --dry-run --access public --no-git-checks` (not run in this PR — verify during first real release)

Closes bead `qmd-team-intent-kb-x3l`.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>