### PR TITLE
feat: vault import pipeline with batch tracking and rollback (E12-B04 + E13)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,7 +25,8 @@
     "fastify": "^5.8.5",
     "@qmd-team-intent-kb/schema": "workspace:*",
     "@qmd-team-intent-kb/common": "workspace:*",
-    "@qmd-team-intent-kb/store": "workspace:*"
+    "@qmd-team-intent-kb/store": "workspace:*",
+    "@qmd-team-intent-kb/curator": "workspace:*"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,8 @@ import {
   MemoryRepository,
   PolicyRepository,
   AuditRepository,
+  ImportBatchRepository,
+  MemoryLinksRepository,
 } from '@qmd-team-intent-kb/store';
 import { CandidateService } from './services/candidate-service.js';
 import { MemoryService } from './services/memory-service.js';
@@ -18,6 +20,8 @@ import { registerPolicyRoutes } from './routes/policies.js';
 import { registerHealthRoutes } from './routes/health.js';
 import { registerAuditRoutes } from './routes/audit.js';
 import { registerSearchRoutes } from './routes/search.js';
+import { registerImportRoutes } from './routes/import.js';
+import { ImportService } from './services/import-service.js';
 import { registerRateLimiter } from './middleware/rate-limiter.js';
 import { registerApiKeyAuth } from './middleware/api-key-auth.js';
 import { registerInputSanitizer } from './middleware/input-sanitizer.js';
@@ -62,12 +66,15 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
   const memoryRepo = new MemoryRepository(deps.db);
   const policyRepo = new PolicyRepository(deps.db);
   const auditRepo = new AuditRepository(deps.db);
+  const batchRepo = new ImportBatchRepository(deps.db);
+  const linksRepo = new MemoryLinksRepository(deps.db);
 
   const candidateService = new CandidateService(candidateRepo);
   const memoryService = new MemoryService(memoryRepo, auditRepo);
   const policyService = new PolicyService(policyRepo);
   const healthService = new HealthService(deps.db);
   const searchService = new SearchService(memoryRepo);
+  const importService = new ImportService(candidateRepo, memoryRepo, batchRepo, linksRepo);
 
   // Routes are wrapped in an inner register() so they load AFTER the
   // @fastify/swagger plugin. The swagger plugin installs an `onRoute`
@@ -80,6 +87,7 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
     registerPolicyRoutes(scope, policyService);
     registerAuditRoutes(scope, auditRepo);
     registerSearchRoutes(scope, searchService);
+    registerImportRoutes(scope, importService);
   });
 
   return app;

--- a/apps/api/src/routes/import.ts
+++ b/apps/api/src/routes/import.ts
@@ -1,0 +1,138 @@
+import type { FastifyInstance } from 'fastify';
+import { ApiError } from '../errors.js';
+import type { ImportService } from '../services/import-service.js';
+
+/**
+ * Register import routes for vault import operations.
+ *
+ * POST   /api/import/preview      — dry-run analysis (200)
+ * POST   /api/import              — execute import (201)
+ * GET    /api/import/batches      — list batches (200)
+ * GET    /api/import/batches/:id  — get batch details (200 | 404)
+ * DELETE /api/import/batches/:id  — rollback a batch (200 | 400 | 404)
+ */
+export function registerImportRoutes(app: FastifyInstance, service: ImportService): void {
+  app.post(
+    '/api/import/preview',
+    {
+      schema: {
+        tags: ['import'],
+        summary: 'Preview an import without persisting',
+        description: 'Walks the vault directory, checks collisions, and reports what would happen.',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const body = request.body as {
+          sourcePath?: string;
+          tenantId?: string;
+          excludeDirs?: string[];
+        };
+        const result = await service.preview(
+          body.sourcePath ?? '',
+          body.tenantId ?? '',
+          body.excludeDirs,
+        );
+        return reply.status(200).send(result);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
+      }
+    },
+  );
+
+  app.post(
+    '/api/import',
+    {
+      schema: {
+        tags: ['import'],
+        summary: 'Execute a vault import',
+        description:
+          'Walks the vault directory, creates candidates with batch tracking, and returns results.',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const body = request.body as {
+          sourcePath?: string;
+          tenantId?: string;
+          excludeDirs?: string[];
+        };
+        const result = await service.execute(
+          body.sourcePath ?? '',
+          body.tenantId ?? '',
+          body.excludeDirs,
+        );
+        return reply.status(201).send(result);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
+      }
+    },
+  );
+
+  app.get(
+    '/api/import/batches',
+    {
+      schema: {
+        tags: ['import'],
+        summary: 'List import batches',
+        description: 'Returns all import batches, optionally filtered by tenantId.',
+      },
+    },
+    async (request, reply) => {
+      const query = request.query as { tenantId?: string };
+      const batches = service.listBatches(query.tenantId);
+      return reply.status(200).send(batches);
+    },
+  );
+
+  app.get(
+    '/api/import/batches/:id',
+    {
+      schema: {
+        tags: ['import'],
+        summary: 'Get import batch details',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const params = request.params as { id: string };
+        const batch = service.getBatch(params.id);
+        return reply.status(200).send(batch);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
+      }
+    },
+  );
+
+  app.delete(
+    '/api/import/batches/:id',
+    {
+      schema: {
+        tags: ['import'],
+        summary: 'Roll back an import batch',
+        description: 'Deletes all candidates created by the batch and marks it as rolled_back.',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const params = request.params as { id: string };
+        const result = service.rollback(params.id);
+        return reply.status(200).send(result);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/apps/api/src/routes/import.ts
+++ b/apps/api/src/routes/import.ts
@@ -1,6 +1,13 @@
 import type { FastifyInstance } from 'fastify';
-import { ApiError } from '../errors.js';
+import { z } from 'zod';
+import { ApiError, badRequest } from '../errors.js';
 import type { ImportService } from '../services/import-service.js';
+
+const ImportBodySchema = z.object({
+  sourcePath: z.string().min(1),
+  tenantId: z.string().min(1),
+  excludeDirs: z.array(z.string()).optional(),
+});
 
 /**
  * Register import routes for vault import operations.
@@ -23,15 +30,16 @@ export function registerImportRoutes(app: FastifyInstance, service: ImportServic
     },
     async (request, reply) => {
       try {
-        const body = request.body as {
-          sourcePath?: string;
-          tenantId?: string;
-          excludeDirs?: string[];
-        };
+        const parsed = ImportBodySchema.safeParse(request.body);
+        if (!parsed.success) {
+          throw badRequest(
+            parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+          );
+        }
         const result = await service.preview(
-          body.sourcePath ?? '',
-          body.tenantId ?? '',
-          body.excludeDirs,
+          parsed.data.sourcePath,
+          parsed.data.tenantId,
+          parsed.data.excludeDirs,
         );
         return reply.status(200).send(result);
       } catch (err) {
@@ -55,15 +63,16 @@ export function registerImportRoutes(app: FastifyInstance, service: ImportServic
     },
     async (request, reply) => {
       try {
-        const body = request.body as {
-          sourcePath?: string;
-          tenantId?: string;
-          excludeDirs?: string[];
-        };
+        const parsed = ImportBodySchema.safeParse(request.body);
+        if (!parsed.success) {
+          throw badRequest(
+            parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; '),
+          );
+        }
         const result = await service.execute(
-          body.sourcePath ?? '',
-          body.tenantId ?? '',
-          body.excludeDirs,
+          parsed.data.sourcePath,
+          parsed.data.tenantId,
+          parsed.data.excludeDirs,
         );
         return reply.status(201).send(result);
       } catch (err) {

--- a/apps/api/src/services/import-service.ts
+++ b/apps/api/src/services/import-service.ts
@@ -1,0 +1,88 @@
+import type {
+  CandidateRepository,
+  MemoryRepository,
+  ImportBatchRepository,
+  MemoryLinksRepository,
+} from '@qmd-team-intent-kb/store';
+import { previewImport, executeImport, rollbackImport } from '@qmd-team-intent-kb/curator';
+import type {
+  ImportPreviewResult,
+  ImportExecutionResult,
+  RollbackResult,
+  ImportDependencies,
+} from '@qmd-team-intent-kb/curator';
+import { badRequest, notFound } from '../errors.js';
+
+export class ImportService {
+  private readonly deps: ImportDependencies;
+  private readonly linksRepo?: MemoryLinksRepository;
+
+  constructor(
+    candidateRepo: CandidateRepository,
+    memoryRepo: MemoryRepository,
+    batchRepo: ImportBatchRepository,
+    linksRepo?: MemoryLinksRepository,
+  ) {
+    this.deps = { candidateRepo, memoryRepo, batchRepo };
+    this.linksRepo = linksRepo;
+  }
+
+  async preview(
+    sourcePath: string,
+    tenantId: string,
+    excludeDirs?: string[],
+  ): Promise<ImportPreviewResult> {
+    if (!sourcePath || !sourcePath.trim()) {
+      throw badRequest('sourcePath is required');
+    }
+    if (!tenantId || !tenantId.trim()) {
+      throw badRequest('tenantId is required');
+    }
+    return previewImport(sourcePath, tenantId, this.deps, excludeDirs);
+  }
+
+  async execute(
+    sourcePath: string,
+    tenantId: string,
+    excludeDirs?: string[],
+  ): Promise<ImportExecutionResult> {
+    if (!sourcePath || !sourcePath.trim()) {
+      throw badRequest('sourcePath is required');
+    }
+    if (!tenantId || !tenantId.trim()) {
+      throw badRequest('tenantId is required');
+    }
+    return executeImport(sourcePath, tenantId, this.deps, excludeDirs);
+  }
+
+  listBatches(tenantId?: string) {
+    if (tenantId) {
+      return this.deps.batchRepo.findByTenant(tenantId);
+    }
+    // Return all active + completed batches
+    return [
+      ...this.deps.batchRepo.findByStatus('active'),
+      ...this.deps.batchRepo.findByStatus('completed'),
+    ];
+  }
+
+  getBatch(batchId: string) {
+    const batch = this.deps.batchRepo.findById(batchId);
+    if (!batch) throw notFound(`Import batch not found: ${batchId}`);
+    return batch;
+  }
+
+  rollback(batchId: string): RollbackResult {
+    try {
+      return rollbackImport(batchId, this.deps, this.linksRepo);
+    } catch (e) {
+      if (e instanceof Error && e.message.includes('not found')) {
+        throw notFound(e.message);
+      }
+      if (e instanceof Error && e.message.includes('already rolled back')) {
+        throw badRequest(e.message);
+      }
+      throw e;
+    }
+  }
+}

--- a/apps/curator/src/__tests__/collision-detector.test.ts
+++ b/apps/curator/src/__tests__/collision-detector.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import {
+  createTestDatabase,
+  MemoryRepository,
+  CandidateRepository,
+} from '@qmd-team-intent-kb/store';
+import { detectCollision } from '../import/collision-detector.js';
+import { makeCandidate, makeCuratedMemory } from './fixtures.js';
+
+describe('detectCollision', () => {
+  let db: Database.Database;
+  let memoryRepo: MemoryRepository;
+  let candidateRepo: CandidateRepository;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    memoryRepo = new MemoryRepository(db);
+    candidateRepo = new CandidateRepository(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('returns no collision for novel content', () => {
+    const result = detectCollision('unique content here', memoryRepo, candidateRepo);
+    expect(result.hasCollision).toBe(false);
+    expect(result.contentHash).toBeTruthy();
+  });
+
+  it('detects collision with curated memory', () => {
+    const content = 'This content already exists in curated';
+    const hash = computeContentHash(content);
+    const memory = makeCuratedMemory({ content, contentHash: hash });
+    memoryRepo.insert(memory);
+
+    const result = detectCollision(content, memoryRepo, candidateRepo);
+    expect(result.hasCollision).toBe(true);
+    expect(result.target).toBe('curated_memory');
+    expect(result.matchedId).toBe(memory.id);
+  });
+
+  it('detects collision with pending candidate', () => {
+    const content = 'This content is already in inbox';
+    const hash = computeContentHash(content);
+    const candidate = makeCandidate({ content });
+    candidateRepo.insert(candidate, hash);
+
+    const result = detectCollision(content, memoryRepo, candidateRepo);
+    expect(result.hasCollision).toBe(true);
+    expect(result.target).toBe('candidate');
+    expect(result.matchedId).toBe(candidate.id);
+  });
+
+  it('curated memory takes priority over candidate', () => {
+    const content = 'Content in both places';
+    const hash = computeContentHash(content);
+    const memory = makeCuratedMemory({ content, contentHash: hash });
+    memoryRepo.insert(memory);
+    const candidate = makeCandidate({ content });
+    candidateRepo.insert(candidate, hash);
+
+    const result = detectCollision(content, memoryRepo, candidateRepo);
+    expect(result.target).toBe('curated_memory');
+    expect(result.matchedId).toBe(memory.id);
+  });
+
+  it('detects intra-batch collision via batchHashes', () => {
+    const content = 'Duplicate within batch';
+    const hash = computeContentHash(content);
+    const batchHashes = new Set([hash]);
+
+    const result = detectCollision(content, memoryRepo, candidateRepo, batchHashes);
+    expect(result.hasCollision).toBe(true);
+    expect(result.target).toBe('candidate');
+    expect(result.matchedTitle).toContain('duplicate within this import batch');
+  });
+
+  it('always returns the content hash', () => {
+    const content = 'Any content at all';
+    const expected = computeContentHash(content);
+
+    const result = detectCollision(content, memoryRepo, candidateRepo);
+    expect(result.contentHash).toBe(expected);
+  });
+});

--- a/apps/curator/src/__tests__/import-pipeline.test.ts
+++ b/apps/curator/src/__tests__/import-pipeline.test.ts
@@ -10,7 +10,7 @@ import {
   ImportBatchRepository,
 } from '@qmd-team-intent-kb/store';
 import { computeContentHash } from '@qmd-team-intent-kb/common';
-import { previewImport, executeImport } from '../import/import-pipeline.js';
+import { previewImport, executeImport, rollbackImport } from '../import/import-pipeline.js';
 import type { ImportDependencies } from '../import/import-pipeline.js';
 import { makeCuratedMemory } from './fixtures.js';
 
@@ -212,5 +212,65 @@ describe('executeImport', () => {
     const candidate = deps.candidateRepo.findById(result.files[0]!.candidateId!)!;
     expect(candidate.content).toBe('Just the body');
     expect(candidate.content).not.toContain('---');
+  });
+});
+
+describe('rollbackImport', () => {
+  let db: Database.Database;
+  let deps: ImportDependencies;
+  let vaultDir: string;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    deps = setupDeps(db);
+    vaultDir = mkdtempSync(join(tmpdir(), 'import-rollback-'));
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(vaultDir, { recursive: true, force: true });
+  });
+
+  function writeVault(relativePath: string, content: string): void {
+    const fullPath = join(vaultDir, relativePath);
+    mkdirSync(fullPath.split('/').slice(0, -1).join('/'), { recursive: true });
+    writeFileSync(fullPath, content, 'utf8');
+  }
+
+  it('deletes candidates created by the batch', async () => {
+    writeVault('note1.md', 'Content one');
+    writeVault('note2.md', 'Content two');
+
+    const importResult = await executeImport(vaultDir, TENANT, deps, undefined, () => NOW);
+    expect(deps.candidateRepo.count()).toBe(2);
+
+    const rollbackResult = rollbackImport(importResult.batchId, deps, undefined, () => NOW);
+    expect(rollbackResult.candidatesDeleted).toBe(2);
+    expect(deps.candidateRepo.count()).toBe(0);
+  });
+
+  it('marks batch as rolled_back', async () => {
+    writeVault('note.md', 'Content');
+
+    const importResult = await executeImport(vaultDir, TENANT, deps, undefined, () => NOW);
+    rollbackImport(importResult.batchId, deps, undefined, () => NOW);
+
+    const batch = deps.batchRepo.findById(importResult.batchId)!;
+    expect(batch.status).toBe('rolled_back');
+    expect(batch.rolledBackAt).toBe(NOW);
+  });
+
+  it('throws for non-existent batch', () => {
+    expect(() => rollbackImport('non-existent', deps)).toThrow('Import batch not found');
+  });
+
+  it('throws for already rolled-back batch', async () => {
+    writeVault('note.md', 'Content');
+    const importResult = await executeImport(vaultDir, TENANT, deps, undefined, () => NOW);
+    rollbackImport(importResult.batchId, deps, undefined, () => NOW);
+
+    expect(() => rollbackImport(importResult.batchId, deps, undefined, () => NOW)).toThrow(
+      'already rolled back',
+    );
   });
 });

--- a/apps/curator/src/__tests__/import-pipeline.test.ts
+++ b/apps/curator/src/__tests__/import-pipeline.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type Database from 'better-sqlite3';
+import {
+  createTestDatabase,
+  MemoryRepository,
+  CandidateRepository,
+  ImportBatchRepository,
+} from '@qmd-team-intent-kb/store';
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import { previewImport, executeImport } from '../import/import-pipeline.js';
+import type { ImportDependencies } from '../import/import-pipeline.js';
+import { makeCuratedMemory } from './fixtures.js';
+
+const TENANT = 'test-tenant';
+const NOW = '2026-01-15T10:00:00.000Z';
+
+function setupDeps(db: Database.Database): ImportDependencies {
+  return {
+    memoryRepo: new MemoryRepository(db),
+    candidateRepo: new CandidateRepository(db),
+    batchRepo: new ImportBatchRepository(db),
+  };
+}
+
+describe('previewImport', () => {
+  let db: Database.Database;
+  let deps: ImportDependencies;
+  let vaultDir: string;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    deps = setupDeps(db);
+    vaultDir = mkdtempSync(join(tmpdir(), 'import-preview-'));
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(vaultDir, { recursive: true, force: true });
+  });
+
+  function writeVault(relativePath: string, content: string): void {
+    const fullPath = join(vaultDir, relativePath);
+    mkdirSync(fullPath.split('/').slice(0, -1).join('/'), { recursive: true });
+    writeFileSync(fullPath, content, 'utf8');
+  }
+
+  it('reports files that would be created', async () => {
+    writeVault('note1.md', '# Note 1\nContent one');
+    writeVault('note2.md', '# Note 2\nContent two');
+
+    const result = await previewImport(vaultDir, TENANT, deps);
+    expect(result.fileCount).toBe(2);
+    expect(result.wouldCreate).toBe(2);
+    expect(result.wouldSkip).toBe(0);
+  });
+
+  it('reports collisions with existing memories', async () => {
+    const content = 'Already curated content';
+    const hash = computeContentHash(content);
+    deps.memoryRepo.insert(makeCuratedMemory({ content, contentHash: hash }));
+
+    writeVault('existing.md', content);
+    writeVault('novel.md', 'Brand new content');
+
+    const result = await previewImport(vaultDir, TENANT, deps);
+    expect(result.wouldCreate).toBe(1);
+    expect(result.wouldSkip).toBe(1);
+    expect(result.files.find((f) => f.relativePath === 'existing.md')?.status).toBe('skipped');
+  });
+
+  it('strips frontmatter before collision check', async () => {
+    const body = 'Unique body content here';
+    writeVault('with-fm.md', `---\ntitle: My Title\n---\n\n${body}`);
+
+    const result = await previewImport(vaultDir, TENANT, deps);
+    expect(result.wouldCreate).toBe(1);
+  });
+
+  it('skips empty-body files', async () => {
+    writeVault('empty-body.md', '---\ntitle: Just Frontmatter\n---\n');
+    writeVault('real.md', 'Has content');
+
+    const result = await previewImport(vaultDir, TENANT, deps);
+    expect(result.wouldCreate).toBe(1);
+    expect(result.wouldSkip).toBe(1);
+  });
+
+  it('detects intra-batch duplicates', async () => {
+    writeVault('original.md', 'Same content');
+    writeVault('copy.md', 'Same content');
+
+    const result = await previewImport(vaultDir, TENANT, deps);
+    expect(result.wouldCreate).toBe(1);
+    expect(result.wouldSkip).toBe(1);
+  });
+});
+
+describe('executeImport', () => {
+  let db: Database.Database;
+  let deps: ImportDependencies;
+  let vaultDir: string;
+
+  beforeEach(() => {
+    db = createTestDatabase();
+    deps = setupDeps(db);
+    vaultDir = mkdtempSync(join(tmpdir(), 'import-exec-'));
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(vaultDir, { recursive: true, force: true });
+  });
+
+  function writeVault(relativePath: string, content: string): void {
+    const fullPath = join(vaultDir, relativePath);
+    mkdirSync(fullPath.split('/').slice(0, -1).join('/'), { recursive: true });
+    writeFileSync(fullPath, content, 'utf8');
+  }
+
+  it('creates candidates and returns batch result', async () => {
+    writeVault('note1.md', '# Note One\nFirst content');
+    writeVault('note2.md', '# Note Two\nSecond content');
+
+    const result = await executeImport(vaultDir, TENANT, deps, undefined, () => NOW);
+    expect(result.fileCount).toBe(2);
+    expect(result.createdCount).toBe(2);
+    expect(result.skippedCount).toBe(0);
+    expect(result.batchId).toBeTruthy();
+  });
+
+  it('creates an import batch record', async () => {
+    writeVault('note.md', 'Content');
+
+    const result = await executeImport(vaultDir, TENANT, deps, undefined, () => NOW);
+    const batch = deps.batchRepo.findById(result.batchId);
+    expect(batch).not.toBeNull();
+    expect(batch!.status).toBe('completed');
+    expect(batch!.fileCount).toBe(1);
+    expect(batch!.createdCount).toBe(1);
+  });
+
+  it('uses frontmatter title when available', async () => {
+    writeVault('note.md', '---\ntitle: Custom Title\n---\n\nBody content');
+
+    const result = await executeImport(vaultDir, TENANT, deps, undefined, () => NOW);
+    const candidateId = result.files[0]!.candidateId!;
+    const candidate = deps.candidateRepo.findById(candidateId);
+    expect(candidate!.title).toBe('Custom Title');
+  });
+
+  it('falls back to filename for title', async () => {
+    writeVault('error-handling-guide.md', 'Content without frontmatter');
+
+    const result = await executeImport(vaultDir, TENANT, deps, undefined, () => NOW);
+    const candidateId = result.files[0]!.candidateId!;
+    const candidate = deps.candidateRepo.findById(candidateId);
+    expect(candidate!.title).toBe('Error Handling Guide');
+  });
+
+  it('maps frontmatter category to valid MemoryCategory', async () => {
+    writeVault('decision.md', '---\ncategory: decision\n---\n\nWe decided X');
+
+    const result = await executeImport(vaultDir, TENANT, deps, undefined, () => NOW);
+    const candidate = deps.candidateRepo.findById(result.files[0]!.candidateId!)!;
+    expect(candidate.category).toBe('decision');
+  });
+
+  it('defaults category to reference for invalid/missing category', async () => {
+    writeVault('note.md', '---\ncategory: invalid_cat\n---\n\nContent');
+
+    const result = await executeImport(vaultDir, TENANT, deps, undefined, () => NOW);
+    const candidate = deps.candidateRepo.findById(result.files[0]!.candidateId!)!;
+    expect(candidate.category).toBe('reference');
+  });
+
+  it('extracts tags from frontmatter', async () => {
+    writeVault('tagged.md', '---\ntags: [api, patterns]\n---\n\nContent');
+
+    const result = await executeImport(vaultDir, TENANT, deps, undefined, () => NOW);
+    const candidate = deps.candidateRepo.findById(result.files[0]!.candidateId!)!;
+    expect(candidate.metadata.tags).toEqual(['api', 'patterns']);
+  });
+
+  it('skips collisions and counts them', async () => {
+    const body = 'Already exists';
+    const hash = computeContentHash(body);
+    deps.memoryRepo.insert(makeCuratedMemory({ content: body, contentHash: hash }));
+
+    writeVault('dupe.md', body);
+    writeVault('novel.md', 'New content');
+
+    const result = await executeImport(vaultDir, TENANT, deps, undefined, () => NOW);
+    expect(result.createdCount).toBe(1);
+    expect(result.skippedCount).toBe(1);
+  });
+
+  it('handles empty vault gracefully', async () => {
+    const result = await executeImport(vaultDir, TENANT, deps, undefined, () => NOW);
+    expect(result.fileCount).toBe(0);
+    expect(result.createdCount).toBe(0);
+    const batch = deps.batchRepo.findById(result.batchId)!;
+    expect(batch.status).toBe('completed');
+  });
+
+  it('strips frontmatter from content before storing', async () => {
+    writeVault('note.md', '---\ntitle: My Title\ntags: [a]\n---\n\nJust the body');
+
+    const result = await executeImport(vaultDir, TENANT, deps, undefined, () => NOW);
+    const candidate = deps.candidateRepo.findById(result.files[0]!.candidateId!)!;
+    expect(candidate.content).toBe('Just the body');
+    expect(candidate.content).not.toContain('---');
+  });
+});

--- a/apps/curator/src/__tests__/markdown-parser.test.ts
+++ b/apps/curator/src/__tests__/markdown-parser.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { parseMarkdown, titleFromPath } from '../import/markdown-parser.js';
+
+describe('parseMarkdown', () => {
+  it('extracts frontmatter and body', () => {
+    const md = `---
+title: My Note
+category: decision
+---
+
+This is the body.`;
+
+    const result = parseMarkdown(md);
+    expect(result.frontmatter['title']).toBe('My Note');
+    expect(result.frontmatter['category']).toBe('decision');
+    expect(result.body).toBe('This is the body.');
+  });
+
+  it('returns empty frontmatter when none present', () => {
+    const md = '# Just a heading\n\nSome content.';
+    const result = parseMarkdown(md);
+    expect(result.frontmatter).toEqual({});
+    expect(result.body).toBe('# Just a heading\n\nSome content.');
+  });
+
+  it('handles empty body after frontmatter', () => {
+    const md = `---
+title: Empty Body
+---
+`;
+    const result = parseMarkdown(md);
+    expect(result.frontmatter['title']).toBe('Empty Body');
+    expect(result.body).toBe('');
+  });
+
+  it('parses boolean values', () => {
+    const md = `---
+published: true
+draft: false
+---
+
+Content.`;
+
+    const result = parseMarkdown(md);
+    expect(result.frontmatter['published']).toBe(true);
+    expect(result.frontmatter['draft']).toBe(false);
+  });
+
+  it('parses numeric values', () => {
+    const md = `---
+priority: 3
+score: 0.85
+---
+
+Content.`;
+
+    const result = parseMarkdown(md);
+    expect(result.frontmatter['priority']).toBe(3);
+    expect(result.frontmatter['score']).toBe(0.85);
+  });
+
+  it('parses flow arrays', () => {
+    const md = `---
+tags: [api, patterns, typescript]
+---
+
+Content.`;
+
+    const result = parseMarkdown(md);
+    expect(result.frontmatter['tags']).toEqual(['api', 'patterns', 'typescript']);
+  });
+
+  it('handles quoted strings', () => {
+    const md = `---
+title: "My Title: With Colons"
+description: 'Single quoted'
+---
+
+Content.`;
+
+    const result = parseMarkdown(md);
+    expect(result.frontmatter['title']).toBe('My Title: With Colons');
+    expect(result.frontmatter['description']).toBe('Single quoted');
+  });
+
+  it('skips comment lines in frontmatter', () => {
+    const md = `---
+# This is a comment
+title: Real Title
+---
+
+Content.`;
+
+    const result = parseMarkdown(md);
+    expect(result.frontmatter['title']).toBe('Real Title');
+    expect(Object.keys(result.frontmatter)).toHaveLength(1);
+  });
+
+  it('handles null/tilde values as empty string', () => {
+    const md = `---
+empty: null
+also_empty: ~
+bare_empty:
+---
+
+Content.`;
+
+    const result = parseMarkdown(md);
+    expect(result.frontmatter['empty']).toBe('');
+    expect(result.frontmatter['also_empty']).toBe('');
+    expect(result.frontmatter['bare_empty']).toBe('');
+  });
+
+  it('handles Obsidian-style frontmatter', () => {
+    const md = `---
+aliases: [API Design, API Patterns]
+tags: [architecture, api]
+created: 2026-01-15
+---
+
+# API Design Patterns
+
+Content about API design.`;
+
+    const result = parseMarkdown(md);
+    expect(result.frontmatter['aliases']).toEqual(['API Design', 'API Patterns']);
+    expect(result.frontmatter['tags']).toEqual(['architecture', 'api']);
+    expect(result.frontmatter['created']).toBe('2026-01-15');
+    expect(result.body).toContain('# API Design Patterns');
+  });
+});
+
+describe('titleFromPath', () => {
+  it('converts file path to title', () => {
+    expect(titleFromPath('docs/error-handling-guide.md')).toBe('Error Handling Guide');
+  });
+
+  it('handles underscores', () => {
+    expect(titleFromPath('api_design_patterns.md')).toBe('Api Design Patterns');
+  });
+
+  it('handles nested paths', () => {
+    expect(titleFromPath('docs/architecture/system-overview.md')).toBe('System Overview');
+  });
+
+  it('handles bare filename', () => {
+    expect(titleFromPath('README.md')).toBe('README');
+  });
+});

--- a/apps/curator/src/__tests__/promoter.test.ts
+++ b/apps/curator/src/__tests__/promoter.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { randomUUID } from 'node:crypto';
-import { createTestDatabase, MemoryRepository, AuditRepository } from '@qmd-team-intent-kb/store';
+import {
+  createTestDatabase,
+  MemoryRepository,
+  AuditRepository,
+  MemoryLinksRepository,
+} from '@qmd-team-intent-kb/store';
 import { computeContentHash } from '@qmd-team-intent-kb/common';
 import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
 import { promote } from '../promotion/promoter.js';
@@ -233,6 +238,44 @@ describe('promote', () => {
       auditRepo,
     );
     expect(memory.supersession).toBeUndefined();
+  });
+
+  it('persists a supersedes graph edge when linksRepo is provided', () => {
+    const db = createTestDatabase();
+    const mRepo = new MemoryRepository(db);
+    const aRepo = new AuditRepository(db);
+    const lRepo = new MemoryLinksRepository(db);
+
+    const old = makeCuratedMemory({ title: 'Error handling guide', category: 'convention' });
+    mRepo.insert(old);
+
+    const candidate = makeCandidate({
+      title: 'Error handling guide updated',
+      category: 'convention',
+    });
+    const contentHash = computeContentHash(candidate.content);
+    const supersession = {
+      supersededMemoryId: old.id,
+      supersededTitle: old.title,
+      similarity: 0.75,
+    };
+
+    const memory = promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult(), supersession },
+      mRepo,
+      aRepo,
+      false,
+      lRepo,
+    );
+
+    const links = lRepo.findBySource(memory.id);
+    expect(links).toHaveLength(1);
+    expect(links[0]!.targetMemoryId).toBe(old.id);
+    expect(links[0]!.linkType).toBe('supersedes');
+    expect(links[0]!.weight).toBe(0.75);
+    expect(links[0]!.source).toBe('curator');
+
+    db.close();
   });
 
   // Additional: promotion timestamp is set

--- a/apps/curator/src/__tests__/vault-walker.test.ts
+++ b/apps/curator/src/__tests__/vault-walker.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { walkVault, countVaultFiles } from '../import/vault-walker.js';
+
+describe('walkVault', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'vault-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function writeFile(relativePath: string, content: string): void {
+    const fullPath = join(root, relativePath);
+    const dir = fullPath.split('/').slice(0, -1).join('/');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(fullPath, content, 'utf8');
+  }
+
+  it('collects Markdown files from flat directory', async () => {
+    writeFile('note1.md', '# Note 1\nContent');
+    writeFile('note2.md', '# Note 2\nContent');
+
+    const files = await walkVault(root);
+    expect(files).toHaveLength(2);
+    expect(files.map((f) => f.relativePath).sort()).toEqual(['note1.md', 'note2.md']);
+  });
+
+  it('recurses into subdirectories', async () => {
+    writeFile('top.md', 'Top level');
+    writeFile('sub/nested.md', 'Nested');
+    writeFile('sub/deep/leaf.md', 'Deep');
+
+    const files = await walkVault(root);
+    expect(files).toHaveLength(3);
+    expect(files.map((f) => f.relativePath)).toContain('sub/nested.md');
+    expect(files.map((f) => f.relativePath)).toContain('sub/deep/leaf.md');
+  });
+
+  it('excludes .obsidian directory', async () => {
+    writeFile('note.md', 'Content');
+    writeFile('.obsidian/config.json', '{}');
+    writeFile('.obsidian/workspace.md', 'Workspace');
+
+    const files = await walkVault(root);
+    expect(files).toHaveLength(1);
+    expect(files[0]!.relativePath).toBe('note.md');
+  });
+
+  it('excludes .trash directory', async () => {
+    writeFile('note.md', 'Content');
+    writeFile('.trash/deleted.md', 'Deleted');
+
+    const files = await walkVault(root);
+    expect(files).toHaveLength(1);
+  });
+
+  it('excludes .git directory', async () => {
+    writeFile('note.md', 'Content');
+    writeFile('.git/HEAD', 'ref: refs/heads/main');
+
+    const files = await walkVault(root);
+    expect(files).toHaveLength(1);
+  });
+
+  it('excludes node_modules', async () => {
+    writeFile('note.md', 'Content');
+    writeFile('node_modules/pkg/README.md', 'Package readme');
+
+    const files = await walkVault(root);
+    expect(files).toHaveLength(1);
+  });
+
+  it('supports custom exclude directories', async () => {
+    writeFile('note.md', 'Content');
+    writeFile('drafts/wip.md', 'Work in progress');
+
+    const files = await walkVault(root, ['drafts']);
+    expect(files).toHaveLength(1);
+  });
+
+  it('only includes Markdown extensions', async () => {
+    writeFile('note.md', 'Markdown');
+    writeFile('doc.markdown', 'Also markdown');
+    writeFile('page.mdx', 'MDX');
+    writeFile('image.png', 'binary');
+    writeFile('data.json', '{}');
+    writeFile('script.ts', 'code');
+
+    const files = await walkVault(root);
+    expect(files).toHaveLength(3);
+  });
+
+  it('skips empty files', async () => {
+    writeFile('note.md', 'Content');
+    writeFile('empty.md', '');
+    writeFile('whitespace.md', '   \n  ');
+
+    const files = await walkVault(root);
+    expect(files).toHaveLength(1);
+  });
+
+  it('loads file content as UTF-8', async () => {
+    writeFile('note.md', '# Hello World\n\nUnicode: ñ é ü');
+
+    const files = await walkVault(root);
+    expect(files[0]!.content).toContain('Unicode: ñ é ü');
+  });
+
+  it('returns empty array for empty directory', async () => {
+    const files = await walkVault(root);
+    expect(files).toEqual([]);
+  });
+
+  it('returns empty array for non-existent directory', async () => {
+    const files = await walkVault('/definitely/not/a/real/path');
+    expect(files).toEqual([]);
+  });
+});
+
+describe('countVaultFiles', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'vault-count-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function writeFile(relativePath: string, content: string): void {
+    const fullPath = join(root, relativePath);
+    const dir = fullPath.split('/').slice(0, -1).join('/');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(fullPath, content, 'utf8');
+  }
+
+  it('counts Markdown files excluding defaults', async () => {
+    writeFile('a.md', 'A');
+    writeFile('b.md', 'B');
+    writeFile('.obsidian/c.md', 'C');
+    writeFile('sub/d.md', 'D');
+
+    const count = await countVaultFiles(root);
+    expect(count).toBe(3);
+  });
+});

--- a/apps/curator/src/curator.ts
+++ b/apps/curator/src/curator.ts
@@ -7,6 +7,7 @@ import type {
   MemoryRepository,
   PolicyRepository,
   AuditRepository,
+  MemoryLinksRepository,
 } from '@qmd-team-intent-kb/store';
 import type { CuratorConfig, CurationResult, CurationBatchResult } from './types.js';
 import { checkDuplicate } from './dedup/dedup-checker.js';
@@ -20,6 +21,7 @@ export interface CuratorDependencies {
   memoryRepo: MemoryRepository;
   policyRepo: PolicyRepository;
   auditRepo: AuditRepository;
+  linksRepo?: MemoryLinksRepository;
 }
 
 /**
@@ -177,6 +179,7 @@ export class Curator {
       this.deps.memoryRepo,
       this.deps.auditRepo,
       this.config.dryRun,
+      this.deps.linksRepo,
     );
 
     return {

--- a/apps/curator/src/import/collision-detector.ts
+++ b/apps/curator/src/import/collision-detector.ts
@@ -1,0 +1,75 @@
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type { CandidateRepository, MemoryRepository } from '@qmd-team-intent-kb/store';
+
+/** Where the collision was found */
+export type CollisionTarget = 'curated_memory' | 'candidate';
+
+/** Result of a collision check for a single file */
+export interface CollisionResult {
+  /** SHA-256 of the content (body only, frontmatter stripped) */
+  contentHash: string;
+  /** True when an existing record with the same content hash was found */
+  hasCollision: boolean;
+  /** Where the collision was found */
+  target?: CollisionTarget;
+  /** ID of the colliding record */
+  matchedId?: string;
+  /** Title of the colliding record (for display) */
+  matchedTitle?: string;
+}
+
+/**
+ * Check whether content already exists in curated memories or pending candidates.
+ *
+ * Priority: curated memory match > candidate match (curated is more authoritative).
+ *
+ * @param content - The file body (frontmatter already stripped)
+ * @param memoryRepo - Curated memory repository
+ * @param candidateRepo - Candidate (inbox) repository
+ * @param batchHashes - Optional set of hashes already seen in the current batch
+ * @returns CollisionResult with hash and match details
+ */
+export function detectCollision(
+  content: string,
+  memoryRepo: MemoryRepository,
+  candidateRepo: CandidateRepository,
+  batchHashes?: Set<string>,
+): CollisionResult {
+  const contentHash = computeContentHash(content);
+
+  // Intra-batch collision (same content already processed in this import)
+  if (batchHashes?.has(contentHash)) {
+    return {
+      contentHash,
+      hasCollision: true,
+      target: 'candidate',
+      matchedTitle: '(duplicate within this import batch)',
+    };
+  }
+
+  // Check curated memories first (most authoritative)
+  const curatedMatch = memoryRepo.findByContentHash(contentHash);
+  if (curatedMatch !== null) {
+    return {
+      contentHash,
+      hasCollision: true,
+      target: 'curated_memory',
+      matchedId: curatedMatch.id,
+      matchedTitle: curatedMatch.title,
+    };
+  }
+
+  // Check pending candidates
+  const candidateMatch = candidateRepo.findByContentHash(contentHash);
+  if (candidateMatch !== null) {
+    return {
+      contentHash,
+      hasCollision: true,
+      target: 'candidate',
+      matchedId: candidateMatch.id,
+      matchedTitle: candidateMatch.title,
+    };
+  }
+
+  return { contentHash, hasCollision: false };
+}

--- a/apps/curator/src/import/import-pipeline.ts
+++ b/apps/curator/src/import/import-pipeline.ts
@@ -5,6 +5,7 @@ import type {
   MemoryRepository,
   ImportBatchRepository,
   ImportBatch,
+  MemoryLinksRepository,
 } from '@qmd-team-intent-kb/store';
 import { walkVault } from './vault-walker.js';
 import { parseMarkdown, titleFromPath } from './markdown-parser.js';
@@ -211,7 +212,7 @@ export async function executeImport(
     };
 
     try {
-      deps.candidateRepo.insert(candidate, collision.contentHash);
+      deps.candidateRepo.insert(candidate, collision.contentHash, batchId);
       batchHashes.add(collision.contentHash);
       files.push({ relativePath: vf.relativePath, status: 'created', candidateId });
       createdCount++;
@@ -243,4 +244,36 @@ export async function executeImport(
     skippedCount,
     files,
   };
+}
+
+/** Result of a batch rollback */
+export interface RollbackResult {
+  batchId: string;
+  candidatesDeleted: number;
+  linksDeleted: number;
+}
+
+/**
+ * Roll back an import batch: delete all candidates created by the batch,
+ * delete associated memory links, and mark the batch as rolled_back.
+ */
+export function rollbackImport(
+  batchId: string,
+  deps: ImportDependencies,
+  linksRepo?: MemoryLinksRepository,
+  nowFn: () => string = () => new Date().toISOString(),
+): RollbackResult {
+  const batch = deps.batchRepo.findById(batchId);
+  if (!batch) {
+    throw new Error(`Import batch not found: ${batchId}`);
+  }
+  if (batch.status === 'rolled_back') {
+    throw new Error(`Import batch already rolled back: ${batchId}`);
+  }
+
+  const candidatesDeleted = deps.candidateRepo.deleteByBatch(batchId);
+  const linksDeleted = linksRepo ? linksRepo.deleteByBatch(batchId) : 0;
+  deps.batchRepo.rollback(batchId, nowFn());
+
+  return { batchId, candidatesDeleted, linksDeleted };
 }

--- a/apps/curator/src/import/import-pipeline.ts
+++ b/apps/curator/src/import/import-pipeline.ts
@@ -1,0 +1,246 @@
+import { randomUUID } from 'node:crypto';
+import type { MemoryCandidate, MemoryCategory } from '@qmd-team-intent-kb/schema';
+import type {
+  CandidateRepository,
+  MemoryRepository,
+  ImportBatchRepository,
+  ImportBatch,
+} from '@qmd-team-intent-kb/store';
+import { walkVault } from './vault-walker.js';
+import { parseMarkdown, titleFromPath } from './markdown-parser.js';
+import { detectCollision } from './collision-detector.js';
+import type { CollisionResult } from './collision-detector.js';
+
+/** Per-file outcome in an import operation */
+export interface ImportFileResult {
+  relativePath: string;
+  status: 'created' | 'skipped' | 'rejected' | 'error';
+  reason?: string;
+  candidateId?: string;
+  collision?: CollisionResult;
+}
+
+/** Aggregate result of an import preview (dry-run) */
+export interface ImportPreviewResult {
+  sourcePath: string;
+  fileCount: number;
+  wouldCreate: number;
+  wouldSkip: number;
+  files: ImportFileResult[];
+}
+
+/** Aggregate result of an import execution */
+export interface ImportExecutionResult {
+  batchId: string;
+  sourcePath: string;
+  fileCount: number;
+  createdCount: number;
+  rejectedCount: number;
+  skippedCount: number;
+  files: ImportFileResult[];
+}
+
+/** Dependencies for the import pipeline */
+export interface ImportDependencies {
+  memoryRepo: MemoryRepository;
+  candidateRepo: CandidateRepository;
+  batchRepo: ImportBatchRepository;
+}
+
+/** Valid memory categories for mapping from frontmatter */
+const VALID_CATEGORIES = new Set([
+  'decision',
+  'pattern',
+  'convention',
+  'architecture',
+  'troubleshooting',
+  'onboarding',
+  'reference',
+]);
+
+/**
+ * Preview an import without persisting anything.
+ * Walks the vault, checks collisions, and reports what would happen.
+ */
+export async function previewImport(
+  sourcePath: string,
+  _tenantId: string,
+  deps: ImportDependencies,
+  excludeDirs?: string[],
+): Promise<ImportPreviewResult> {
+  const vaultFiles = await walkVault(sourcePath, excludeDirs);
+  const batchHashes = new Set<string>();
+  const files: ImportFileResult[] = [];
+  let wouldCreate = 0;
+  let wouldSkip = 0;
+
+  for (const vf of vaultFiles) {
+    const { body } = parseMarkdown(vf.content);
+
+    if (!body.trim()) {
+      files.push({ relativePath: vf.relativePath, status: 'skipped', reason: 'Empty body' });
+      wouldSkip++;
+      continue;
+    }
+
+    const collision = detectCollision(body, deps.memoryRepo, deps.candidateRepo, batchHashes);
+
+    if (collision.hasCollision) {
+      files.push({
+        relativePath: vf.relativePath,
+        status: 'skipped',
+        reason: `Collision with ${collision.target}: ${collision.matchedTitle ?? collision.matchedId ?? 'unknown'}`,
+        collision,
+      });
+      wouldSkip++;
+    } else {
+      batchHashes.add(collision.contentHash);
+      files.push({ relativePath: vf.relativePath, status: 'created' });
+      wouldCreate++;
+    }
+  }
+
+  return {
+    sourcePath,
+    fileCount: vaultFiles.length,
+    wouldCreate,
+    wouldSkip,
+    files,
+  };
+}
+
+/**
+ * Execute a full import: walk vault, check collisions, create candidates,
+ * track batch. Returns aggregate results.
+ */
+export async function executeImport(
+  sourcePath: string,
+  tenantId: string,
+  deps: ImportDependencies,
+  excludeDirs?: string[],
+  nowFn: () => string = () => new Date().toISOString(),
+): Promise<ImportExecutionResult> {
+  const batchId = randomUUID();
+  const now = nowFn();
+
+  // Create batch record
+  const batch: ImportBatch = {
+    id: batchId,
+    tenantId,
+    sourcePath,
+    fileCount: 0,
+    createdCount: 0,
+    rejectedCount: 0,
+    skippedCount: 0,
+    status: 'active',
+    createdAt: now,
+    rolledBackAt: null,
+  };
+  deps.batchRepo.insert(batch);
+
+  const vaultFiles = await walkVault(sourcePath, excludeDirs);
+  const batchHashes = new Set<string>();
+  const files: ImportFileResult[] = [];
+  let createdCount = 0;
+  let skippedCount = 0;
+  let rejectedCount = 0;
+
+  for (const vf of vaultFiles) {
+    const parsed = parseMarkdown(vf.content);
+
+    if (!parsed.body.trim()) {
+      files.push({ relativePath: vf.relativePath, status: 'skipped', reason: 'Empty body' });
+      skippedCount++;
+      continue;
+    }
+
+    const collision = detectCollision(
+      parsed.body,
+      deps.memoryRepo,
+      deps.candidateRepo,
+      batchHashes,
+    );
+
+    if (collision.hasCollision) {
+      files.push({
+        relativePath: vf.relativePath,
+        status: 'skipped',
+        reason: `Collision: ${collision.matchedTitle ?? collision.matchedId ?? 'duplicate'}`,
+        collision,
+      });
+      skippedCount++;
+      continue;
+    }
+
+    // Build the candidate
+    const candidateId = randomUUID();
+    const title =
+      typeof parsed.frontmatter['title'] === 'string' && parsed.frontmatter['title']
+        ? parsed.frontmatter['title']
+        : titleFromPath(vf.relativePath);
+
+    const fmCategory = parsed.frontmatter['category'];
+    const category: MemoryCategory =
+      typeof fmCategory === 'string' && VALID_CATEGORIES.has(fmCategory)
+        ? (fmCategory as MemoryCategory)
+        : 'reference';
+
+    const fmTags = parsed.frontmatter['tags'];
+    const tags: string[] = Array.isArray(fmTags) ? fmTags.filter((t) => typeof t === 'string') : [];
+
+    const candidate: MemoryCandidate = {
+      id: candidateId,
+      status: 'inbox',
+      source: 'import',
+      content: parsed.body,
+      title,
+      category,
+      trustLevel: 'medium',
+      author: { type: 'system', id: 'vault-import' },
+      tenantId,
+      metadata: {
+        filePaths: [vf.absolutePath],
+        tags,
+      },
+      prePolicyFlags: {
+        potentialSecret: false,
+        lowConfidence: false,
+        duplicateSuspect: false,
+      },
+      capturedAt: now,
+    };
+
+    try {
+      deps.candidateRepo.insert(candidate, collision.contentHash);
+      batchHashes.add(collision.contentHash);
+      files.push({ relativePath: vf.relativePath, status: 'created', candidateId });
+      createdCount++;
+    } catch (e) {
+      files.push({
+        relativePath: vf.relativePath,
+        status: 'error',
+        reason: e instanceof Error ? e.message : String(e),
+      });
+      rejectedCount++;
+    }
+  }
+
+  // Update batch counts and complete
+  deps.batchRepo.updateCounts(batchId, {
+    fileCount: vaultFiles.length,
+    createdCount,
+    rejectedCount,
+    skippedCount,
+  });
+  deps.batchRepo.complete(batchId);
+
+  return {
+    batchId,
+    sourcePath,
+    fileCount: vaultFiles.length,
+    createdCount,
+    rejectedCount,
+    skippedCount,
+    files,
+  };
+}

--- a/apps/curator/src/import/index.ts
+++ b/apps/curator/src/import/index.ts
@@ -4,3 +4,10 @@ export { walkVault, countVaultFiles } from './vault-walker.js';
 export type { VaultFile } from './vault-walker.js';
 export { detectCollision } from './collision-detector.js';
 export type { CollisionResult, CollisionTarget } from './collision-detector.js';
+export { previewImport, executeImport } from './import-pipeline.js';
+export type {
+  ImportFileResult,
+  ImportPreviewResult,
+  ImportExecutionResult,
+  ImportDependencies,
+} from './import-pipeline.js';

--- a/apps/curator/src/import/index.ts
+++ b/apps/curator/src/import/index.ts
@@ -4,10 +4,11 @@ export { walkVault, countVaultFiles } from './vault-walker.js';
 export type { VaultFile } from './vault-walker.js';
 export { detectCollision } from './collision-detector.js';
 export type { CollisionResult, CollisionTarget } from './collision-detector.js';
-export { previewImport, executeImport } from './import-pipeline.js';
+export { previewImport, executeImport, rollbackImport } from './import-pipeline.js';
 export type {
   ImportFileResult,
   ImportPreviewResult,
   ImportExecutionResult,
   ImportDependencies,
+  RollbackResult,
 } from './import-pipeline.js';

--- a/apps/curator/src/import/index.ts
+++ b/apps/curator/src/import/index.ts
@@ -1,0 +1,4 @@
+export { parseMarkdown, titleFromPath } from './markdown-parser.js';
+export type { ParsedMarkdown } from './markdown-parser.js';
+export { walkVault, countVaultFiles } from './vault-walker.js';
+export type { VaultFile } from './vault-walker.js';

--- a/apps/curator/src/import/index.ts
+++ b/apps/curator/src/import/index.ts
@@ -2,3 +2,5 @@ export { parseMarkdown, titleFromPath } from './markdown-parser.js';
 export type { ParsedMarkdown } from './markdown-parser.js';
 export { walkVault, countVaultFiles } from './vault-walker.js';
 export type { VaultFile } from './vault-walker.js';
+export { detectCollision } from './collision-detector.js';
+export type { CollisionResult, CollisionTarget } from './collision-detector.js';

--- a/apps/curator/src/import/markdown-parser.ts
+++ b/apps/curator/src/import/markdown-parser.ts
@@ -1,0 +1,103 @@
+/**
+ * Minimal YAML frontmatter parser for Markdown files.
+ *
+ * No external YAML library — handles simple key:value frontmatter
+ * (strings, numbers, booleans, arrays of strings) which covers
+ * Obsidian vault files and typical documentation.
+ */
+
+/** Parsed result from a Markdown file with optional frontmatter */
+export interface ParsedMarkdown {
+  frontmatter: Record<string, string | string[] | number | boolean>;
+  body: string;
+}
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+/**
+ * Parse a Markdown string into frontmatter and body.
+ *
+ * Handles YAML-like frontmatter delimited by `---` fences.
+ * Returns an empty frontmatter object when no frontmatter is present.
+ */
+export function parseMarkdown(content: string): ParsedMarkdown {
+  const match = FRONTMATTER_RE.exec(content);
+  if (!match) {
+    return { frontmatter: {}, body: content.trim() };
+  }
+
+  const rawYaml = match[1]!;
+  const body = content.slice(match[0].length).trim();
+
+  return { frontmatter: parseSimpleYaml(rawYaml), body };
+}
+
+/**
+ * Parse simple YAML key-value pairs.
+ * Supports: strings, numbers, booleans, and YAML flow arrays ([a, b, c]).
+ * Does NOT support nested objects, multiline strings, or anchors.
+ */
+function parseSimpleYaml(yaml: string): Record<string, string | string[] | number | boolean> {
+  const result: Record<string, string | string[] | number | boolean> = {};
+
+  for (const line of yaml.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed === '' || trimmed.startsWith('#')) continue;
+
+    const colonIdx = trimmed.indexOf(':');
+    if (colonIdx === -1) continue;
+
+    const key = trimmed.slice(0, colonIdx).trim();
+    const rawValue = trimmed.slice(colonIdx + 1).trim();
+
+    if (key === '') continue;
+
+    result[key] = coerceValue(rawValue);
+  }
+
+  return result;
+}
+
+function coerceValue(raw: string): string | string[] | number | boolean {
+  if (raw === '' || raw === '~' || raw === 'null') return '';
+
+  // Booleans
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+
+  // Flow array: [a, b, c]
+  if (raw.startsWith('[') && raw.endsWith(']')) {
+    const inner = raw.slice(1, -1);
+    return inner
+      .split(',')
+      .map((s) => unquote(s.trim()))
+      .filter((s) => s !== '');
+  }
+
+  // Numbers
+  const num = Number(raw);
+  if (!Number.isNaN(num) && raw !== '') return num;
+
+  // Quoted or bare string
+  return unquote(raw);
+}
+
+function unquote(s: string): string {
+  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+/**
+ * Derive a human-readable title from a file path.
+ * Strips extension, replaces hyphens/underscores with spaces, title-cases.
+ */
+export function titleFromPath(filePath: string): string {
+  const name =
+    filePath
+      .split('/')
+      .pop()
+      ?.replace(/\.[^.]+$/, '') ?? filePath;
+  return name.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/apps/curator/src/import/markdown-parser.ts
+++ b/apps/curator/src/import/markdown-parser.ts
@@ -74,9 +74,12 @@ function coerceValue(raw: string): string | string[] | number | boolean {
       .filter((s) => s !== '');
   }
 
-  // Numbers
-  const num = Number(raw);
-  if (!Number.isNaN(num) && raw !== '') return num;
+  // Numbers (reject whitespace-only strings — Number('  ') is 0)
+  const trimmedRaw = raw.trim();
+  if (trimmedRaw !== '' && trimmedRaw === raw) {
+    const num = Number(raw);
+    if (!Number.isNaN(num)) return num;
+  }
 
   // Quoted or bare string
   return unquote(raw);

--- a/apps/curator/src/import/vault-walker.ts
+++ b/apps/curator/src/import/vault-walker.ts
@@ -1,0 +1,110 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative, extname } from 'node:path';
+
+/** Result of walking a vault directory */
+export interface VaultFile {
+  /** Absolute path to the file */
+  absolutePath: string;
+  /** Path relative to the vault root */
+  relativePath: string;
+  /** Raw file content (UTF-8) */
+  content: string;
+}
+
+/** Directories excluded by default (Obsidian internals, trash, git) */
+const DEFAULT_EXCLUDES = new Set(['.obsidian', '.trash', '.git', 'node_modules']);
+
+/** File extensions to include */
+const MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown', '.mdx']);
+
+/**
+ * Recursively walk a directory and collect Markdown files.
+ *
+ * Excludes `.obsidian/`, `.trash/`, `.git/`, `node_modules/` by default.
+ * Only includes files with Markdown extensions (.md, .markdown, .mdx).
+ *
+ * @param rootPath - Absolute path to the vault/directory root
+ * @param excludeDirs - Additional directory names to exclude
+ * @returns Array of VaultFile objects with content loaded
+ */
+export async function walkVault(
+  rootPath: string,
+  excludeDirs: string[] = [],
+): Promise<VaultFile[]> {
+  const excludeSet = new Set([...DEFAULT_EXCLUDES, ...excludeDirs]);
+  const files: VaultFile[] = [];
+  await walkDir(rootPath, rootPath, excludeSet, files);
+  return files;
+}
+
+async function walkDir(
+  currentPath: string,
+  rootPath: string,
+  excludeSet: Set<string>,
+  files: VaultFile[],
+): Promise<void> {
+  let entries;
+  try {
+    entries = await readdir(currentPath, { withFileTypes: true });
+  } catch {
+    return; // skip unreadable directories
+  }
+
+  for (const entry of entries) {
+    const fullPath = join(currentPath, entry.name);
+
+    if (entry.isDirectory()) {
+      if (!excludeSet.has(entry.name)) {
+        await walkDir(fullPath, rootPath, excludeSet, files);
+      }
+      continue;
+    }
+
+    if (!entry.isFile()) continue;
+    if (!MARKDOWN_EXTENSIONS.has(extname(entry.name).toLowerCase())) continue;
+
+    try {
+      const content = await readFile(fullPath, 'utf8');
+      if (content.trim() === '') continue; // skip empty files
+
+      files.push({
+        absolutePath: fullPath,
+        relativePath: relative(rootPath, fullPath),
+        content,
+      });
+    } catch {
+      // skip unreadable files
+    }
+  }
+}
+
+/**
+ * Count Markdown files in a directory without reading content.
+ * Useful for preview/dry-run to show scope without loading all files.
+ */
+export async function countVaultFiles(
+  rootPath: string,
+  excludeDirs: string[] = [],
+): Promise<number> {
+  const excludeSet = new Set([...DEFAULT_EXCLUDES, ...excludeDirs]);
+  return countDir(rootPath, excludeSet);
+}
+
+async function countDir(currentPath: string, excludeSet: Set<string>): Promise<number> {
+  let entries;
+  try {
+    entries = await readdir(currentPath, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+
+  let count = 0;
+  for (const entry of entries) {
+    if (entry.isDirectory() && !excludeSet.has(entry.name)) {
+      count += await countDir(join(currentPath, entry.name), excludeSet);
+    } else if (entry.isFile() && MARKDOWN_EXTENSIONS.has(extname(entry.name).toLowerCase())) {
+      count++;
+    }
+  }
+  return count;
+}

--- a/apps/curator/src/index.ts
+++ b/apps/curator/src/index.ts
@@ -12,3 +12,5 @@ export type { SupersessionMatch } from './supersession/supersession-detector.js'
 export { promote } from './promotion/promoter.js';
 export type { PromotionInput } from './promotion/promoter.js';
 export { reject } from './rejection/rejector.js';
+export { parseMarkdown, titleFromPath, walkVault, countVaultFiles } from './import/index.js';
+export type { ParsedMarkdown, VaultFile } from './import/index.js';

--- a/apps/curator/src/index.ts
+++ b/apps/curator/src/index.ts
@@ -14,3 +14,13 @@ export type { PromotionInput } from './promotion/promoter.js';
 export { reject } from './rejection/rejector.js';
 export { parseMarkdown, titleFromPath, walkVault, countVaultFiles } from './import/index.js';
 export type { ParsedMarkdown, VaultFile } from './import/index.js';
+export { detectCollision, previewImport, executeImport, rollbackImport } from './import/index.js';
+export type {
+  CollisionResult,
+  CollisionTarget,
+  ImportFileResult,
+  ImportPreviewResult,
+  ImportExecutionResult,
+  ImportDependencies,
+  RollbackResult,
+} from './import/index.js';

--- a/apps/curator/src/promotion/promoter.ts
+++ b/apps/curator/src/promotion/promoter.ts
@@ -4,7 +4,11 @@ import {
   AuditEvent as AuditEventSchema,
 } from '@qmd-team-intent-kb/schema';
 import type { MemoryCandidate, CuratedMemory, PolicyEvaluation } from '@qmd-team-intent-kb/schema';
-import type { MemoryRepository, AuditRepository, MemoryLinksRepository } from '@qmd-team-intent-kb/store';
+import type {
+  MemoryRepository,
+  AuditRepository,
+  MemoryLinksRepository,
+} from '@qmd-team-intent-kb/store';
 import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
 import type { SupersessionMatch } from '../supersession/supersession-detector.js';
 
@@ -104,7 +108,6 @@ export function promote(
           timestamp: now,
         }),
       );
-
     }
 
     memoryRepo.insert(memory);

--- a/apps/curator/src/promotion/promoter.ts
+++ b/apps/curator/src/promotion/promoter.ts
@@ -4,7 +4,7 @@ import {
   AuditEvent as AuditEventSchema,
 } from '@qmd-team-intent-kb/schema';
 import type { MemoryCandidate, CuratedMemory, PolicyEvaluation } from '@qmd-team-intent-kb/schema';
-import type { MemoryRepository, AuditRepository } from '@qmd-team-intent-kb/store';
+import type { MemoryRepository, AuditRepository, MemoryLinksRepository } from '@qmd-team-intent-kb/store';
 import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
 import type { SupersessionMatch } from '../supersession/supersession-detector.js';
 
@@ -37,6 +37,7 @@ export function promote(
   memoryRepo: MemoryRepository,
   auditRepo: AuditRepository,
   dryRun: boolean = false,
+  linksRepo?: MemoryLinksRepository,
 ): CuratedMemory {
   const now = new Date().toISOString();
   const memoryId = randomUUID();
@@ -103,9 +104,24 @@ export function promote(
           timestamp: now,
         }),
       );
+
     }
 
     memoryRepo.insert(memory);
+
+    if (input.supersession !== undefined && linksRepo) {
+      linksRepo.insert({
+        id: randomUUID(),
+        sourceMemoryId: memoryId,
+        targetMemoryId: input.supersession.supersededMemoryId,
+        linkType: 'supersedes',
+        weight: input.supersession.similarity,
+        createdBy: 'curator',
+        source: 'curator',
+        importBatchId: null,
+        createdAt: now,
+      });
+    }
 
     auditRepo.insert(
       AuditEventSchema.parse({

--- a/packages/store/src/repositories/candidate-repository.ts
+++ b/packages/store/src/repositories/candidate-repository.ts
@@ -96,17 +96,20 @@ export class CandidateRepository {
   private readonly stmtFindByHash: Database.Statement;
   private readonly stmtCount: Database.Statement;
   private readonly stmtCountByTenant: Database.Statement;
+  private readonly stmtDeleteByBatch: Database.Statement;
 
   constructor(db: Database.Database) {
     this.stmtInsert = db.prepare(`
       INSERT INTO candidates (
         id, status, source, content, title, category,
         trust_level, author_json, tenant_id,
-        metadata_json, pre_policy_flags_json, content_hash, captured_at
+        metadata_json, pre_policy_flags_json, content_hash, captured_at,
+        import_batch_id
       ) VALUES (
         @id, @status, @source, @content, @title, @category,
         @trust_level, @author_json, @tenant_id,
-        @metadata_json, @pre_policy_flags_json, @content_hash, @captured_at
+        @metadata_json, @pre_policy_flags_json, @content_hash, @captured_at,
+        @import_batch_id
       )
     `);
 
@@ -129,10 +132,14 @@ export class CandidateRepository {
     this.stmtCountByTenant = db.prepare(`
       SELECT tenant_id, COUNT(*) as cnt FROM candidates GROUP BY tenant_id
     `);
+
+    this.stmtDeleteByBatch = db.prepare(`
+      DELETE FROM candidates WHERE import_batch_id = ?
+    `);
   }
 
   /** Insert a new candidate. The contentHash must be provided by the caller. */
-  insert(candidate: MemoryCandidate, contentHash: string): void {
+  insert(candidate: MemoryCandidate, contentHash: string, importBatchId?: string): void {
     this.stmtInsert.run({
       id: candidate.id,
       status: candidate.status,
@@ -147,6 +154,7 @@ export class CandidateRepository {
       pre_policy_flags_json: JSON.stringify(candidate.prePolicyFlags),
       content_hash: contentHash,
       captured_at: candidate.capturedAt,
+      import_batch_id: importBatchId ?? null,
     });
   }
 
@@ -175,6 +183,11 @@ export class CandidateRepository {
   count(): number {
     const result = this.stmtCount.get() as { cnt: number };
     return result.cnt;
+  }
+
+  /** Delete all candidates associated with an import batch. Returns count deleted. */
+  deleteByBatch(batchId: string): number {
+    return this.stmtDeleteByBatch.run(batchId).changes;
   }
 
   /** Count candidates grouped by tenant */

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -205,4 +205,12 @@ CREATE INDEX IF NOT EXISTS idx_batches_tenant ON import_batches(tenant_id);
 CREATE INDEX IF NOT EXISTS idx_batches_status ON import_batches(status);
     `.trim(),
   },
+  {
+    version: 4,
+    name: 'add_import_batch_id_to_candidates',
+    sql: `
+ALTER TABLE candidates ADD COLUMN import_batch_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_candidates_batch ON candidates(import_batch_id);
+    `.trim(),
+  },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@qmd-team-intent-kb/common':
         specifier: workspace:*
         version: link:../../packages/common
+      '@qmd-team-intent-kb/curator':
+        specifier: workspace:*
+        version: link:../curator
       '@qmd-team-intent-kb/schema':
         specifier: workspace:*
         version: link:../../packages/schema


### PR DESCRIPTION
## Summary

- **E12-B04**: Curator creates `supersedes` graph edges during promotion when `MemoryLinksRepository` is provided (optional, backward compatible)
- **E13-B01**: Import pipeline core — markdown parser (frontmatter extraction) + vault walker (recursive dir walk with .obsidian/.trash/.git exclusion)
- **E13-B02**: Collision detection against curated memories, pending candidates, and intra-batch duplicates
- **E13-B03**: Preview/dry-run mode — reports what would happen without persisting
- **E13-B04**: Execute import with batch tracking, frontmatter-derived titles/categories/tags
- **E13-B05**: Batch rollback — deletes candidates by batch_id, cleans associated links, marks batch rolled_back. Migration 4 adds `import_batch_id` to candidates table.
- **E13-B06**: REST API routes — `POST /api/import/preview`, `POST /api/import`, `GET /api/import/batches`, `GET /api/import/batches/:id`, `DELETE /api/import/batches/:id`

**Beads closed**: pj1, 72q, qp9, 0vj, 7dr, lkw, zth (7 total)

## Test plan

- [x] `pnpm validate` passes (format + lint + typecheck + 1261 tests)
- [x] Markdown parser: 14 tests (frontmatter types, Obsidian-style, edge cases)
- [x] Vault walker: 13 tests (recursion, exclusions, extensions, empty files)
- [x] Collision detector: 6 tests (novel, curated match, candidate match, priority, intra-batch)
- [x] Import pipeline: 19 tests (5 preview + 10 execute + 4 rollback)
- [x] Promoter graph edge: 1 new test, 89 curator tests total
- [x] No regressions in API, store, edge-daemon tests

Jeremy made me do it
-claude