### PR TITLE
feat: wiki-link resolution + graph traversal API (E14 + E15)

### DIFF
--- a/apps/api/src/__tests__/graph.test.ts
+++ b/apps/api/src/__tests__/graph.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+import type Database from 'better-sqlite3';
+import {
+  createTestDatabase,
+  MemoryRepository,
+  MemoryLinksRepository,
+} from '@qmd-team-intent-kb/store';
+import type { MemoryLink } from '@qmd-team-intent-kb/store';
+import { buildApp } from '../app.js';
+import { makeMemory } from './fixtures.js';
+
+const NOW = '2026-01-15T10:00:00.000Z';
+
+function makeLink(overrides?: Partial<MemoryLink>): MemoryLink {
+  return {
+    id: randomUUID(),
+    sourceMemoryId: 'm1',
+    targetMemoryId: 'm2',
+    linkType: 'relates_to',
+    weight: 1.0,
+    createdBy: 'test-user',
+    source: 'manual',
+    importBatchId: null,
+    createdAt: NOW,
+    ...overrides,
+  };
+}
+
+describe('/api/memories/:id/neighbors and /api/memories/:id/graph', () => {
+  let db: Database.Database;
+  let app: FastifyInstance;
+  let memoryRepo: MemoryRepository;
+  let linksRepo: MemoryLinksRepository;
+
+  // Stable IDs for graph seeding — avoids UUID generation noise in assertions
+  const idA = randomUUID();
+  const idB = randomUUID();
+  const idC = randomUUID();
+
+  beforeEach(async () => {
+    db = createTestDatabase();
+    memoryRepo = new MemoryRepository(db);
+    linksRepo = new MemoryLinksRepository(db);
+    app = buildApp({ db });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    db.close();
+  });
+
+  // ---- GET /api/memories/:id/neighbors -------------------------------------
+
+  describe('GET /:id/neighbors', () => {
+    it('returns linked memories in both directions', async () => {
+      const memA = makeMemory({ id: idA });
+      const memB = makeMemory({ id: idB, content: 'Memory B content for graph test' });
+      const memC = makeMemory({ id: idC, content: 'Memory C content for graph test' });
+      memoryRepo.insert(memA);
+      memoryRepo.insert(memB);
+      memoryRepo.insert(memC);
+
+      // A → B (outgoing from A)
+      linksRepo.insert(makeLink({ sourceMemoryId: idA, targetMemoryId: idB }));
+      // C → A (incoming to A)
+      linksRepo.insert(
+        makeLink({ sourceMemoryId: idC, targetMemoryId: idA, linkType: 'depends_on' }),
+      );
+
+      const res = await app.inject({ method: 'GET', url: `/api/memories/${idA}/neighbors` });
+      expect(res.statusCode).toBe(200);
+
+      const body = res.json<Array<{ memoryId: string; direction: string; linkType: string }>>();
+      expect(body).toHaveLength(2);
+
+      const outgoing = body.find((n) => n.direction === 'outgoing');
+      const incoming = body.find((n) => n.direction === 'incoming');
+
+      expect(outgoing?.memoryId).toBe(idB);
+      expect(outgoing?.linkType).toBe('relates_to');
+
+      expect(incoming?.memoryId).toBe(idC);
+      expect(incoming?.linkType).toBe('depends_on');
+    });
+
+    it('returns an empty array for a memory with no links', async () => {
+      const mem = makeMemory();
+      memoryRepo.insert(mem);
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/memories/${mem.id}/neighbors`,
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual([]);
+    });
+
+    it('returns 404 for a non-existent memory', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/memories/${randomUUID()}/neighbors`,
+      });
+      expect(res.statusCode).toBe(404);
+      expect(res.json<{ error: string }>().error).toMatch(/not found/i);
+    });
+
+    it('includes weight in each neighbor entry', async () => {
+      const memA = makeMemory({ id: idA });
+      const memB = makeMemory({ id: idB, content: 'Memory B weight test' });
+      memoryRepo.insert(memA);
+      memoryRepo.insert(memB);
+
+      linksRepo.insert(makeLink({ sourceMemoryId: idA, targetMemoryId: idB, weight: 0.75 }));
+
+      const res = await app.inject({ method: 'GET', url: `/api/memories/${idA}/neighbors` });
+      expect(res.statusCode).toBe(200);
+
+      const body = res.json<Array<{ weight: number }>>();
+      expect(body[0]?.weight).toBe(0.75);
+    });
+  });
+
+  // ---- GET /api/memories/:id/graph -----------------------------------------
+
+  describe('GET /:id/graph', () => {
+    it('returns nodes at multiple depths', async () => {
+      const memA = makeMemory({ id: idA });
+      const memB = makeMemory({ id: idB, content: 'Graph depth 1 memory' });
+      const memC = makeMemory({ id: idC, content: 'Graph depth 2 memory' });
+      memoryRepo.insert(memA);
+      memoryRepo.insert(memB);
+      memoryRepo.insert(memC);
+
+      // A → B → C (chain depth 2)
+      linksRepo.insert(makeLink({ sourceMemoryId: idA, targetMemoryId: idB }));
+      linksRepo.insert(
+        makeLink({ sourceMemoryId: idB, targetMemoryId: idC, linkType: 'supersedes' }),
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/memories/${idA}/graph?depth=2`,
+      });
+      expect(res.statusCode).toBe(200);
+
+      const nodes = res.json<Array<{ memoryId: string; depth: number; linkType: string }>>();
+      expect(nodes).toHaveLength(2);
+
+      expect(nodes[0]?.memoryId).toBe(idB);
+      expect(nodes[0]?.depth).toBe(1);
+      expect(nodes[0]?.linkType).toBe('relates_to');
+
+      expect(nodes[1]?.memoryId).toBe(idC);
+      expect(nodes[1]?.depth).toBe(2);
+      expect(nodes[1]?.linkType).toBe('supersedes');
+    });
+
+    it('respects the depth parameter and stops early', async () => {
+      const memA = makeMemory({ id: idA });
+      const memB = makeMemory({ id: idB, content: 'Depth limit test B' });
+      const memC = makeMemory({ id: idC, content: 'Depth limit test C' });
+      memoryRepo.insert(memA);
+      memoryRepo.insert(memB);
+      memoryRepo.insert(memC);
+
+      linksRepo.insert(makeLink({ sourceMemoryId: idA, targetMemoryId: idB }));
+      linksRepo.insert(makeLink({ sourceMemoryId: idB, targetMemoryId: idC }));
+
+      // Request depth=1 — only B should appear
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/memories/${idA}/graph?depth=1`,
+      });
+      expect(res.statusCode).toBe(200);
+
+      const nodes = res.json<Array<{ memoryId: string; depth: number }>>();
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0]?.memoryId).toBe(idB);
+      expect(nodes[0]?.depth).toBe(1);
+    });
+
+    it('uses default depth of 2 when depth param is omitted', async () => {
+      const memA = makeMemory({ id: idA });
+      const memB = makeMemory({ id: idB, content: 'Default depth B' });
+      const memC = makeMemory({ id: idC, content: 'Default depth C' });
+      memoryRepo.insert(memA);
+      memoryRepo.insert(memB);
+      memoryRepo.insert(memC);
+
+      linksRepo.insert(makeLink({ sourceMemoryId: idA, targetMemoryId: idB }));
+      linksRepo.insert(makeLink({ sourceMemoryId: idB, targetMemoryId: idC }));
+
+      // No depth param — default is 2, so both B and C appear
+      const res = await app.inject({ method: 'GET', url: `/api/memories/${idA}/graph` });
+      expect(res.statusCode).toBe(200);
+
+      const nodes = res.json<Array<{ memoryId: string }>>();
+      expect(nodes).toHaveLength(2);
+    });
+
+    it('rejects depth greater than 5 with 400', async () => {
+      const mem = makeMemory();
+      memoryRepo.insert(mem);
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/memories/${mem.id}/graph?depth=6`,
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json<{ error: string }>().error).toMatch(/maximum/i);
+    });
+
+    it('caps traversal exactly at depth 5', async () => {
+      // Build a chain: A → B → C at depth 2; depth=5 should return both nodes
+      const memA = makeMemory({ id: idA });
+      const memB = makeMemory({ id: idB, content: 'Cap test B' });
+      const memC = makeMemory({ id: idC, content: 'Cap test C' });
+      memoryRepo.insert(memA);
+      memoryRepo.insert(memB);
+      memoryRepo.insert(memC);
+
+      linksRepo.insert(makeLink({ sourceMemoryId: idA, targetMemoryId: idB }));
+      linksRepo.insert(makeLink({ sourceMemoryId: idB, targetMemoryId: idC }));
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/memories/${idA}/graph?depth=5`,
+      });
+      expect(res.statusCode).toBe(200);
+
+      const nodes = res.json<Array<{ memoryId: string }>>();
+      // Chain is only 2 deep; depth=5 doesn't error, just returns what exists
+      expect(nodes).toHaveLength(2);
+    });
+
+    it('returns 404 for a non-existent memory', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/memories/${randomUUID()}/graph`,
+      });
+      expect(res.statusCode).toBe(404);
+      expect(res.json<{ error: string }>().error).toMatch(/not found/i);
+    });
+
+    it('returns 400 for a non-numeric depth value', async () => {
+      const mem = makeMemory();
+      memoryRepo.insert(mem);
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/memories/${mem.id}/graph?depth=banana`,
+      });
+      expect(res.statusCode).toBe(400);
+      expect(res.json<{ error: string }>().error).toMatch(/positive integer/i);
+    });
+
+    it('returns an empty array for an isolated memory', async () => {
+      const mem = makeMemory();
+      memoryRepo.insert(mem);
+
+      const res = await app.inject({ method: 'GET', url: `/api/memories/${mem.id}/graph` });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual([]);
+    });
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -22,6 +22,7 @@ import { registerAuditRoutes } from './routes/audit.js';
 import { registerSearchRoutes } from './routes/search.js';
 import { registerImportRoutes } from './routes/import.js';
 import { ImportService } from './services/import-service.js';
+import { registerGraphRoutes } from './routes/graph.js';
 import { registerRateLimiter } from './middleware/rate-limiter.js';
 import { registerApiKeyAuth } from './middleware/api-key-auth.js';
 import { registerInputSanitizer } from './middleware/input-sanitizer.js';
@@ -88,6 +89,7 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
     registerAuditRoutes(scope, auditRepo);
     registerSearchRoutes(scope, searchService);
     registerImportRoutes(scope, importService);
+    registerGraphRoutes(scope, linksRepo, memoryRepo);
   });
 
   return app;

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -84,7 +84,7 @@ export function buildApp(deps: AppDependencies): FastifyInstance {
   void app.register(async (scope) => {
     registerHealthRoutes(scope, healthService);
     registerCandidateRoutes(scope, candidateService);
-    registerMemoryRoutes(scope, memoryService);
+    registerMemoryRoutes(scope, memoryService, memoryRepo);
     registerPolicyRoutes(scope, policyService);
     registerAuditRoutes(scope, auditRepo);
     registerSearchRoutes(scope, searchService);

--- a/apps/api/src/routes/graph.ts
+++ b/apps/api/src/routes/graph.ts
@@ -1,0 +1,96 @@
+import type { FastifyInstance } from 'fastify';
+import { ApiError, notFound, badRequest } from '../errors.js';
+import type { MemoryLinksRepository, Neighbor, GraphNode } from '@qmd-team-intent-kb/store';
+import type { MemoryRepository } from '@qmd-team-intent-kb/store';
+
+const MAX_DEPTH = 5;
+const DEFAULT_DEPTH = 2;
+
+/**
+ * Register graph traversal routes.
+ *
+ * GET /api/memories/:id/neighbors   — direct neighbors (both directions, depth 1)
+ * GET /api/memories/:id/graph       — recursive CTE traversal (?depth=2, max 5)
+ */
+export function registerGraphRoutes(
+  app: FastifyInstance,
+  linksRepo: MemoryLinksRepository,
+  memoryRepo: MemoryRepository,
+): void {
+  app.get(
+    '/api/memories/:id/neighbors',
+    {
+      schema: {
+        tags: ['graph'],
+        summary: 'Get direct neighbors of a memory',
+        description:
+          'Returns all memories linked to or from the given memory, ' +
+          'including link type, weight, and direction (outgoing/incoming).',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { id } = request.params as { id: string };
+
+        const memory = memoryRepo.findById(id);
+        if (memory === null) {
+          throw notFound(`Memory ${id} not found`);
+        }
+
+        const neighbors: Neighbor[] = linksRepo.neighbors(id);
+        return reply.send(neighbors);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
+      }
+    },
+  );
+
+  app.get(
+    '/api/memories/:id/graph',
+    {
+      schema: {
+        tags: ['graph'],
+        summary: 'Traverse the memory graph from a starting node',
+        description:
+          'Performs a recursive CTE traversal starting from the given memory. ' +
+          'Returns all reachable nodes up to the requested depth (default 2, max 5), ' +
+          'each annotated with its depth, link type, and weight.',
+      },
+    },
+    async (request, reply) => {
+      try {
+        const { id } = request.params as { id: string };
+        const query = request.query as { depth?: string };
+
+        let depth = DEFAULT_DEPTH;
+        if (query.depth !== undefined) {
+          const parsed = parseInt(query.depth, 10);
+          if (isNaN(parsed) || parsed < 1) {
+            throw badRequest(`depth must be a positive integer, got: ${query.depth}`);
+          }
+          depth = parsed;
+        }
+
+        if (depth > MAX_DEPTH) {
+          throw badRequest(`depth exceeds maximum allowed value of ${MAX_DEPTH}`);
+        }
+
+        const memory = memoryRepo.findById(id);
+        if (memory === null) {
+          throw notFound(`Memory ${id} not found`);
+        }
+
+        const nodes: GraphNode[] = linksRepo.traverse(id, depth);
+        return reply.send(nodes);
+      } catch (err) {
+        if (err instanceof ApiError) {
+          return reply.status(err.statusCode).send({ error: err.message });
+        }
+        throw err;
+      }
+    },
+  );
+}

--- a/apps/api/src/routes/memories.ts
+++ b/apps/api/src/routes/memories.ts
@@ -1,5 +1,7 @@
 import type { FastifyInstance } from 'fastify';
 import { MemoryLifecycleState } from '@qmd-team-intent-kb/schema';
+import type { MemoryRepository } from '@qmd-team-intent-kb/store';
+import { resolveWikiLinks } from '@qmd-team-intent-kb/curator';
 import { ApiError } from '../errors.js';
 import type { MemoryService } from '../services/memory-service.js';
 
@@ -14,7 +16,11 @@ import type { MemoryService } from '../services/memory-service.js';
  * Note: by-hash must be registered before :id so Fastify does not treat
  * "by-hash" as a UUID parameter value.
  */
-export function registerMemoryRoutes(app: FastifyInstance, service: MemoryService): void {
+export function registerMemoryRoutes(
+  app: FastifyInstance,
+  service: MemoryService,
+  memoryRepo?: MemoryRepository,
+): void {
   app.get(
     '/api/memories',
     {
@@ -66,7 +72,18 @@ export function registerMemoryRoutes(app: FastifyInstance, service: MemoryServic
     async (request, reply) => {
       try {
         const { id } = request.params as { id: string };
+        const query = request.query as { resolve_links?: string };
         const memory = service.getById(id);
+
+        if (query.resolve_links === 'true' && memoryRepo) {
+          const { resolvedContent } = resolveWikiLinks(memory.content, (slug) => {
+            const matches = memoryRepo.searchByText(slug);
+            const match = matches.find((m) => m.title.toLowerCase() === slug.toLowerCase());
+            return match ? { id: match.id, title: match.title } : null;
+          });
+          return reply.send({ ...memory, content: resolvedContent });
+        }
+
         return reply.send(memory);
       } catch (err) {
         if (err instanceof ApiError) {

--- a/apps/curator/src/__tests__/wikilink-parser.test.ts
+++ b/apps/curator/src/__tests__/wikilink-parser.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, vi } from 'vitest';
+import { extractWikiLinks, resolveWikiLinks } from '../import/wikilink-parser.js';
+import type { WikiLink } from '../import/wikilink-parser.js';
+
+// ---------------------------------------------------------------------------
+// extractWikiLinks
+// ---------------------------------------------------------------------------
+
+describe('extractWikiLinks — basic extraction', () => {
+  it('extracts a single plain wiki-link', () => {
+    const links = extractWikiLinks('See [[API Design]] for details.');
+    expect(links).toHaveLength(1);
+    const link = links[0] as WikiLink;
+    expect(link.raw).toBe('[[API Design]]');
+    expect(link.slug).toBe('API Design');
+    expect(link.displayText).toBeNull();
+  });
+
+  it('records correct start and end indices', () => {
+    const content = 'Prefix [[My Note]] suffix';
+    const links = extractWikiLinks(content);
+    expect(links).toHaveLength(1);
+    const link = links[0] as WikiLink;
+    expect(link.startIndex).toBe(7);
+    expect(link.endIndex).toBe(18);
+    expect(content.slice(link.startIndex, link.endIndex)).toBe('[[My Note]]');
+  });
+
+  it('returns an empty array when no wiki-links are present', () => {
+    expect(extractWikiLinks('No links here.')).toHaveLength(0);
+  });
+
+  it('returns an empty array for empty string', () => {
+    expect(extractWikiLinks('')).toHaveLength(0);
+  });
+});
+
+describe('extractWikiLinks — display text variants', () => {
+  it('extracts slug and display text when pipe is present', () => {
+    const links = extractWikiLinks('Check [[API Design|API patterns]] today.');
+    expect(links).toHaveLength(1);
+    const link = links[0] as WikiLink;
+    expect(link.slug).toBe('API Design');
+    expect(link.displayText).toBe('API patterns');
+    expect(link.raw).toBe('[[API Design|API patterns]]');
+  });
+
+  it('trims whitespace from slug and display text', () => {
+    const links = extractWikiLinks('[[ My Note | My Label ]]');
+    expect(links).toHaveLength(1);
+    const link = links[0] as WikiLink;
+    expect(link.slug).toBe('My Note');
+    expect(link.displayText).toBe('My Label');
+  });
+
+  it('treats content after pipe as display text even with spaces', () => {
+    const links = extractWikiLinks('[[Design Principles|Keep it simple, stupid]]');
+    expect(links).toHaveLength(1);
+    expect(links[0]!.displayText).toBe('Keep it simple, stupid');
+  });
+});
+
+describe('extractWikiLinks — multiple links', () => {
+  it('extracts multiple links in order', () => {
+    const content = 'Read [[API Design]] and [[Error Handling]] for guidance.';
+    const links = extractWikiLinks(content);
+    expect(links).toHaveLength(2);
+    expect(links[0]!.slug).toBe('API Design');
+    expect(links[1]!.slug).toBe('Error Handling');
+  });
+
+  it('handles consecutive links without separators', () => {
+    const content = '[[Alpha]][[Beta]][[Gamma]]';
+    const links = extractWikiLinks(content);
+    expect(links).toHaveLength(3);
+    expect(links.map((l) => l.slug)).toEqual(['Alpha', 'Beta', 'Gamma']);
+  });
+
+  it('extracts repeated occurrences of the same slug as separate entries', () => {
+    const content = 'See [[Note A]] and also [[Note A]] again.';
+    const links = extractWikiLinks(content);
+    expect(links).toHaveLength(2);
+    expect(links[0]!.startIndex).not.toBe(links[1]!.startIndex);
+  });
+});
+
+describe('extractWikiLinks — special characters in titles', () => {
+  it('handles parentheses in slug', () => {
+    const links = extractWikiLinks('See [[API Design (v2)]] for the new spec.');
+    expect(links).toHaveLength(1);
+    expect(links[0]!.slug).toBe('API Design (v2)');
+  });
+
+  it('handles hyphens and slashes in slug', () => {
+    const links = extractWikiLinks('Refer to [[error-handling/retry-policy]].');
+    expect(links).toHaveLength(1);
+    expect(links[0]!.slug).toBe('error-handling/retry-policy');
+  });
+
+  it('handles numbers and dots in slug', () => {
+    const links = extractWikiLinks('See [[RFC 7231 (HTTP 1.1)]].');
+    expect(links).toHaveLength(1);
+    expect(links[0]!.slug).toBe('RFC 7231 (HTTP 1.1)');
+  });
+
+  it('handles unicode characters in slug', () => {
+    const links = extractWikiLinks('See [[Système de fichiers]].');
+    expect(links).toHaveLength(1);
+    expect(links[0]!.slug).toBe('Système de fichiers');
+  });
+});
+
+describe('extractWikiLinks — edge cases', () => {
+  it('does not match empty brackets [[]]', () => {
+    expect(extractWikiLinks('Empty [[]] brackets.')).toHaveLength(0);
+  });
+
+  it('does not match brackets with only a pipe [[|]]', () => {
+    // The slug part is required to be non-empty after trimming
+    expect(extractWikiLinks('[[|display only]]')).toHaveLength(0);
+  });
+
+  it('handles link at the very start of content', () => {
+    const links = extractWikiLinks('[[First Link]] starts here.');
+    expect(links).toHaveLength(1);
+    expect(links[0]!.startIndex).toBe(0);
+  });
+
+  it('handles link at the very end of content', () => {
+    const content = 'Ends with [[Last Link]]';
+    const links = extractWikiLinks(content);
+    expect(links).toHaveLength(1);
+    expect(links[0]!.endIndex).toBe(content.length);
+  });
+
+  it('does not match triple-bracket patterns as wiki-link', () => {
+    // [[[foo]]] — outer [[ and ]] should not produce a nested match
+    // At minimum must not throw; result count is implementation-defined
+    expect(() => extractWikiLinks('[[[Nested]]]')).not.toThrow();
+  });
+});
+
+describe('extractWikiLinks — code block exclusion', () => {
+  it('ignores wiki-links inside fenced code blocks', () => {
+    const content = `Normal [[Real Link]] here.
+
+\`\`\`
+This is [[Not A Link]] inside a code block.
+\`\`\`
+
+And [[Another Real Link]] after.`;
+
+    const links = extractWikiLinks(content);
+    const slugs = links.map((l) => l.slug);
+    expect(slugs).toContain('Real Link');
+    expect(slugs).toContain('Another Real Link');
+    expect(slugs).not.toContain('Not A Link');
+  });
+
+  it('ignores wiki-links inside inline code spans', () => {
+    const content = 'Use `[[inline code]]` as an example but [[real link]] is live.';
+    const links = extractWikiLinks(content);
+    expect(links).toHaveLength(1);
+    expect(links[0]!.slug).toBe('real link');
+  });
+
+  it('handles tildes fenced code blocks', () => {
+    const content = `Before [[Link A]].
+
+~~~python
+x = [[Not A Link]]
+~~~
+
+After [[Link B]].`;
+
+    const links = extractWikiLinks(content);
+    const slugs = links.map((l) => l.slug);
+    expect(slugs).toContain('Link A');
+    expect(slugs).toContain('Link B');
+    expect(slugs).not.toContain('Not A Link');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveWikiLinks
+// ---------------------------------------------------------------------------
+
+const MEMORY_MAP: Record<string, { id: string; title: string }> = {
+  'API Design': { id: 'mem-001', title: 'API Design' },
+  'Error Handling': { id: 'mem-002', title: 'Error Handling' },
+  'Custom Title Note': { id: 'mem-003', title: 'Custom Title Note' },
+};
+
+function testResolver(slug: string): { id: string; title: string } | null {
+  return MEMORY_MAP[slug] ?? null;
+}
+
+describe('resolveWikiLinks — resolution with found targets', () => {
+  it('replaces a resolved plain link with Markdown anchor using memory title', () => {
+    const { resolvedContent } = resolveWikiLinks('See [[API Design]] for details.', testResolver);
+    expect(resolvedContent).toBe('See [API Design](/api/memories/mem-001) for details.');
+  });
+
+  it('uses display text as the link label when a pipe is present', () => {
+    const { resolvedContent } = resolveWikiLinks(
+      'See [[API Design|design patterns]] here.',
+      testResolver,
+    );
+    expect(resolvedContent).toBe('See [design patterns](/api/memories/mem-001) here.');
+  });
+
+  it('resolves multiple different links in one pass', () => {
+    const { resolvedContent } = resolveWikiLinks(
+      'Read [[API Design]] and [[Error Handling]].',
+      testResolver,
+    );
+    expect(resolvedContent).toBe(
+      'Read [API Design](/api/memories/mem-001) and [Error Handling](/api/memories/mem-002).',
+    );
+  });
+
+  it('replaces all occurrences of the same resolved slug', () => {
+    const { resolvedContent } = resolveWikiLinks(
+      'First [[API Design]], second [[API Design]].',
+      testResolver,
+    );
+    expect(resolvedContent).toBe(
+      'First [API Design](/api/memories/mem-001), second [API Design](/api/memories/mem-001).',
+    );
+  });
+});
+
+describe('resolveWikiLinks — unresolved links', () => {
+  it('leaves unresolved links as literal [[slug]] text', () => {
+    const { resolvedContent } = resolveWikiLinks(
+      'See [[Unknown Topic]] for details.',
+      testResolver,
+    );
+    expect(resolvedContent).toBe('See [[Unknown Topic]] for details.');
+  });
+
+  it('handles a mix of resolved and unresolved links', () => {
+    const { resolvedContent } = resolveWikiLinks(
+      'Check [[API Design]] and [[Unknown Topic]].',
+      testResolver,
+    );
+    expect(resolvedContent).toBe(
+      'Check [API Design](/api/memories/mem-001) and [[Unknown Topic]].',
+    );
+  });
+});
+
+describe('resolveWikiLinks — links metadata', () => {
+  it('returns resolved: true and memoryId for resolved links', () => {
+    const { links } = resolveWikiLinks('See [[API Design]].', testResolver);
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({ slug: 'API Design', memoryId: 'mem-001', resolved: true });
+  });
+
+  it('returns resolved: false and memoryId: null for unresolved links', () => {
+    const { links } = resolveWikiLinks('See [[Ghost Note]].', testResolver);
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({ slug: 'Ghost Note', memoryId: null, resolved: false });
+  });
+
+  it('deduplicates repeated slugs in links array', () => {
+    const { links } = resolveWikiLinks(
+      '[[API Design]] appears [[API Design]] twice.',
+      testResolver,
+    );
+    expect(links).toHaveLength(1);
+    expect(links[0]!.slug).toBe('API Design');
+  });
+
+  it('lists links in order of first appearance', () => {
+    const { links } = resolveWikiLinks('[[Error Handling]] then [[API Design]].', testResolver);
+    expect(links[0]!.slug).toBe('Error Handling');
+    expect(links[1]!.slug).toBe('API Design');
+  });
+
+  it('returns mixed resolved/unresolved metadata correctly', () => {
+    const { links } = resolveWikiLinks('[[API Design]] and [[Phantom]].', testResolver);
+    expect(links).toHaveLength(2);
+    expect(links.find((l) => l.slug === 'API Design')?.resolved).toBe(true);
+    expect(links.find((l) => l.slug === 'Phantom')?.resolved).toBe(false);
+  });
+});
+
+describe('resolveWikiLinks — resolver call behaviour', () => {
+  it('calls the resolver exactly once per unique slug', () => {
+    const resolver = vi.fn(testResolver);
+    resolveWikiLinks('[[API Design]] and [[API Design]] and [[Error Handling]].', resolver);
+    // Two unique slugs → two calls
+    expect(resolver).toHaveBeenCalledTimes(2);
+    expect(resolver).toHaveBeenCalledWith('API Design');
+    expect(resolver).toHaveBeenCalledWith('Error Handling');
+  });
+
+  it('does not call the resolver when there are no wiki-links', () => {
+    const resolver = vi.fn(testResolver);
+    resolveWikiLinks('No links here.', resolver);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveWikiLinks — no-op cases', () => {
+  it('returns the original content unchanged when no links are present', () => {
+    const content = 'Plain text with no wiki-links.';
+    const { resolvedContent, links } = resolveWikiLinks(content, testResolver);
+    expect(resolvedContent).toBe(content);
+    expect(links).toHaveLength(0);
+  });
+
+  it('returns empty content unchanged', () => {
+    const { resolvedContent, links } = resolveWikiLinks('', testResolver);
+    expect(resolvedContent).toBe('');
+    expect(links).toHaveLength(0);
+  });
+});
+
+describe('resolveWikiLinks — content integrity', () => {
+  it('preserves surrounding text exactly after resolution', () => {
+    const { resolvedContent } = resolveWikiLinks('Before\n[[API Design]]\nAfter', testResolver);
+    expect(resolvedContent).toBe('Before\n[API Design](/api/memories/mem-001)\nAfter');
+  });
+
+  it('handles links at the start and end of content', () => {
+    const { resolvedContent } = resolveWikiLinks(
+      '[[API Design]] is the start and [[Error Handling]] is the end',
+      testResolver,
+    );
+    expect(resolvedContent).toBe(
+      '[API Design](/api/memories/mem-001) is the start and [Error Handling](/api/memories/mem-002) is the end',
+    );
+  });
+});

--- a/apps/curator/src/import/index.ts
+++ b/apps/curator/src/import/index.ts
@@ -12,3 +12,5 @@ export type {
   ImportDependencies,
   RollbackResult,
 } from './import-pipeline.js';
+export { extractWikiLinks, resolveWikiLinks } from './wikilink-parser.js';
+export type { WikiLink, ResolvedLink, WikiLinkResolutionResult } from './wikilink-parser.js';

--- a/apps/curator/src/import/wikilink-parser.ts
+++ b/apps/curator/src/import/wikilink-parser.ts
@@ -1,0 +1,208 @@
+/**
+ * Wiki-link parser for Obsidian-style `[[slug]]` and `[[slug|display]]` syntax.
+ *
+ * Handles extraction and resolution of wiki-links found in curated memory content.
+ * Resolution maps slugs to curated memory IDs so links can be rendered as API URLs.
+ */
+
+/** A parsed wiki-link occurrence within a content string */
+export interface WikiLink {
+  /** The full raw match including brackets, e.g. `[[API Design|API patterns]]` */
+  raw: string;
+  /** The slug (note title or path) before any pipe, e.g. `API Design` */
+  slug: string;
+  /** Display text after the pipe, or null when absent */
+  displayText: string | null;
+  /** Inclusive start index of the raw match in the original content string */
+  startIndex: number;
+  /** Exclusive end index of the raw match in the original content string */
+  endIndex: number;
+}
+
+/** Per-link outcome from resolveWikiLinks */
+export interface ResolvedLink {
+  /** The slug as written in the source content */
+  slug: string;
+  /** The curated memory ID returned by the resolver, or null when unresolved */
+  memoryId: string | null;
+  /** True when the resolver returned a non-null match */
+  resolved: boolean;
+}
+
+/** Return value of resolveWikiLinks */
+export interface WikiLinkResolutionResult {
+  /** Content with resolved links replaced by Markdown reference syntax */
+  resolvedContent: string;
+  /** One entry per unique wiki-link found, in order of first appearance */
+  links: ResolvedLink[];
+}
+
+/**
+ * Matches `[[...]]` patterns where the inner content is not another `[[` or `]]`.
+ *
+ * Group 1 — slug (required): everything before the first `|` (or the whole inner
+ *            content when no pipe is present), trimmed by the caller.
+ * Group 2 — display text (optional): everything after the first `|`.
+ *
+ * The pattern intentionally rejects:
+ *   - `[[]]`  (empty inner content)
+ *   - Nested brackets e.g. `[[[foo]]]` (outer brackets do not match)
+ *
+ * Code-block avoidance is handled at call sites via stripCodeBlocks().
+ */
+const WIKILINK_RE = /\[\[([^\[\]|][^\[\]|]*?)(?:\|([^\[\]]*))?\]\]/g;
+
+/**
+ * Extract all wiki-links from a content string.
+ *
+ * Links inside fenced code blocks (``` ``` ```) and inline code spans (`` ` ``)
+ * are excluded on a best-effort basis — the underlying content is not modified,
+ * only matches that fall outside code regions are returned.
+ *
+ * @param content - Raw Markdown content to scan
+ * @returns Array of WikiLink objects ordered by position
+ */
+export function extractWikiLinks(content: string): WikiLink[] {
+  const codeRanges = findCodeRanges(content);
+  const links: WikiLink[] = [];
+
+  WIKILINK_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = WIKILINK_RE.exec(content)) !== null) {
+    const startIndex = match.index;
+    const endIndex = startIndex + match[0].length;
+
+    if (isInsideCodeRange(startIndex, endIndex, codeRanges)) {
+      continue;
+    }
+
+    const rawSlug = match[1]!;
+    const rawDisplay = match[2] ?? null;
+
+    links.push({
+      raw: match[0],
+      slug: rawSlug.trim(),
+      displayText: rawDisplay !== null ? rawDisplay.trim() : null,
+      startIndex,
+      endIndex,
+    });
+  }
+
+  return links;
+}
+
+/**
+ * Resolve wiki-links in content, replacing found links with Markdown anchor syntax.
+ *
+ * Resolution strategy:
+ *   - Calls `resolver(slug)` for each unique slug (case-sensitive).
+ *   - **Resolved** (`resolver` returns non-null): replaces every occurrence of
+ *     `[[slug]]` / `[[slug|display]]` with `[display text or title](/api/memories/{id})`.
+ *   - **Unresolved** (`resolver` returns null): the `[[slug]]` text is left unchanged
+ *     as a visual signal that the target has not yet been curated.
+ *
+ * @param content  - Raw Markdown content to process
+ * @param resolver - Function that maps a slug string to a memory record, or null
+ * @returns Resolved content string and per-link metadata
+ */
+export function resolveWikiLinks(
+  content: string,
+  resolver: (slug: string) => { id: string; title: string } | null,
+): WikiLinkResolutionResult {
+  const allLinks = extractWikiLinks(content);
+
+  if (allLinks.length === 0) {
+    return { resolvedContent: content, links: [] };
+  }
+
+  // Build resolution map keyed by slug (one resolver call per unique slug)
+  const resolutionCache = new Map<string, { id: string; title: string } | null>();
+  for (const link of allLinks) {
+    if (!resolutionCache.has(link.slug)) {
+      resolutionCache.set(link.slug, resolver(link.slug));
+    }
+  }
+
+  // Build the links metadata array (first occurrence order, deduplicated by slug)
+  const seenSlugs = new Set<string>();
+  const links: ResolvedLink[] = [];
+
+  for (const link of allLinks) {
+    if (!seenSlugs.has(link.slug)) {
+      seenSlugs.add(link.slug);
+      const resolved = resolutionCache.get(link.slug) ?? null;
+      links.push({
+        slug: link.slug,
+        memoryId: resolved?.id ?? null,
+        resolved: resolved !== null,
+      });
+    }
+  }
+
+  // Apply replacements in reverse order to preserve indices
+  let result = content;
+  for (let i = allLinks.length - 1; i >= 0; i--) {
+    const link = allLinks[i]!;
+    const resolved = resolutionCache.get(link.slug) ?? null;
+
+    if (resolved === null) {
+      // Leave unresolved links as-is
+      continue;
+    }
+
+    const displayLabel = link.displayText ?? resolved.title;
+    const replacement = `[${displayLabel}](/api/memories/${resolved.id})`;
+    result = result.slice(0, link.startIndex) + replacement + result.slice(link.endIndex);
+  }
+
+  return { resolvedContent: result, links };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+interface CodeRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * Locate fenced code blocks (``` or ~~~) and inline code spans (`) in content.
+ * Returns an array of [start, end) ranges (exclusive end) that should be excluded
+ * from wiki-link matching.
+ */
+function findCodeRanges(content: string): CodeRange[] {
+  const ranges: CodeRange[] = [];
+
+  // Fenced code blocks: ``` or ~~~ on their own line
+  const fencedRe = /^(`{3,}|~{3,})[^\n]*\n[\s\S]*?^\1\s*$/gm;
+  let m: RegExpExecArray | null;
+
+  fencedRe.lastIndex = 0;
+  while ((m = fencedRe.exec(content)) !== null) {
+    ranges.push({ start: m.index, end: m.index + m[0].length });
+  }
+
+  // Inline code spans: single backtick pairs (non-greedy, no newlines inside)
+  const inlineRe = /`[^`\n]+`/g;
+  inlineRe.lastIndex = 0;
+  while ((m = inlineRe.exec(content)) !== null) {
+    // Only add if not already covered by a fenced range
+    if (!isInsideCodeRange(m.index, m.index + m[0].length, ranges)) {
+      ranges.push({ start: m.index, end: m.index + m[0].length });
+    }
+  }
+
+  return ranges;
+}
+
+function isInsideCodeRange(start: number, end: number, ranges: CodeRange[]): boolean {
+  for (const range of ranges) {
+    if (start >= range.start && end <= range.end) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/apps/curator/src/index.ts
+++ b/apps/curator/src/index.ts
@@ -14,7 +14,14 @@ export type { PromotionInput } from './promotion/promoter.js';
 export { reject } from './rejection/rejector.js';
 export { parseMarkdown, titleFromPath, walkVault, countVaultFiles } from './import/index.js';
 export type { ParsedMarkdown, VaultFile } from './import/index.js';
-export { detectCollision, previewImport, executeImport, rollbackImport } from './import/index.js';
+export {
+  detectCollision,
+  previewImport,
+  executeImport,
+  rollbackImport,
+  extractWikiLinks,
+  resolveWikiLinks,
+} from './import/index.js';
 export type {
   CollisionResult,
   CollisionTarget,

--- a/apps/curator/src/promotion/promoter.ts
+++ b/apps/curator/src/promotion/promoter.ts
@@ -11,6 +11,7 @@ import type {
 } from '@qmd-team-intent-kb/store';
 import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
 import type { SupersessionMatch } from '../supersession/supersession-detector.js';
+import { extractWikiLinks } from '../import/wikilink-parser.js';
 
 /** Input bundle for a single promotion operation */
 export interface PromotionInput {
@@ -124,6 +125,34 @@ export function promote(
         importBatchId: null,
         createdAt: now,
       });
+    }
+
+    // Extract wiki-links from content and create relates_to edges
+    if (linksRepo) {
+      const wikiLinks = extractWikiLinks(input.candidate.content);
+      for (const wl of wikiLinks) {
+        const targets = memoryRepo.searchByText(wl.slug);
+        const match = targets.find(
+          (m) => m.title.toLowerCase() === wl.slug.toLowerCase() && m.id !== memoryId,
+        );
+        if (match) {
+          try {
+            linksRepo.insert({
+              id: randomUUID(),
+              sourceMemoryId: memoryId,
+              targetMemoryId: match.id,
+              linkType: 'relates_to',
+              weight: 1.0,
+              createdBy: 'curator',
+              source: 'curator',
+              importBatchId: null,
+              createdAt: now,
+            });
+          } catch {
+            // Unique constraint violation — link already exists, skip
+          }
+        }
+      }
     }
 
     auditRepo.insert(

--- a/apps/git-exporter/src/formatter/markdown-formatter.ts
+++ b/apps/git-exporter/src/formatter/markdown-formatter.ts
@@ -1,8 +1,15 @@
 import type { CuratedMemory } from '@qmd-team-intent-kb/schema';
 import { extractFrontmatter, renderFrontmatter } from './frontmatter.js';
 
+/** Optional callback to resolve wiki-links in content before export */
+export type LinkResolver = (content: string) => string;
+
 /**
  * Format a CuratedMemory as a full Markdown document with YAML frontmatter.
+ *
+ * When a `resolveLinks` callback is provided, wiki-links in the content
+ * are resolved before rendering. Unresolved links pass through as literal
+ * `[[slug]]` text.
  *
  * Structure:
  * ```
@@ -15,9 +22,10 @@ import { extractFrontmatter, renderFrontmatter } from './frontmatter.js';
  * <content>
  * ```
  */
-export function formatMemoryAsMarkdown(memory: CuratedMemory): string {
+export function formatMemoryAsMarkdown(memory: CuratedMemory, resolveLinks?: LinkResolver): string {
   const frontmatter = renderFrontmatter(extractFrontmatter(memory));
-  return `${frontmatter}\n\n# ${memory.title}\n\n${memory.content}\n`;
+  const content = resolveLinks ? resolveLinks(memory.content) : memory.content;
+  return `${frontmatter}\n\n# ${memory.title}\n\n${content}\n`;
 }
 
 /**

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -8,6 +8,7 @@ import { getStatus } from './tools/status.js';
 import { applyTransition } from './tools/transition.js';
 import { runSync, isQmdAvailable } from './tools/sync.js';
 import { vaultPreview, vaultExecute, vaultRollback } from './tools/vault-import.js';
+import { createDatabase, MemoryLinksRepository } from '@qmd-team-intent-kb/store';
 
 const VERSION = '0.1.0';
 
@@ -205,6 +206,29 @@ export function createServer(
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
       };
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // teamkb_neighbors — get linked memories for a given memory
+  // -------------------------------------------------------------------------
+  server.tool(
+    'teamkb_neighbors',
+    'Return all memories linked to the given memory (both directions). Shows link types, weights, and direction (outgoing/incoming). Useful for exploring the knowledge graph from a specific node.',
+    {
+      memoryId: z.string().uuid().describe('UUID of the curated memory to find neighbors for'),
+    },
+    async (params) => {
+      const db = createDatabase({ path: config.dbPath });
+      try {
+        const linksRepo = new MemoryLinksRepository(db);
+        const neighbors = linksRepo.neighbors(params.memoryId);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(neighbors, null, 2) }],
+        };
+      } finally {
+        db.close();
+      }
     },
   );
 


### PR DESCRIPTION
## Summary

### Epic 14: Wiki-Link Resolution
- **E14-B01**: Wiki-link parser — `extractWikiLinks()` + `resolveWikiLinks()` with code-block awareness, memoized resolver (39 tests)
- **E14-B02**: Write-path — promoter auto-creates `relates_to` graph edges for wiki-link references during memory promotion
- **E14-B03**: Read-path — `GET /api/memories/:id?resolve_links=true` resolves `[[slug]]` to `[Title](/api/memories/{id})`
- **E14-B04**: Git exporter — `formatMemoryAsMarkdown()` accepts optional `LinkResolver` callback

### Epic 15: Graph Traversal API
- **E15-B01**: API endpoints — `GET /api/memories/:id/neighbors` + `GET /api/memories/:id/graph?depth=2` (12 tests)
- **E15-B02**: MCP tool — `teamkb_neighbors` returns bidirectional linked memories
- **E15-B03**: Auto-link creation — handled via E14-B02 promoter wiring

**Beads closed**: 0ru, 6r4, vo8, y6s, bqw, a2l, 4da + epic containers 5uu, 8ni (9 total)

## Test plan

- [x] `pnpm validate` passes (1312 tests)
- [x] Wiki-link parser: 39 tests (extraction, resolution, code blocks, edge cases)
- [x] Graph API: 12 tests (neighbors both directions, traversal depth, error cases)
- [x] No regressions across all 119 test files

Jeremy made me do it
-claude