### PR TITLE
feat(api): generate OpenAPI 3.1 spec + /docs UI

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,4 +6,5 @@ pnpm-lock.yaml
 CHANGELOG.md
 *.tsbuildinfo
 .beads/
+.claude/worktrees/
 AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `apps/api`: generated OpenAPI 3.1 spec served at `GET /openapi.json` and Swagger UI at `GET /docs`, powered by `@fastify/swagger` + `@fastify/swagger-ui`. Routes declare minimal schema metadata (tags, summary, description) for navigable documentation. The spec and docs UI are exempt from API key authentication so they stay publicly reachable. (bead `qmd-team-intent-kb-fwp`)
+
 ## [0.3.0] - 2026-03-19
 
 ### Added

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,6 +20,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@fastify/swagger": "^9.7.0",
+    "@fastify/swagger-ui": "^5.2.5",
     "fastify": "^5.8.5",
     "@qmd-team-intent-kb/schema": "workspace:*",
     "@qmd-team-intent-kb/common": "workspace:*",

--- a/apps/api/src/__tests__/openapi.test.ts
+++ b/apps/api/src/__tests__/openapi.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '@qmd-team-intent-kb/store';
+import { buildApp } from '../app.js';
+
+describe('GET /openapi.json', () => {
+  let db: Database.Database;
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    app = buildApp({ db, silent: true });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.close();
+  });
+
+  it('returns 200 and a valid OpenAPI 3.1 document that includes core paths', async () => {
+    const res = await app.inject({ method: 'GET', url: '/openapi.json' });
+    expect(res.statusCode).toBe(200);
+
+    const spec = res.json<{
+      openapi: string;
+      info: { title: string; version: string };
+      paths: Record<string, unknown>;
+      tags?: Array<{ name: string }>;
+    }>();
+
+    expect(spec.openapi).toBe('3.1.0');
+    expect(spec.info.title).toMatch(/qmd Team Intent KB/i);
+    expect(spec.paths).toBeDefined();
+    expect(Object.keys(spec.paths)).toEqual(expect.arrayContaining(['/api/candidates']));
+    expect(Object.keys(spec.paths)).toEqual(expect.arrayContaining(['/api/memories']));
+
+    // Tag metadata should be propagated from route schemas.
+    const tagNames = (spec.tags ?? []).map((t) => t.name);
+    expect(tagNames).toEqual(expect.arrayContaining(['candidates', 'memories']));
+  });
+
+  it('serves the Swagger UI at /docs', async () => {
+    const res = await app.inject({ method: 'GET', url: '/docs/static/index.html' });
+    // Swagger UI serves an HTML page; acceptable statuses are 200 or 302 (redirect to index).
+    expect([200, 302]).toContain(res.statusCode);
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -21,6 +21,7 @@ import { registerSearchRoutes } from './routes/search.js';
 import { registerRateLimiter } from './middleware/rate-limiter.js';
 import { registerApiKeyAuth } from './middleware/api-key-auth.js';
 import { registerInputSanitizer } from './middleware/input-sanitizer.js';
+import { registerOpenApi } from './openapi.js';
 
 /** External dependencies injected into the application factory. */
 export interface AppDependencies {
@@ -53,6 +54,10 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
   registerApiKeyAuth(app, deps.apiKey);
   registerInputSanitizer(app, deps.maxBodySize ?? 1_048_576);
 
+  // OpenAPI must be registered BEFORE routes so their schema metadata
+  // is collected into the generated document.
+  registerOpenApi(app);
+
   const candidateRepo = new CandidateRepository(deps.db);
   const memoryRepo = new MemoryRepository(deps.db);
   const policyRepo = new PolicyRepository(deps.db);
@@ -64,12 +69,18 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
   const healthService = new HealthService(deps.db);
   const searchService = new SearchService(memoryRepo);
 
-  registerHealthRoutes(app, healthService);
-  registerCandidateRoutes(app, candidateService);
-  registerMemoryRoutes(app, memoryService);
-  registerPolicyRoutes(app, policyService);
-  registerAuditRoutes(app, auditRepo);
-  registerSearchRoutes(app, searchService);
+  // Routes are wrapped in an inner register() so they load AFTER the
+  // @fastify/swagger plugin. The swagger plugin installs an `onRoute`
+  // hook during its async load; routes added synchronously before the
+  // hook is active would be missing from the generated spec.
+  void app.register(async (scope) => {
+    registerHealthRoutes(scope, healthService);
+    registerCandidateRoutes(scope, candidateService);
+    registerMemoryRoutes(scope, memoryService);
+    registerPolicyRoutes(scope, policyService);
+    registerAuditRoutes(scope, auditRepo);
+    registerSearchRoutes(scope, searchService);
+  });
 
   return app;
 }

--- a/apps/api/src/middleware/api-key-auth.ts
+++ b/apps/api/src/middleware/api-key-auth.ts
@@ -47,6 +47,15 @@ export function registerApiKeyAuth(app: FastifyInstance, apiKey: string | undefi
       return;
     }
 
+    // OpenAPI spec and docs UI are always public.
+    if (
+      request.url === '/openapi.json' ||
+      request.url === '/docs' ||
+      request.url.startsWith('/docs/')
+    ) {
+      return;
+    }
+
     const authHeader = request.headers['authorization'];
 
     if (authHeader === undefined) {

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -1,0 +1,74 @@
+import type { FastifyInstance } from 'fastify';
+import swagger from '@fastify/swagger';
+import swaggerUi from '@fastify/swagger-ui';
+
+/**
+ * Register the OpenAPI 3.1 spec generator and Swagger UI.
+ *
+ * MUST be registered BEFORE routes so that Fastify route registrations
+ * emit their `schema` metadata into the generated document.
+ *
+ * Registration is deferred (Fastify's `register` is promise-based but the
+ * plugins are loaded by `app.ready()`). We do not await here so `buildApp`
+ * can remain synchronous; callers that need the spec to be served must
+ * call `await app.ready()` before `inject()` or `listen()` — which the
+ * existing test suite and `index.ts` already do.
+ *
+ * Exposes:
+ * - GET /openapi.json — the generated spec
+ * - GET /docs         — Swagger UI
+ */
+export function registerOpenApi(app: FastifyInstance): void {
+  void app.register(swagger, {
+    openapi: {
+      openapi: '3.1.0',
+      info: {
+        title: 'qmd Team Intent KB API',
+        description:
+          'Control plane REST API for the governed team memory platform. Exposes candidate intake, curated memory lifecycle, governance policies, audit trail, and search.',
+        version: '0.4.0',
+      },
+      tags: [
+        { name: 'health', description: 'Liveness and readiness probes' },
+        { name: 'candidates', description: 'Memory candidate intake and retrieval' },
+        { name: 'memories', description: 'Curated memory retrieval and lifecycle' },
+        { name: 'policies', description: 'Governance policy CRUD' },
+        { name: 'audit', description: 'Immutable audit event queries' },
+        { name: 'search', description: 'Full-text search over curated memories' },
+      ],
+      components: {
+        securitySchemes: {
+          bearerAuth: {
+            type: 'http',
+            scheme: 'bearer',
+            description:
+              'Bearer token authentication. In production TEAMKB_API_KEY is required; in development auth is skipped when unset.',
+          },
+        },
+      },
+    },
+  });
+
+  void app.register(swaggerUi, {
+    routePrefix: '/docs',
+    uiConfig: {
+      docExpansion: 'list',
+      deepLinking: true,
+    },
+    staticCSP: true,
+  });
+
+  // Expose the generated spec at a stable well-known path. @fastify/swagger
+  // itself does not register a route; only @fastify/swagger-ui does (under
+  // its own prefix). We publish /openapi.json so SDK generators and tooling
+  // can fetch the document without depending on the UI route prefix.
+  app.get(
+    '/openapi.json',
+    {
+      schema: {
+        hide: true,
+      },
+    },
+    async () => app.swagger(),
+  );
+}

--- a/apps/api/src/routes/audit.ts
+++ b/apps/api/src/routes/audit.ts
@@ -12,25 +12,36 @@ import type { AuditRepository } from '@qmd-team-intent-kb/store';
  * is returned — a tenant scope is recommended for production use.
  */
 export function registerAuditRoutes(app: FastifyInstance, repo: AuditRepository): void {
-  app.get('/api/audit', async (request, reply) => {
-    const { tenantId, memoryId, action } = request.query as {
-      tenantId?: string;
-      memoryId?: string;
-      action?: string;
-    };
+  app.get(
+    '/api/audit',
+    {
+      schema: {
+        tags: ['audit'],
+        summary: 'Query the immutable audit event log',
+        description:
+          'Filter precedence: `memoryId` > `action` > `tenantId`. Returns `[]` if no filter is provided.',
+      },
+    },
+    async (request, reply) => {
+      const { tenantId, memoryId, action } = request.query as {
+        tenantId?: string;
+        memoryId?: string;
+        action?: string;
+      };
 
-    if (memoryId !== undefined && memoryId.length > 0) {
-      return reply.send(repo.findByMemory(memoryId));
-    }
+      if (memoryId !== undefined && memoryId.length > 0) {
+        return reply.send(repo.findByMemory(memoryId));
+      }
 
-    if (action !== undefined && action.length > 0) {
-      return reply.send(repo.findByAction(action));
-    }
+      if (action !== undefined && action.length > 0) {
+        return reply.send(repo.findByAction(action));
+      }
 
-    if (tenantId !== undefined && tenantId.length > 0) {
-      return reply.send(repo.findByTenant(tenantId));
-    }
+      if (tenantId !== undefined && tenantId.length > 0) {
+        return reply.send(repo.findByTenant(tenantId));
+      }
 
-    return reply.send([]);
-  });
+      return reply.send([]);
+    },
+  );
 }

--- a/apps/api/src/routes/candidates.ts
+++ b/apps/api/src/routes/candidates.ts
@@ -10,41 +10,71 @@ import type { CandidateService } from '../services/candidate-service.js';
  * GET    /api/candidates          — list by tenantId query param (200 | 400)
  */
 export function registerCandidateRoutes(app: FastifyInstance, service: CandidateService): void {
-  app.post('/api/candidates', async (request, reply) => {
-    try {
-      const candidate = service.intake(request.body);
-      return reply.status(201).send(candidate);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        return reply.status(err.statusCode).send({ error: err.message });
+  app.post(
+    '/api/candidates',
+    {
+      schema: {
+        tags: ['candidates'],
+        summary: 'Intake a new memory candidate',
+        description:
+          'Accepts a candidate payload from a Claude Code session and stores it in the inbox.',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const candidate = service.intake(request.body);
+        return reply.status(201).send(candidate);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
       }
-      throw err;
-    }
-  });
+    },
+  );
 
-  app.get('/api/candidates/:id', async (request, reply) => {
-    try {
-      const { id } = request.params as { id: string };
-      const candidate = service.getById(id);
-      return reply.send(candidate);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        return reply.status(err.statusCode).send({ error: err.message });
+  app.get(
+    '/api/candidates/:id',
+    {
+      schema: {
+        tags: ['candidates'],
+        summary: 'Retrieve a candidate by UUID',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { id } = request.params as { id: string };
+        const candidate = service.getById(id);
+        return reply.send(candidate);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
       }
-      throw err;
-    }
-  });
+    },
+  );
 
-  app.get('/api/candidates', async (request, reply) => {
-    try {
-      const { tenantId } = request.query as { tenantId?: string };
-      const candidates = service.list(tenantId);
-      return reply.send(candidates);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        return reply.status(err.statusCode).send({ error: err.message });
+  app.get(
+    '/api/candidates',
+    {
+      schema: {
+        tags: ['candidates'],
+        summary: 'List candidates for a tenant',
+        description: 'Requires `tenantId` query param. Returns 400 if missing.',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { tenantId } = request.query as { tenantId?: string };
+        const candidates = service.list(tenantId);
+        return reply.send(candidates);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
       }
-      throw err;
-    }
-  });
+    },
+  );
 }

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -6,9 +6,20 @@ import type { HealthService } from '../services/health-service.js';
  * GET /api/health — returns liveness and database connectivity.
  */
 export function registerHealthRoutes(app: FastifyInstance, service: HealthService): void {
-  app.get('/api/health', async (_request, reply) => {
-    const status = service.check();
-    const httpStatus = status.status === 'healthy' ? 200 : 503;
-    return reply.status(httpStatus).send(status);
-  });
+  app.get(
+    '/api/health',
+    {
+      schema: {
+        tags: ['health'],
+        summary: 'Liveness and database reachability probe',
+        description:
+          'Returns `healthy` with uptime and version when the database is reachable, `unhealthy` (503) otherwise.',
+      },
+    },
+    async (_request, reply) => {
+      const status = service.check();
+      const httpStatus = status.status === 'healthy' ? 200 : 503;
+      return reply.status(httpStatus).send(status);
+    },
+  );
 }

--- a/apps/api/src/routes/memories.ts
+++ b/apps/api/src/routes/memories.ts
@@ -15,63 +15,101 @@ import type { MemoryService } from '../services/memory-service.js';
  * "by-hash" as a UUID parameter value.
  */
 export function registerMemoryRoutes(app: FastifyInstance, service: MemoryService): void {
-  app.get('/api/memories', async (request, reply) => {
-    const { tenantId } = request.query as { tenantId?: string };
-    const memories = service.list(tenantId);
-    return reply.send(memories);
-  });
+  app.get(
+    '/api/memories',
+    {
+      schema: {
+        tags: ['memories'],
+        summary: 'List curated memories for a tenant',
+      },
+    },
+    async (request, reply) => {
+      const { tenantId } = request.query as { tenantId?: string };
+      const memories = service.list(tenantId);
+      return reply.send(memories);
+    },
+  );
 
-  app.get('/api/memories/by-hash/:hash', async (request, reply) => {
-    try {
-      const { hash } = request.params as { hash: string };
-      const memory = service.findByHash(hash);
-      if (memory === null) {
-        return reply.status(404).send({ error: `No memory found with hash ${hash}` });
+  app.get(
+    '/api/memories/by-hash/:hash',
+    {
+      schema: {
+        tags: ['memories'],
+        summary: 'Look up a curated memory by content hash',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { hash } = request.params as { hash: string };
+        const memory = service.findByHash(hash);
+        if (memory === null) {
+          return reply.status(404).send({ error: `No memory found with hash ${hash}` });
+        }
+        return reply.send(memory);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
       }
-      return reply.send(memory);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        return reply.status(err.statusCode).send({ error: err.message });
-      }
-      throw err;
-    }
-  });
+    },
+  );
 
-  app.get('/api/memories/:id', async (request, reply) => {
-    try {
-      const { id } = request.params as { id: string };
-      const memory = service.getById(id);
-      return reply.send(memory);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        return reply.status(err.statusCode).send({ error: err.message });
+  app.get(
+    '/api/memories/:id',
+    {
+      schema: {
+        tags: ['memories'],
+        summary: 'Retrieve a curated memory by UUID',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { id } = request.params as { id: string };
+        const memory = service.getById(id);
+        return reply.send(memory);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
       }
-      throw err;
-    }
-  });
+    },
+  );
 
-  app.post('/api/memories/:id/transition', async (request, reply) => {
-    try {
-      const { id } = request.params as { id: string };
-      const body = request.body as { to?: unknown } & Record<string, unknown>;
-      const toRaw = body['to'];
+  app.post(
+    '/api/memories/:id/transition',
+    {
+      schema: {
+        tags: ['memories'],
+        summary: 'Transition a memory to a new lifecycle state',
+        description:
+          'Valid transitions are defined in the lifecycle state machine: active → {deprecated, superseded, archived}; deprecated → {active, archived}; superseded → {archived}; archived is terminal.',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { id } = request.params as { id: string };
+        const body = request.body as { to?: unknown } & Record<string, unknown>;
+        const toRaw = body['to'];
 
-      const toParsed = MemoryLifecycleState.safeParse(toRaw);
-      if (!toParsed.success) {
-        return reply
-          .status(400)
-          .send({ error: `Invalid lifecycle state: ${String(toRaw ?? 'undefined')}` });
+        const toParsed = MemoryLifecycleState.safeParse(toRaw);
+        if (!toParsed.success) {
+          return reply
+            .status(400)
+            .send({ error: `Invalid lifecycle state: ${String(toRaw ?? 'undefined')}` });
+        }
+
+        // Forward the rest of the body as the TransitionRequest
+        const { to: _to, ...transitionBody } = body;
+        const memory = service.transition(id, toParsed.data, transitionBody);
+        return reply.send(memory);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
       }
-
-      // Forward the rest of the body as the TransitionRequest
-      const { to: _to, ...transitionBody } = body;
-      const memory = service.transition(id, toParsed.data, transitionBody);
-      return reply.send(memory);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        return reply.status(err.statusCode).send({ error: err.message });
-      }
-      throw err;
-    }
-  });
+    },
+  );
 }

--- a/apps/api/src/routes/policies.ts
+++ b/apps/api/src/routes/policies.ts
@@ -12,67 +12,113 @@ import type { PolicyService } from '../services/policy-service.js';
  * DELETE /api/policies/:id        — delete (204 | 404)
  */
 export function registerPolicyRoutes(app: FastifyInstance, service: PolicyService): void {
-  app.post('/api/policies', async (request, reply) => {
-    try {
-      const policy = service.create(request.body);
-      return reply.status(201).send(policy);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        return reply.status(err.statusCode).send({ error: err.message });
+  app.post(
+    '/api/policies',
+    {
+      schema: {
+        tags: ['policies'],
+        summary: 'Create a governance policy',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const policy = service.create(request.body);
+        return reply.status(201).send(policy);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
       }
-      throw err;
-    }
-  });
+    },
+  );
 
-  app.get('/api/policies', async (request, reply) => {
-    try {
-      const { tenantId } = request.query as { tenantId?: string };
-      const policies = service.list(tenantId);
-      return reply.send(policies);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        return reply.status(err.statusCode).send({ error: err.message });
+  app.get(
+    '/api/policies',
+    {
+      schema: {
+        tags: ['policies'],
+        summary: 'List policies for a tenant',
+        description: 'Requires `tenantId` query param.',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { tenantId } = request.query as { tenantId?: string };
+        const policies = service.list(tenantId);
+        return reply.send(policies);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
       }
-      throw err;
-    }
-  });
+    },
+  );
 
-  app.get('/api/policies/:id', async (request, reply) => {
-    try {
-      const { id } = request.params as { id: string };
-      const policy = service.getById(id);
-      return reply.send(policy);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        return reply.status(err.statusCode).send({ error: err.message });
+  app.get(
+    '/api/policies/:id',
+    {
+      schema: {
+        tags: ['policies'],
+        summary: 'Retrieve a policy by UUID',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { id } = request.params as { id: string };
+        const policy = service.getById(id);
+        return reply.send(policy);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
       }
-      throw err;
-    }
-  });
+    },
+  );
 
-  app.put('/api/policies/:id', async (request, reply) => {
-    try {
-      const { id } = request.params as { id: string };
-      const policy = service.update(id, request.body);
-      return reply.send(policy);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        return reply.status(err.statusCode).send({ error: err.message });
+  app.put(
+    '/api/policies/:id',
+    {
+      schema: {
+        tags: ['policies'],
+        summary: 'Replace an existing policy',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { id } = request.params as { id: string };
+        const policy = service.update(id, request.body);
+        return reply.send(policy);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
       }
-      throw err;
-    }
-  });
+    },
+  );
 
-  app.delete('/api/policies/:id', async (request, reply) => {
-    try {
-      const { id } = request.params as { id: string };
-      service.delete(id);
-      return reply.status(204).send();
-    } catch (err) {
-      if (err instanceof ApiError) {
-        return reply.status(err.statusCode).send({ error: err.message });
+  app.delete(
+    '/api/policies/:id',
+    {
+      schema: {
+        tags: ['policies'],
+        summary: 'Delete a policy',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { id } = request.params as { id: string };
+        service.delete(id);
+        return reply.status(204).send();
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
       }
-      throw err;
-    }
-  });
+    },
+  );
 }

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -9,20 +9,31 @@ import type { SearchService } from '../services/search-service.js';
  * POST /api/search — full-text search with freshness reranking
  */
 export function registerSearchRoutes(app: FastifyInstance, service: SearchService): void {
-  app.post('/api/search', async (request, reply) => {
-    try {
-      const parsed = SearchQuery.safeParse(request.body);
-      if (!parsed.success) {
-        return reply.status(400).send({ error: `Invalid search query: ${parsed.error.message}` });
-      }
+  app.post(
+    '/api/search',
+    {
+      schema: {
+        tags: ['search'],
+        summary: 'Full-text search over curated memories',
+        description:
+          'Applies freshness reranking. Body is validated against the SearchQuery schema.',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const parsed = SearchQuery.safeParse(request.body);
+        if (!parsed.success) {
+          return reply.status(400).send({ error: `Invalid search query: ${parsed.error.message}` });
+        }
 
-      const result = service.search(parsed.data);
-      return reply.send(result);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        return reply.status(err.statusCode).send({ error: err.message });
+        const result = service.search(parsed.data);
+        return reply.send(result);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
       }
-      throw err;
-    }
-  });
+    },
+  );
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,7 @@ export default tseslint.config(
       '**/coverage/**',
       '**/node_modules/**',
       '**/*.tsbuildinfo',
+      '.claude/worktrees/**',
     ],
   },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,12 @@ importers:
 
   apps/api:
     dependencies:
+      '@fastify/swagger':
+        specifier: ^9.7.0
+        version: 9.7.0
+      '@fastify/swagger-ui':
+        specifier: ^5.2.5
+        version: 5.2.5
       '@qmd-team-intent-kb/common':
         specifier: workspace:*
         version: link:../../packages/common
@@ -457,6 +463,9 @@ packages:
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@fastify/accept-negotiator@2.0.1':
+    resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
+
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
@@ -474,6 +483,18 @@ packages:
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/send@4.1.0':
+    resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
+
+  '@fastify/static@9.1.0':
+    resolution: {integrity: sha512-EPRNQYqEYEYTK8yyGbcM0iHpyJaupb94bey5O6iCQfLTADr02kaZU+qeHSdd9H9TiMwTBVkrMa59V8CMbn3avQ==}
+
+  '@fastify/swagger-ui@5.2.5':
+    resolution: {integrity: sha512-ky3I0LAkXKX/prwSDpoQ3kscBKsj2Ha6Gp1/JfgQSqyx0bm9F2bE//XmGVGj2cR9l5hUjZYn60/hqn7e+OLgWQ==}
+
+  '@fastify/swagger@9.7.0':
+    resolution: {integrity: sha512-Vp1SC1GC2Hrkd3faFILv86BzUNyFz5N4/xdExqtCgkGASOzn/x+eMe4qXIGq7cdT6wif/P/oa6r1Ruqx19paZA==}
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -499,6 +520,10 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@lukeed/ms@2.0.2':
+    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
+    engines: {node: '>=8'}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -1309,6 +1334,9 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fastify-plugin@5.1.0:
+    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
+
   fastify@5.8.5:
     resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
 
@@ -1402,6 +1430,10 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1498,6 +1530,10 @@ packages:
   json-schema-ref-resolver@3.0.0:
     resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
 
+  json-schema-resolver@3.0.0:
+    resolution: {integrity: sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==}
+    engines: {node: '>=20'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -1528,6 +1564,10 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1560,6 +1600,11 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -1574,6 +1619,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -1622,6 +1671,9 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1652,6 +1704,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -2249,6 +2305,8 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@fastify/accept-negotiator@2.0.1': {}
+
   '@fastify/ajv-compiler@4.0.5':
     dependencies:
       ajv: 8.18.0
@@ -2272,6 +2330,41 @@ snapshots:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.3.0
 
+  '@fastify/send@4.1.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      escape-html: 1.0.3
+      fast-decode-uri-component: 1.0.1
+      http-errors: 2.0.1
+      mime: 3.0.0
+
+  '@fastify/static@9.1.0':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/send': 4.1.0
+      content-disposition: 1.1.0
+      fastify-plugin: 5.1.0
+      fastq: 1.20.1
+      glob: 13.0.6
+
+  '@fastify/swagger-ui@5.2.5':
+    dependencies:
+      '@fastify/static': 9.1.0
+      fastify-plugin: 5.1.0
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.8.3
+
+  '@fastify/swagger@9.7.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      json-schema-resolver: 3.0.0
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@hono/node-server@1.19.14(hono@4.12.12)':
     dependencies:
       hono: 4.12.12
@@ -2288,6 +2381,8 @@ snapshots:
   '@humanwhocodes/retry@0.4.3': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@lukeed/ms@2.0.2': {}
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
@@ -3066,6 +3161,8 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  fastify-plugin@5.1.0: {}
+
   fastify@5.8.5:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
@@ -3186,6 +3283,12 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   gopd@1.2.0: {}
 
   has-symbols@1.1.0: {}
@@ -3252,6 +3355,14 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  json-schema-resolver@3.0.0:
+    dependencies:
+      debug: 4.4.3
+      fast-uri: 3.1.0
+      rfdc: 1.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -3300,6 +3411,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lru-cache@11.3.5: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3323,6 +3436,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mime@3.0.0: {}
+
   mimic-response@3.1.0: {}
 
   minimatch@10.2.4:
@@ -3334,6 +3449,8 @@ snapshots:
       brace-expansion: 5.0.5
 
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   mkdirp-classic@0.5.3: {}
 
@@ -3366,6 +3483,8 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  openapi-types@12.1.3: {}
 
   optionator@0.9.4:
     dependencies:
@@ -3443,6 +3562,11 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.5
+      minipass: 7.1.3
 
   path-to-regexp@8.4.2: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    exclude: ['**/dist/**', '**/node_modules/**'],
+    exclude: ['**/dist/**', '**/node_modules/**', '.claude/worktrees/**'],
   },
 });


### PR DESCRIPTION
## Summary

- Wires `@fastify/swagger` + `@fastify/swagger-ui` into `apps/api` so the control plane now publishes an OpenAPI 3.1 document at `GET /openapi.json` and a Swagger UI at `GET /docs`.
- Every route declares minimal schema metadata (tags, summary, description) — no handler logic was modified.
- Route registration is wrapped in an inner `app.register()` so swagger's `onRoute` hook is active before routes are added; otherwise the spec would come out empty.
- Spec + docs are exempt from bearer-token auth so SDK generators and operators can consume them without credentials.
- Adds `.claude/worktrees/` exclusions to prettier / eslint / vitest so nested agent worktrees stop polluting the root `pnpm validate` run.

Closes bead `qmd-team-intent-kb-fwp`.

## Test plan

- [x] `pnpm validate` green (111 test files, 1164 tests passing)
- [x] New `apps/api/src/__tests__/openapi.test.ts` asserts `GET /openapi.json` returns 200, `openapi: '3.1.0'`, and that `/api/candidates` and `/api/memories` paths are present
- [x] Swagger UI reachable at `/docs/static/index.html`
- [ ] Manual smoke: `curl http://localhost:3000/openapi.json | jq .info.title` after `pnpm --filter @qmd-team-intent-kb/api dev`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>