### PR TITLE
feat: Zod 4 migration + knowledge graph foundation (E11+E12)

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { MemoryCategory, MemoryLifecycleState } from '@qmd-team-intent-kb/schema';
 import type { McpServerConfig } from './config.js';
 import { propose } from './tools/propose.js';
 import { importFiles } from './tools/import.js';
@@ -9,32 +10,8 @@ import { runSync, isQmdAvailable } from './tools/sync.js';
 
 const VERSION = '0.1.0';
 
-// ---------------------------------------------------------------------------
-// Inline enum definitions for tool parameter schemas.
-//
-// Intentionally NOT imported from @qmd-team-intent-kb/schema: that package
-// resolves against zod@3 while the MCP SDK (and the root workspace) uses
-// zod@4. Passing v3 schema objects to server.tool() triggers "Mixed Zod
-// versions detected" at runtime. The enum values here mirror enums.ts exactly.
-// ---------------------------------------------------------------------------
-
-const MEMORY_CATEGORY_VALUES = [
-  'decision',
-  'pattern',
-  'convention',
-  'architecture',
-  'troubleshooting',
-  'onboarding',
-  'reference',
-] as const;
-
-const LIFECYCLE_STATE_VALUES = ['active', 'deprecated', 'superseded', 'archived'] as const;
-
 /**
  * Create a configured McpServer with all team-kb tools registered.
- *
- * All tool parameter schemas use the zod instance from the root workspace
- * (zod@4), which is the same instance the MCP SDK was resolved against.
  *
  * Call `isQmdAvailable()` before calling this function if you want to
  * conditionally register the sync tool.
@@ -54,12 +31,9 @@ export function createServer(
     {
       title: z.string().min(1).describe('Short descriptive title for the memory'),
       content: z.string().min(1).describe('Full content of the memory'),
-      category: z
-        .enum(MEMORY_CATEGORY_VALUES)
-        .optional()
-        .describe(
-          'Memory category: decision, pattern, convention, architecture, troubleshooting, onboarding, reference',
-        ),
+      category: MemoryCategory.optional().describe(
+        'Memory category: decision, pattern, convention, architecture, troubleshooting, onboarding, reference',
+      ),
       filePaths: z
         .array(z.string())
         .optional()
@@ -70,8 +44,7 @@ export function createServer(
         {
           title: params.title,
           content: params.content,
-          // Narrow to MemoryCategory via runtime validation in propose()
-          category: params.category as Parameters<typeof propose>[0]['category'],
+          category: params.category,
           filePaths: params.filePaths,
         },
         config,
@@ -141,7 +114,7 @@ export function createServer(
     'Apply a lifecycle transition to a curated memory. Validates against the state machine and writes an audit event.',
     {
       memoryId: z.string().uuid().describe('UUID of the curated memory to transition'),
-      to: z.enum(LIFECYCLE_STATE_VALUES).describe('Target lifecycle state'),
+      to: MemoryLifecycleState.describe('Target lifecycle state'),
       reason: z.string().min(1).describe('Human-readable reason for the transition'),
       actor: z
         .string()
@@ -152,8 +125,7 @@ export function createServer(
       const result = applyTransition(
         {
           memoryId: params.memoryId,
-          // Narrow to MemoryLifecycleState via runtime validation in applyTransition()
-          to: params.to as Parameters<typeof applyTransition>[0]['to'],
+          to: params.to,
           reason: params.reason,
           actor: params.actor,
         },

--- a/packages/repo-resolver/package.json
+++ b/packages/repo-resolver/package.json
@@ -26,6 +26,6 @@
   },
   "dependencies": {
     "@qmd-team-intent-kb/common": "workspace:*",
-    "zod": "^3.23.0"
+    "zod": "^4.3.6"
   }
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -25,6 +25,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "zod": "^3.23.0"
+    "zod": "^4.3.6"
   }
 }

--- a/packages/schema/src/__tests__/enums.test.ts
+++ b/packages/schema/src/__tests__/enums.test.ts
@@ -12,6 +12,9 @@ import {
   Confidence,
   Sensitivity,
   AuthorType,
+  LinkType,
+  LinkSource,
+  ImportBatchStatus,
 } from '../enums.js';
 
 describe('MemorySource', () => {
@@ -158,5 +161,35 @@ describe('AuthorType', () => {
   });
   it('rejects invalid value', () => {
     expect(() => AuthorType.parse('bot')).toThrow();
+  });
+});
+
+describe('LinkType', () => {
+  it.each(['relates_to', 'supersedes', 'contradicts', 'depends_on', 'part_of'])(
+    'accepts "%s"',
+    (val) => {
+      expect(LinkType.parse(val)).toBe(val);
+    },
+  );
+  it('rejects invalid value', () => {
+    expect(() => LinkType.parse('follows')).toThrow();
+  });
+});
+
+describe('LinkSource', () => {
+  it.each(['curator', 'import', 'manual', 'mcp'])('accepts "%s"', (val) => {
+    expect(LinkSource.parse(val)).toBe(val);
+  });
+  it('rejects invalid value', () => {
+    expect(() => LinkSource.parse('api')).toThrow();
+  });
+});
+
+describe('ImportBatchStatus', () => {
+  it.each(['active', 'completed', 'rolled_back'])('accepts "%s"', (val) => {
+    expect(ImportBatchStatus.parse(val)).toBe(val);
+  });
+  it('rejects invalid value', () => {
+    expect(() => ImportBatchStatus.parse('pending')).toThrow();
   });
 });

--- a/packages/schema/src/audit-event.ts
+++ b/packages/schema/src/audit-event.ts
@@ -10,7 +10,7 @@ export const AuditEvent = z.object({
   tenantId: TenantId,
   actor: Author,
   reason: NonEmptyString.optional(),
-  details: z.record(z.unknown()).default({}),
+  details: z.record(z.string(), z.unknown()).default({}),
   timestamp: IsoDatetime,
 });
 export type AuditEvent = z.infer<typeof AuditEvent>;

--- a/packages/schema/src/curated-memory.ts
+++ b/packages/schema/src/curated-memory.ts
@@ -47,7 +47,7 @@ export const CuratedMemory = z
     sensitivity: Sensitivity.default('internal'),
     author: Author,
     tenantId: TenantId,
-    metadata: ContentMetadata.default({}),
+    metadata: ContentMetadata.default({ filePaths: [], tags: [] }),
     lifecycle: MemoryLifecycleState,
     contentHash: Sha256Hash,
     policyEvaluations: z.array(PolicyEvaluation).default([]),

--- a/packages/schema/src/enums.ts
+++ b/packages/schema/src/enums.ts
@@ -60,3 +60,18 @@ export type Sensitivity = z.infer<typeof Sensitivity>;
 
 export const AuthorType = z.enum(['human', 'ai', 'system']);
 export type AuthorType = z.infer<typeof AuthorType>;
+
+export const LinkType = z.enum([
+  'relates_to',
+  'supersedes',
+  'contradicts',
+  'depends_on',
+  'part_of',
+]);
+export type LinkType = z.infer<typeof LinkType>;
+
+export const LinkSource = z.enum(['curator', 'import', 'manual', 'mcp']);
+export type LinkSource = z.infer<typeof LinkSource>;
+
+export const ImportBatchStatus = z.enum(['active', 'completed', 'rolled_back']);
+export type ImportBatchStatus = z.infer<typeof ImportBatchStatus>;

--- a/packages/schema/src/governance-policy.ts
+++ b/packages/schema/src/governance-policy.ts
@@ -9,7 +9,7 @@ export const PolicyRule = z.object({
   action: PolicyRuleAction,
   enabled: z.boolean().default(true),
   priority: z.number().int().min(0).default(0),
-  parameters: z.record(z.unknown()).default({}),
+  parameters: z.record(z.string(), z.unknown()).default({}),
   description: z.string().optional(),
 });
 export type PolicyRule = z.infer<typeof PolicyRule>;

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -11,6 +11,9 @@ export {
   Confidence,
   Sensitivity,
   AuthorType,
+  LinkType,
+  LinkSource,
+  ImportBatchStatus,
 } from './enums.js';
 
 export {

--- a/packages/schema/src/memory-candidate.ts
+++ b/packages/schema/src/memory-candidate.ts
@@ -21,8 +21,12 @@ export const MemoryCandidate = z.object({
   trustLevel: TrustLevel.default('medium'),
   author: Author,
   tenantId: TenantId,
-  metadata: ContentMetadata.default({}),
-  prePolicyFlags: PrePolicyFlags.default({}),
+  metadata: ContentMetadata.default({ filePaths: [], tags: [] }),
+  prePolicyFlags: PrePolicyFlags.default({
+    potentialSecret: false,
+    lowConfidence: false,
+    duplicateSuspect: false,
+  }),
   capturedAt: IsoDatetime,
 });
 export type MemoryCandidate = z.infer<typeof MemoryCandidate>;

--- a/packages/schema/src/search.ts
+++ b/packages/schema/src/search.ts
@@ -17,7 +17,7 @@ export const SearchQuery = z.object({
   categories: z.array(MemoryCategory).optional(),
   dateFrom: IsoDatetime.optional(),
   dateTo: IsoDatetime.optional(),
-  pagination: Pagination.default({}),
+  pagination: Pagination.default({ page: 1, pageSize: 20 }),
 });
 export type SearchQuery = z.infer<typeof SearchQuery>;
 

--- a/packages/store/src/__tests__/import-batch-repository.test.ts
+++ b/packages/store/src/__tests__/import-batch-repository.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '../database.js';
+import { ImportBatchRepository } from '../repositories/import-batch-repository.js';
+import type { ImportBatch } from '../repositories/import-batch-repository.js';
+
+const NOW = '2026-01-15T10:00:00.000Z';
+
+function makeBatch(overrides?: Partial<ImportBatch>): ImportBatch {
+  return {
+    id: 'batch-1',
+    tenantId: 'tenant-1',
+    sourcePath: '/path/to/vault',
+    fileCount: 0,
+    createdCount: 0,
+    rejectedCount: 0,
+    skippedCount: 0,
+    status: 'active',
+    createdAt: NOW,
+    rolledBackAt: null,
+    ...overrides,
+  };
+}
+
+describe('ImportBatchRepository', () => {
+  let db: Database.Database;
+  let repo: ImportBatchRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new ImportBatchRepository(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('inserts and retrieves a batch by id', () => {
+    repo.insert(makeBatch());
+    const found = repo.findById('batch-1');
+    expect(found).not.toBeNull();
+    expect(found!.tenantId).toBe('tenant-1');
+    expect(found!.sourcePath).toBe('/path/to/vault');
+    expect(found!.status).toBe('active');
+  });
+
+  it('returns null for non-existent id', () => {
+    expect(repo.findById('nope')).toBeNull();
+  });
+
+  it('findByTenant returns batches for a tenant', () => {
+    repo.insert(makeBatch());
+    repo.insert(makeBatch({ id: 'batch-2', tenantId: 'tenant-1' }));
+    repo.insert(makeBatch({ id: 'batch-3', tenantId: 'tenant-2' }));
+    expect(repo.findByTenant('tenant-1')).toHaveLength(2);
+    expect(repo.findByTenant('tenant-2')).toHaveLength(1);
+  });
+
+  it('findByStatus returns batches with given status', () => {
+    repo.insert(makeBatch());
+    repo.insert(makeBatch({ id: 'batch-2', status: 'completed' }));
+    expect(repo.findByStatus('active')).toHaveLength(1);
+    expect(repo.findByStatus('completed')).toHaveLength(1);
+    expect(repo.findByStatus('rolled_back')).toHaveLength(0);
+  });
+
+  it('updateCounts modifies count fields', () => {
+    repo.insert(makeBatch());
+    const updated = repo.updateCounts('batch-1', {
+      fileCount: 10,
+      createdCount: 7,
+      rejectedCount: 2,
+      skippedCount: 1,
+    });
+    expect(updated).toBe(true);
+
+    const found = repo.findById('batch-1')!;
+    expect(found.fileCount).toBe(10);
+    expect(found.createdCount).toBe(7);
+    expect(found.rejectedCount).toBe(2);
+    expect(found.skippedCount).toBe(1);
+  });
+
+  it('updateCounts returns false for non-existent id', () => {
+    expect(
+      repo.updateCounts('nope', {
+        fileCount: 0,
+        createdCount: 0,
+        rejectedCount: 0,
+        skippedCount: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it('complete marks batch as completed', () => {
+    repo.insert(makeBatch());
+    expect(repo.complete('batch-1')).toBe(true);
+    const found = repo.findById('batch-1')!;
+    expect(found.status).toBe('completed');
+    expect(found.rolledBackAt).toBeNull();
+  });
+
+  it('rollback marks batch as rolled_back with timestamp', () => {
+    repo.insert(makeBatch());
+    const rollbackTime = '2026-01-15T12:00:00.000Z';
+    expect(repo.rollback('batch-1', rollbackTime)).toBe(true);
+    const found = repo.findById('batch-1')!;
+    expect(found.status).toBe('rolled_back');
+    expect(found.rolledBackAt).toBe(rollbackTime);
+  });
+
+  it('handles null sourcePath', () => {
+    repo.insert(makeBatch({ sourcePath: null }));
+    const found = repo.findById('batch-1')!;
+    expect(found.sourcePath).toBeNull();
+  });
+});

--- a/packages/store/src/__tests__/memory-links-repository.test.ts
+++ b/packages/store/src/__tests__/memory-links-repository.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { createTestDatabase } from '../database.js';
+import { MemoryLinksRepository } from '../repositories/memory-links-repository.js';
+import type { MemoryLink } from '../repositories/memory-links-repository.js';
+
+const NOW = '2026-01-15T10:00:00.000Z';
+const HASH = 'a'.repeat(64);
+
+/** Insert a minimal curated memory row for FK satisfaction */
+function insertMemory(db: Database.Database, id: string): void {
+  db.prepare(
+    `INSERT INTO curated_memories (
+      id, candidate_id, source, content, title, category,
+      trust_level, sensitivity, author_json, tenant_id,
+      metadata_json, lifecycle, content_hash,
+      policy_evaluations_json, promoted_at, promoted_by_json, updated_at, version
+    ) VALUES (?, ?, 'manual', 'content', 'title', 'pattern', 'high', 'internal',
+      '{"type":"ai","id":"c1"}', 'tenant-1', '{}', 'active', ?,
+      '[]', ?, '{"type":"system","id":"s1"}', ?, 1)`,
+  ).run(id, `cand-${id}`, HASH, NOW, NOW);
+}
+
+function makeLink(overrides?: Partial<MemoryLink>): MemoryLink {
+  return {
+    id: 'link-1',
+    sourceMemoryId: 'm1',
+    targetMemoryId: 'm2',
+    linkType: 'relates_to',
+    weight: 1.0,
+    createdBy: 'test-user',
+    source: 'manual',
+    importBatchId: null,
+    createdAt: NOW,
+    ...overrides,
+  };
+}
+
+describe('MemoryLinksRepository', () => {
+  let db: Database.Database;
+  let repo: MemoryLinksRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    repo = new MemoryLinksRepository(db);
+    insertMemory(db, 'm1');
+    insertMemory(db, 'm2');
+    insertMemory(db, 'm3');
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('inserts and retrieves a link by id', () => {
+    const link = makeLink();
+    repo.insert(link);
+    const found = repo.findById('link-1');
+    expect(found).not.toBeNull();
+    expect(found!.sourceMemoryId).toBe('m1');
+    expect(found!.targetMemoryId).toBe('m2');
+    expect(found!.linkType).toBe('relates_to');
+    expect(found!.weight).toBe(1.0);
+  });
+
+  it('returns null for non-existent id', () => {
+    expect(repo.findById('nope')).toBeNull();
+  });
+
+  it('enforces unique constraint on (source, target, type)', () => {
+    repo.insert(makeLink());
+    expect(() => repo.insert(makeLink({ id: 'link-2' }))).toThrow();
+  });
+
+  it('allows same pair with different link types', () => {
+    repo.insert(makeLink());
+    repo.insert(makeLink({ id: 'link-2', linkType: 'supersedes' }));
+    expect(repo.findBySource('m1')).toHaveLength(2);
+  });
+
+  it('findBySource returns outgoing links', () => {
+    repo.insert(makeLink());
+    repo.insert(makeLink({ id: 'link-2', sourceMemoryId: 'm1', targetMemoryId: 'm3' }));
+    const links = repo.findBySource('m1');
+    expect(links).toHaveLength(2);
+  });
+
+  it('findByTarget returns incoming links', () => {
+    repo.insert(makeLink());
+    const links = repo.findByTarget('m2');
+    expect(links).toHaveLength(1);
+    expect(links[0]!.sourceMemoryId).toBe('m1');
+  });
+
+  it('findByType filters by link type', () => {
+    repo.insert(makeLink());
+    repo.insert(
+      makeLink({
+        id: 'link-2',
+        sourceMemoryId: 'm2',
+        targetMemoryId: 'm3',
+        linkType: 'supersedes',
+      }),
+    );
+    expect(repo.findByType('relates_to')).toHaveLength(1);
+    expect(repo.findByType('supersedes')).toHaveLength(1);
+  });
+
+  it('findByBatch filters by import batch', () => {
+    repo.insert(makeLink({ importBatchId: 'batch-1' }));
+    repo.insert(
+      makeLink({
+        id: 'link-2',
+        sourceMemoryId: 'm2',
+        targetMemoryId: 'm3',
+        importBatchId: 'batch-1',
+      }),
+    );
+    expect(repo.findByBatch('batch-1')).toHaveLength(2);
+    expect(repo.findByBatch('batch-2')).toHaveLength(0);
+  });
+
+  it('delete removes a link', () => {
+    repo.insert(makeLink());
+    expect(repo.delete('link-1')).toBe(true);
+    expect(repo.findById('link-1')).toBeNull();
+  });
+
+  it('delete returns false for non-existent id', () => {
+    expect(repo.delete('nope')).toBe(false);
+  });
+
+  it('deleteByBatch removes all links for a batch', () => {
+    repo.insert(makeLink({ importBatchId: 'batch-1' }));
+    repo.insert(
+      makeLink({
+        id: 'link-2',
+        sourceMemoryId: 'm2',
+        targetMemoryId: 'm3',
+        importBatchId: 'batch-1',
+      }),
+    );
+    expect(repo.deleteByBatch('batch-1')).toBe(2);
+    expect(repo.findByBatch('batch-1')).toHaveLength(0);
+  });
+
+  it('neighbors returns both directions', () => {
+    repo.insert(makeLink()); // m1 → m2
+    repo.insert(
+      makeLink({
+        id: 'link-2',
+        sourceMemoryId: 'm3',
+        targetMemoryId: 'm1',
+        linkType: 'depends_on',
+      }),
+    ); // m3 → m1
+
+    const neighbors = repo.neighbors('m1');
+    expect(neighbors).toHaveLength(2);
+
+    const outgoing = neighbors.find((n) => n.direction === 'outgoing');
+    const incoming = neighbors.find((n) => n.direction === 'incoming');
+    expect(outgoing!.memoryId).toBe('m2');
+    expect(incoming!.memoryId).toBe('m3');
+  });
+
+  it('traverse returns reachable nodes via recursive CTE', () => {
+    // m1 → m2 → m3 (chain of depth 2)
+    repo.insert(makeLink()); // m1 → m2
+    repo.insert(makeLink({ id: 'link-2', sourceMemoryId: 'm2', targetMemoryId: 'm3' })); // m2 → m3
+
+    const nodes = repo.traverse('m1', 2);
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0]!.memoryId).toBe('m2');
+    expect(nodes[0]!.depth).toBe(1);
+    expect(nodes[1]!.memoryId).toBe('m3');
+    expect(nodes[1]!.depth).toBe(2);
+  });
+
+  it('traverse respects maxDepth', () => {
+    repo.insert(makeLink()); // m1 → m2
+    repo.insert(makeLink({ id: 'link-2', sourceMemoryId: 'm2', targetMemoryId: 'm3' })); // m2 → m3
+
+    const nodes = repo.traverse('m1', 1);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]!.memoryId).toBe('m2');
+  });
+
+  it('traverse returns empty for isolated node', () => {
+    expect(repo.traverse('m3')).toHaveLength(0);
+  });
+});

--- a/packages/store/src/__tests__/migrations.test.ts
+++ b/packages/store/src/__tests__/migrations.test.ts
@@ -161,6 +161,103 @@ describe('FTS5 virtual table after migrations', () => {
   });
 });
 
+describe('memory_links and import_batches tables after migration 3', () => {
+  it('memory_links table exists', () => {
+    const db = createTestDatabase();
+    try {
+      const row = db
+        .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='memory_links'`)
+        .get() as { name: string } | undefined;
+      expect(row).toBeDefined();
+      expect(row?.name).toBe('memory_links');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('import_batches table exists', () => {
+    const db = createTestDatabase();
+    try {
+      const row = db
+        .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='import_batches'`)
+        .get() as { name: string } | undefined;
+      expect(row).toBeDefined();
+      expect(row?.name).toBe('import_batches');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('memory_links unique constraint enforced', () => {
+    const db = createTestDatabase();
+    try {
+      // Insert two curated memories to link
+      const hash = 'a'.repeat(64);
+      for (const id of ['m1', 'm2']) {
+        db.prepare(
+          `INSERT INTO curated_memories (
+            id, candidate_id, source, content, title, category,
+            trust_level, sensitivity, author_json, tenant_id,
+            metadata_json, lifecycle, content_hash,
+            policy_evaluations_json, promoted_at, promoted_by_json, updated_at, version
+          ) VALUES (?, ?, 'manual', 'c', 't', 'pattern', 'high', 'internal',
+            '{"type":"ai","id":"c1"}', 'tenant-1', '{}', 'active', ?,
+            '[]', datetime('now'), '{"type":"system","id":"s1"}', datetime('now'), 1)`,
+        ).run(id, `cand-${id}`, hash);
+      }
+
+      db.prepare(
+        `INSERT INTO memory_links (id, source_memory_id, target_memory_id, link_type, created_by, source)
+         VALUES ('link-1', 'm1', 'm2', 'relates_to', 'test', 'manual')`,
+      ).run();
+
+      expect(() =>
+        db
+          .prepare(
+            `INSERT INTO memory_links (id, source_memory_id, target_memory_id, link_type, created_by, source)
+             VALUES ('link-2', 'm1', 'm2', 'relates_to', 'test', 'manual')`,
+          )
+          .run(),
+      ).toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('memory_links indexes exist', () => {
+    const db = createTestDatabase();
+    try {
+      for (const name of [
+        'idx_links_source',
+        'idx_links_target',
+        'idx_links_type',
+        'idx_links_batch',
+      ]) {
+        const row = db
+          .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`)
+          .get(name) as { name: string } | undefined;
+        expect(row, `index ${name} should exist`).toBeDefined();
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  it('import_batches indexes exist', () => {
+    const db = createTestDatabase();
+    try {
+      for (const name of ['idx_batches_tenant', 'idx_batches_status']) {
+        const row = db
+          .prepare(`SELECT name FROM sqlite_master WHERE type='index' AND name=?`)
+          .get(name) as { name: string } | undefined;
+        expect(row, `index ${name} should exist`).toBeDefined();
+      }
+    } finally {
+      db.close();
+    }
+  });
+});
+
 describe('compound indexes after migrations', () => {
   it('idx_memories_tenant_lifecycle index exists', () => {
     const db = createTestDatabase();

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -7,3 +7,7 @@ export { PolicyRepository } from './repositories/policy-repository.js';
 export { AuditRepository } from './repositories/audit-repository.js';
 export { ExportStateRepository } from './repositories/export-state-repository.js';
 export type { ExportState } from './repositories/export-state-repository.js';
+export { MemoryLinksRepository } from './repositories/memory-links-repository.js';
+export type { MemoryLink, Neighbor, GraphNode } from './repositories/memory-links-repository.js';
+export { ImportBatchRepository } from './repositories/import-batch-repository.js';
+export type { ImportBatch } from './repositories/import-batch-repository.js';

--- a/packages/store/src/repositories/import-batch-repository.ts
+++ b/packages/store/src/repositories/import-batch-repository.ts
@@ -1,0 +1,173 @@
+import type Database from 'better-sqlite3';
+import type { ImportBatchStatus } from '@qmd-team-intent-kb/schema';
+
+/** Domain representation of an import batch */
+export interface ImportBatch {
+  id: string;
+  tenantId: string;
+  sourcePath: string | null;
+  fileCount: number;
+  createdCount: number;
+  rejectedCount: number;
+  skippedCount: number;
+  status: ImportBatchStatus;
+  createdAt: string;
+  rolledBackAt: string | null;
+}
+
+/**
+ * Repository for import batch tracking and rollback support.
+ */
+export class ImportBatchRepository {
+  private readonly stmtInsert: Database.Statement;
+  private readonly stmtFindById: Database.Statement;
+  private readonly stmtFindByTenant: Database.Statement;
+  private readonly stmtFindByStatus: Database.Statement;
+  private readonly stmtUpdateCounts: Database.Statement;
+  private readonly stmtUpdateStatus: Database.Statement;
+
+  constructor(db: Database.Database) {
+    this.stmtInsert = db.prepare(`
+      INSERT INTO import_batches (
+        id, tenant_id, source_path, file_count,
+        created_count, rejected_count, skipped_count,
+        status, created_at
+      ) VALUES (
+        @id, @tenant_id, @source_path, @file_count,
+        @created_count, @rejected_count, @skipped_count,
+        @status, @created_at
+      )
+    `);
+
+    this.stmtFindById = db.prepare(`
+      SELECT * FROM import_batches WHERE id = ?
+    `);
+
+    this.stmtFindByTenant = db.prepare(`
+      SELECT * FROM import_batches WHERE tenant_id = ? ORDER BY created_at DESC
+    `);
+
+    this.stmtFindByStatus = db.prepare(`
+      SELECT * FROM import_batches WHERE status = ? ORDER BY created_at DESC
+    `);
+
+    this.stmtUpdateCounts = db.prepare(`
+      UPDATE import_batches SET
+        file_count = @file_count,
+        created_count = @created_count,
+        rejected_count = @rejected_count,
+        skipped_count = @skipped_count
+      WHERE id = @id
+    `);
+
+    this.stmtUpdateStatus = db.prepare(`
+      UPDATE import_batches SET
+        status = @status,
+        rolled_back_at = @rolled_back_at
+      WHERE id = @id
+    `);
+  }
+
+  /** Create a new import batch record. */
+  insert(batch: ImportBatch): void {
+    this.stmtInsert.run({
+      id: batch.id,
+      tenant_id: batch.tenantId,
+      source_path: batch.sourcePath,
+      file_count: batch.fileCount,
+      created_count: batch.createdCount,
+      rejected_count: batch.rejectedCount,
+      skipped_count: batch.skippedCount,
+      status: batch.status,
+      created_at: batch.createdAt,
+    });
+  }
+
+  /** Find a batch by its primary key, or return null. */
+  findById(id: string): ImportBatch | null {
+    const row = this.stmtFindById.get(id) as RawBatchRow | undefined;
+    return row !== undefined ? rowToBatch(row) : null;
+  }
+
+  /** All batches for a given tenant, most recent first. */
+  findByTenant(tenantId: string): ImportBatch[] {
+    return (this.stmtFindByTenant.all(tenantId) as RawBatchRow[]).map(rowToBatch);
+  }
+
+  /** All batches with a given status, most recent first. */
+  findByStatus(status: ImportBatchStatus): ImportBatch[] {
+    return (this.stmtFindByStatus.all(status) as RawBatchRow[]).map(rowToBatch);
+  }
+
+  /** Update the count fields on a batch. Returns true if a row was modified. */
+  updateCounts(
+    id: string,
+    counts: {
+      fileCount: number;
+      createdCount: number;
+      rejectedCount: number;
+      skippedCount: number;
+    },
+  ): boolean {
+    return (
+      this.stmtUpdateCounts.run({
+        id,
+        file_count: counts.fileCount,
+        created_count: counts.createdCount,
+        rejected_count: counts.rejectedCount,
+        skipped_count: counts.skippedCount,
+      }).changes > 0
+    );
+  }
+
+  /** Mark a batch as completed. Returns true if a row was modified. */
+  complete(id: string): boolean {
+    return (
+      this.stmtUpdateStatus.run({
+        id,
+        status: 'completed',
+        rolled_back_at: null,
+      }).changes > 0
+    );
+  }
+
+  /** Mark a batch as rolled back. Returns true if a row was modified. */
+  rollback(id: string, rolledBackAt: string): boolean {
+    return (
+      this.stmtUpdateStatus.run({
+        id,
+        status: 'rolled_back',
+        rolled_back_at: rolledBackAt,
+      }).changes > 0
+    );
+  }
+}
+
+/** Raw row shape from SQLite */
+interface RawBatchRow {
+  id: string;
+  tenant_id: string;
+  source_path: string | null;
+  file_count: number;
+  created_count: number;
+  rejected_count: number;
+  skipped_count: number;
+  status: string;
+  created_at: string;
+  rolled_back_at: string | null;
+}
+
+function rowToBatch(row: RawBatchRow): ImportBatch {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    sourcePath: row.source_path,
+    fileCount: row.file_count,
+    createdCount: row.created_count,
+    rejectedCount: row.rejected_count,
+    skippedCount: row.skipped_count,
+    status: row.status as ImportBatchStatus,
+    createdAt: row.created_at,
+    rolledBackAt: row.rolled_back_at,
+  };
+}

--- a/packages/store/src/repositories/memory-links-repository.ts
+++ b/packages/store/src/repositories/memory-links-repository.ts
@@ -1,0 +1,206 @@
+import type Database from 'better-sqlite3';
+import type { LinkType, LinkSource } from '@qmd-team-intent-kb/schema';
+
+/** Domain representation of a memory link */
+export interface MemoryLink {
+  id: string;
+  sourceMemoryId: string;
+  targetMemoryId: string;
+  linkType: LinkType;
+  weight: number;
+  createdBy: string;
+  source: LinkSource;
+  importBatchId: string | null;
+  createdAt: string;
+}
+
+/** A neighbor node returned by graph traversal */
+export interface Neighbor {
+  memoryId: string;
+  linkType: LinkType;
+  weight: number;
+  direction: 'outgoing' | 'incoming';
+}
+
+/** A node in a graph traversal result */
+export interface GraphNode {
+  memoryId: string;
+  depth: number;
+  linkType: LinkType;
+  weight: number;
+}
+
+/**
+ * Repository for memory-to-memory links (knowledge graph edges).
+ * Supports CRUD, neighbor queries, and recursive CTE graph traversal.
+ */
+export class MemoryLinksRepository {
+  private readonly stmtInsert: Database.Statement;
+  private readonly stmtFindById: Database.Statement;
+  private readonly stmtFindBySource: Database.Statement;
+  private readonly stmtFindByTarget: Database.Statement;
+  private readonly stmtFindByType: Database.Statement;
+  private readonly stmtFindByBatch: Database.Statement;
+  private readonly stmtDelete: Database.Statement;
+  private readonly stmtDeleteByBatch: Database.Statement;
+  private readonly stmtNeighbors: Database.Statement;
+  private readonly db: Database.Database;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+
+    this.stmtInsert = db.prepare(`
+      INSERT INTO memory_links (
+        id, source_memory_id, target_memory_id, link_type,
+        weight, created_by, source, import_batch_id, created_at
+      ) VALUES (
+        @id, @source_memory_id, @target_memory_id, @link_type,
+        @weight, @created_by, @source, @import_batch_id, @created_at
+      )
+    `);
+
+    this.stmtFindById = db.prepare(`
+      SELECT * FROM memory_links WHERE id = ?
+    `);
+
+    this.stmtFindBySource = db.prepare(`
+      SELECT * FROM memory_links WHERE source_memory_id = ? ORDER BY created_at ASC
+    `);
+
+    this.stmtFindByTarget = db.prepare(`
+      SELECT * FROM memory_links WHERE target_memory_id = ? ORDER BY created_at ASC
+    `);
+
+    this.stmtFindByType = db.prepare(`
+      SELECT * FROM memory_links WHERE link_type = ? ORDER BY created_at ASC
+    `);
+
+    this.stmtFindByBatch = db.prepare(`
+      SELECT * FROM memory_links WHERE import_batch_id = ? ORDER BY created_at ASC
+    `);
+
+    this.stmtDelete = db.prepare(`
+      DELETE FROM memory_links WHERE id = ?
+    `);
+
+    this.stmtDeleteByBatch = db.prepare(`
+      DELETE FROM memory_links WHERE import_batch_id = ?
+    `);
+
+    this.stmtNeighbors = db.prepare(`
+      SELECT target_memory_id AS memoryId, link_type AS linkType, weight, 'outgoing' AS direction
+        FROM memory_links WHERE source_memory_id = ?
+      UNION ALL
+      SELECT source_memory_id AS memoryId, link_type AS linkType, weight, 'incoming' AS direction
+        FROM memory_links WHERE target_memory_id = ?
+      ORDER BY weight DESC
+    `);
+  }
+
+  /** Insert a new link. Throws on unique constraint violation. */
+  insert(link: MemoryLink): void {
+    this.stmtInsert.run({
+      id: link.id,
+      source_memory_id: link.sourceMemoryId,
+      target_memory_id: link.targetMemoryId,
+      link_type: link.linkType,
+      weight: link.weight,
+      created_by: link.createdBy,
+      source: link.source,
+      import_batch_id: link.importBatchId,
+      created_at: link.createdAt,
+    });
+  }
+
+  /** Find a link by its primary key, or return null. */
+  findById(id: string): MemoryLink | null {
+    const row = this.stmtFindById.get(id) as RawLinkRow | undefined;
+    return row !== undefined ? rowToLink(row) : null;
+  }
+
+  /** All links originating from a given memory. */
+  findBySource(memoryId: string): MemoryLink[] {
+    return (this.stmtFindBySource.all(memoryId) as RawLinkRow[]).map(rowToLink);
+  }
+
+  /** All links pointing to a given memory. */
+  findByTarget(memoryId: string): MemoryLink[] {
+    return (this.stmtFindByTarget.all(memoryId) as RawLinkRow[]).map(rowToLink);
+  }
+
+  /** All links of a given type. */
+  findByType(linkType: LinkType): MemoryLink[] {
+    return (this.stmtFindByType.all(linkType) as RawLinkRow[]).map(rowToLink);
+  }
+
+  /** All links associated with a given import batch. */
+  findByBatch(batchId: string): MemoryLink[] {
+    return (this.stmtFindByBatch.all(batchId) as RawLinkRow[]).map(rowToLink);
+  }
+
+  /** Delete a link by id. Returns true if a row was removed. */
+  delete(id: string): boolean {
+    return this.stmtDelete.run(id).changes > 0;
+  }
+
+  /** Delete all links associated with an import batch. Returns count deleted. */
+  deleteByBatch(batchId: string): number {
+    return this.stmtDeleteByBatch.run(batchId).changes;
+  }
+
+  /** Get all neighbors (both directions) of a memory. */
+  neighbors(memoryId: string): Neighbor[] {
+    return this.stmtNeighbors.all(memoryId, memoryId) as Neighbor[];
+  }
+
+  /**
+   * Recursive CTE graph traversal from a starting memory.
+   * Returns all reachable nodes up to the given depth.
+   */
+  traverse(memoryId: string, maxDepth: number = 2): GraphNode[] {
+    const sql = `
+      WITH RECURSIVE graph(memoryId, depth, linkType, weight) AS (
+        SELECT target_memory_id, 1, link_type, weight
+          FROM memory_links WHERE source_memory_id = @start
+        UNION ALL
+        SELECT ml.target_memory_id, g.depth + 1, ml.link_type, ml.weight
+          FROM memory_links ml
+          JOIN graph g ON ml.source_memory_id = g.memoryId
+          WHERE g.depth < @maxDepth
+      )
+      SELECT DISTINCT memoryId, MIN(depth) AS depth, linkType, weight
+        FROM graph
+        WHERE memoryId != @start
+        GROUP BY memoryId
+        ORDER BY depth ASC, weight DESC
+    `;
+    return this.db.prepare(sql).all({ start: memoryId, maxDepth }) as GraphNode[];
+  }
+}
+
+/** Raw row shape from SQLite */
+interface RawLinkRow {
+  id: string;
+  source_memory_id: string;
+  target_memory_id: string;
+  link_type: string;
+  weight: number;
+  created_by: string;
+  source: string;
+  import_batch_id: string | null;
+  created_at: string;
+}
+
+function rowToLink(row: RawLinkRow): MemoryLink {
+  return {
+    id: row.id,
+    sourceMemoryId: row.source_memory_id,
+    targetMemoryId: row.target_memory_id,
+    linkType: row.link_type as LinkType,
+    weight: row.weight,
+    createdBy: row.created_by,
+    source: row.source as LinkSource,
+    importBatchId: row.import_batch_id,
+    createdAt: row.created_at,
+  };
+}

--- a/packages/store/src/repositories/memory-links-repository.ts
+++ b/packages/store/src/repositories/memory-links-repository.ts
@@ -167,11 +167,17 @@ export class MemoryLinksRepository {
           FROM memory_links ml
           JOIN graph g ON ml.source_memory_id = g.memoryId
           WHERE g.depth < @maxDepth
-      )
-      SELECT DISTINCT memoryId, MIN(depth) AS depth, linkType, weight
+      ),
+      ranked_paths AS (
+        SELECT
+          *,
+          ROW_NUMBER() OVER(PARTITION BY memoryId ORDER BY depth ASC, weight DESC) as rn
         FROM graph
         WHERE memoryId != @start
-        GROUP BY memoryId
+      )
+      SELECT memoryId, depth, linkType, weight
+        FROM ranked_paths
+        WHERE rn = 1
         ORDER BY depth ASC, weight DESC
     `;
     return this.db.prepare(sql).all({ start: memoryId, maxDepth }) as GraphNode[];

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -168,4 +168,41 @@ AFTER UPDATE ON curated_memories BEGIN
 END;
     `.trim(),
   },
+  {
+    version: 3,
+    name: 'add_memory_links_and_import_batches',
+    sql: `
+CREATE TABLE IF NOT EXISTS memory_links (
+  id TEXT PRIMARY KEY,
+  source_memory_id TEXT NOT NULL REFERENCES curated_memories(id),
+  target_memory_id TEXT NOT NULL REFERENCES curated_memories(id),
+  link_type TEXT NOT NULL,
+  weight REAL NOT NULL DEFAULT 1.0,
+  created_by TEXT NOT NULL,
+  source TEXT NOT NULL,
+  import_batch_id TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(source_memory_id, target_memory_id, link_type)
+);
+CREATE INDEX IF NOT EXISTS idx_links_source ON memory_links(source_memory_id);
+CREATE INDEX IF NOT EXISTS idx_links_target ON memory_links(target_memory_id);
+CREATE INDEX IF NOT EXISTS idx_links_type ON memory_links(link_type);
+CREATE INDEX IF NOT EXISTS idx_links_batch ON memory_links(import_batch_id);
+
+CREATE TABLE IF NOT EXISTS import_batches (
+  id TEXT PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  source_path TEXT,
+  file_count INTEGER NOT NULL DEFAULT 0,
+  created_count INTEGER NOT NULL DEFAULT 0,
+  rejected_count INTEGER NOT NULL DEFAULT 0,
+  skipped_count INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'active',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  rolled_back_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_batches_tenant ON import_batches(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_batches_status ON import_batches(status);
+    `.trim(),
+  },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,14 +229,14 @@ importers:
         specifier: workspace:*
         version: link:../common
       zod:
-        specifier: ^3.23.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
 
   packages/schema:
     dependencies:
       zod:
-        specifier: ^3.23.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
 
   packages/store:
     dependencies:
@@ -2173,9 +2173,6 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -4035,7 +4032,5 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
-
-  zod@3.25.76: {}
 
   zod@4.3.6: {}


### PR DESCRIPTION
## Summary

- **Epic 11 (Zod 4 Migration)**: Migrated `packages/schema` and `packages/repo-resolver` from Zod 3 to Zod 4. Fixed two Zod 4 breaking changes (`z.record(z.unknown())` and nested `.default({})` behavior). Removed MCP server's inline enum workarounds — now imports directly from schema.
- **Epic 12 (Knowledge Graph Foundation)**: Added `LinkType`, `LinkSource`, `ImportBatchStatus` enums. Added `memory_links` and `import_batches` tables (migration 3). Built `MemoryLinksRepository` with recursive CTE graph traversal and `ImportBatchRepository` with batch lifecycle management.

**Beads closed**: qf2, qmv, i72, 93w, 3s2, f6n, ahg (7 total)

## Test plan

- [x] `pnpm validate` passes (format + lint + typecheck + 1208 tests)
- [x] Schema package tests: 240 pass (includes new enum tests)
- [x] Store package tests: 42 pass (includes 5 migration + 15 links repo + 9 batch repo)
- [x] MCP server tests: 55 pass (with workaround removal)
- [x] No regressions in API, curator, edge-daemon, policy-engine tests

Jeremy made me do it
-claude