### PR TITLE
feat(mcp-server): vault import tools — preview, execute, rollback (E13-B07)

### DIFF
--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -28,6 +28,7 @@
     "@qmd-team-intent-kb/common": "workspace:*",
     "@qmd-team-intent-kb/schema": "workspace:*",
     "@qmd-team-intent-kb/store": "workspace:*",
+    "@qmd-team-intent-kb/curator": "workspace:*",
     "fast-glob": "^3.3.3"
   },
   "devDependencies": {

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -7,6 +7,7 @@ import { importFiles } from './tools/import.js';
 import { getStatus } from './tools/status.js';
 import { applyTransition } from './tools/transition.js';
 import { runSync, isQmdAvailable } from './tools/sync.js';
+import { vaultPreview, vaultExecute, vaultRollback } from './tools/vault-import.js';
 
 const VERSION = '0.1.0';
 
@@ -138,6 +139,71 @@ export function createServer(
             text: JSON.stringify(result, null, 2),
           },
         ],
+      };
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // teamkb_vault_preview — dry-run vault import analysis
+  // -------------------------------------------------------------------------
+  server.tool(
+    'teamkb_vault_preview',
+    'Preview a vault directory import without persisting. Reports file counts, collisions, and what would be created.',
+    {
+      sourcePath: z.string().min(1).describe('Absolute path to the vault/directory to import'),
+      excludeDirs: z
+        .array(z.string())
+        .optional()
+        .describe('Additional directory names to exclude (beyond .obsidian, .trash, .git)'),
+    },
+    async (params) => {
+      const result = await vaultPreview(
+        { sourcePath: params.sourcePath, excludeDirs: params.excludeDirs },
+        config,
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // teamkb_vault_import — execute vault import with batch tracking
+  // -------------------------------------------------------------------------
+  server.tool(
+    'teamkb_vault_import',
+    'Import a vault directory as memory candidates with batch tracking. Parses Markdown frontmatter, detects collisions, creates candidates. Excludes .obsidian/.trash/.git by default.',
+    {
+      sourcePath: z.string().min(1).describe('Absolute path to the vault/directory to import'),
+      excludeDirs: z
+        .array(z.string())
+        .optional()
+        .describe('Additional directory names to exclude (beyond .obsidian, .trash, .git)'),
+    },
+    async (params) => {
+      const result = await vaultExecute(
+        { sourcePath: params.sourcePath, excludeDirs: params.excludeDirs },
+        config,
+      );
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+      };
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // teamkb_vault_rollback — roll back an import batch
+  // -------------------------------------------------------------------------
+  server.tool(
+    'teamkb_vault_rollback',
+    'Roll back a vault import batch. Deletes all candidates created by the batch, removes associated memory links, and marks the batch as rolled_back.',
+    {
+      batchId: z.string().min(1).describe('UUID of the import batch to roll back'),
+    },
+    async (params) => {
+      const result = vaultRollback({ batchId: params.batchId }, config);
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
       };
     },
   );

--- a/apps/mcp-server/src/tools/vault-import.ts
+++ b/apps/mcp-server/src/tools/vault-import.ts
@@ -1,0 +1,81 @@
+import {
+  createDatabase,
+  CandidateRepository,
+  MemoryRepository,
+  ImportBatchRepository,
+  MemoryLinksRepository,
+} from '@qmd-team-intent-kb/store';
+import { previewImport, executeImport, rollbackImport } from '@qmd-team-intent-kb/curator';
+import type {
+  ImportPreviewResult,
+  ImportExecutionResult,
+  RollbackResult,
+} from '@qmd-team-intent-kb/curator';
+import type { McpServerConfig } from '../config.js';
+
+interface VaultImportInput {
+  sourcePath: string;
+  excludeDirs?: string[];
+}
+
+interface VaultRollbackInput {
+  batchId: string;
+}
+
+/**
+ * Run a preview of vault import — reports what would happen without persisting.
+ */
+export async function vaultPreview(
+  input: VaultImportInput,
+  config: McpServerConfig,
+): Promise<ImportPreviewResult> {
+  const db = createDatabase({ path: config.dbPath });
+  try {
+    const deps = {
+      candidateRepo: new CandidateRepository(db),
+      memoryRepo: new MemoryRepository(db),
+      batchRepo: new ImportBatchRepository(db),
+    };
+    return await previewImport(input.sourcePath, config.tenantId, deps, input.excludeDirs);
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Execute a vault import — walks directory, creates candidates with batch tracking.
+ */
+export async function vaultExecute(
+  input: VaultImportInput,
+  config: McpServerConfig,
+): Promise<ImportExecutionResult> {
+  const db = createDatabase({ path: config.dbPath });
+  try {
+    const deps = {
+      candidateRepo: new CandidateRepository(db),
+      memoryRepo: new MemoryRepository(db),
+      batchRepo: new ImportBatchRepository(db),
+    };
+    return await executeImport(input.sourcePath, config.tenantId, deps, input.excludeDirs);
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Roll back a vault import batch — deletes all candidates and marks batch rolled_back.
+ */
+export function vaultRollback(input: VaultRollbackInput, config: McpServerConfig): RollbackResult {
+  const db = createDatabase({ path: config.dbPath });
+  try {
+    const deps = {
+      candidateRepo: new CandidateRepository(db),
+      memoryRepo: new MemoryRepository(db),
+      batchRepo: new ImportBatchRepository(db),
+    };
+    const linksRepo = new MemoryLinksRepository(db);
+    return rollbackImport(input.batchId, deps, linksRepo);
+  } finally {
+    db.close();
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       '@qmd-team-intent-kb/common':
         specifier: workspace:*
         version: link:../../packages/common
+      '@qmd-team-intent-kb/curator':
+        specifier: workspace:*
+        version: link:../curator
       '@qmd-team-intent-kb/schema':
         specifier: workspace:*
         version: link:../../packages/schema


### PR DESCRIPTION
## Summary

- Three new MCP tools for vault import: `teamkb_vault_preview`, `teamkb_vault_import`, `teamkb_vault_rollback`
- Each opens a short-lived DB connection, runs the curator import pipeline, and closes
- Obsidian-aware: excludes `.obsidian/`, `.trash/`, `.git/` by default with custom `excludeDirs` support
- Parses YAML frontmatter for title, category, tags

**Bead**: 5gl (E13-B07)

## Test plan

- [x] `pnpm validate` passes (1261 tests)
- [x] No regressions in existing MCP server tests (55 pass)
- [x] Import pipeline tested via curator test suite (19 tests)

Jeremy made me do it
-claude