### PR TITLE
chore(release): v0.5.0 — knowledge graph + vault import + wiki-links

### DIFF
--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -31,6 +31,7 @@
 ### DR — Documentation & Reference
 
 - `009-DR-GUID-contribution-workflow.md` — Step-by-step contributor guide
+- `030-DR-GUID-import-conversion-recipes.md` — How to import from Obsidian, Notion, Google Docs, Confluence, etc.
 
 ### WA — Workflows & Automation
 
@@ -92,5 +93,6 @@
 | 027 | OD-OPSM | edge-daemon-runbook         | edge-daemon operations runbook |
 | 028 | OD-SECU | release-signing             | Release supply-chain signing   |
 | 029 | OD-RELS | npm-publishing-strategy     | npm publishing strategy        |
+| 030 | DR-GUID | import-conversion-recipes   | Import from various sources    |
 
-## Next Available Sequence: 030
+## Next Available Sequence: 031

--- a/000-docs/030-DR-GUID-import-conversion-recipes.md
+++ b/000-docs/030-DR-GUID-import-conversion-recipes.md
@@ -1,0 +1,162 @@
+# Import Conversion Recipes
+
+How to get content from various sources into qmd-team-intent-kb's vault import pipeline.
+
+**Principle**: Markdown is the universal input format. Don't build format converters — let
+existing battle-tested tools handle conversion upstream. The import pipeline only needs to be
+world-class at ingesting Markdown directories with frontmatter, wiki-links, and batch tracking.
+
+## The Pipeline
+
+```
+Source format → Convert to Markdown → Place in a directory → teamkb_vault_import
+```
+
+All conversions produce a directory of `.md` files. The import pipeline handles:
+
+- YAML frontmatter extraction (title, category, tags)
+- Wiki-link resolution (`[[slug]]` → graph edges)
+- Content hash dedup (exact match detection)
+- Batch tracking with rollback
+
+## Obsidian Vault (Native)
+
+No conversion needed. Point the import directly at your vault:
+
+```
+teamkb_vault_import { "sourcePath": "/path/to/my-vault" }
+```
+
+The pipeline automatically:
+
+- Excludes `.obsidian/`, `.trash/`, `.git/`, `node_modules/`
+- Parses YAML frontmatter for title, category, tags
+- Resolves `[[wiki-links]]` to graph edges
+- Skips empty files
+
+### Frontmatter Convention
+
+For best results, add frontmatter to your Obsidian notes:
+
+```yaml
+---
+title: API Design Patterns
+category: pattern
+tags: [api, architecture, rest]
+---
+```
+
+Valid categories: `decision`, `pattern`, `convention`, `architecture`, `troubleshooting`, `onboarding`, `reference`. Files without a category default to `reference`.
+
+## Notion
+
+1. **Export**: Settings → Workspace → Export all workspace content → Markdown & CSV
+2. **Unzip** the export to a local directory
+3. **Import**:
+   ```
+   teamkb_vault_import { "sourcePath": "/path/to/notion-export" }
+   ```
+
+Notion exports include frontmatter-like headers. Titles are derived from filenames.
+
+### Alternative: Obsidian Importer
+
+The [Obsidian Importer](https://github.com/obsidianmd/obsidian-importer) plugin (MIT) converts
+Notion exports to clean Obsidian-compatible Markdown with proper wiki-links.
+
+## Google Docs
+
+1. **Download** as .docx: File → Download → Microsoft Word (.docx)
+2. **Convert** with pandoc:
+   ```bash
+   pandoc input.docx -t markdown -o output.md
+   ```
+3. **Import** the output directory
+
+### Batch conversion for Google Drive exports:
+
+```bash
+mkdir converted
+for f in *.docx; do
+  pandoc "$f" -t markdown -o "converted/${f%.docx}.md"
+done
+teamkb_vault_import { "sourcePath": "/path/to/converted" }
+```
+
+## Confluence
+
+1. **Export**: Space Settings → Content Tools → Export → HTML or XML
+2. **Convert** with pandoc:
+   ```bash
+   pandoc input.html -t markdown -o output.md
+   ```
+3. **Import** the converted directory
+
+Or use Confluence's Markdown export plugin if available in your instance.
+
+## Microsoft OneNote / Apple Notes / Evernote / Bear / Roam
+
+Use the [Obsidian Importer](https://github.com/obsidianmd/obsidian-importer) plugin. It supports:
+
+| Source        | Format          | Notes                      |
+| ------------- | --------------- | -------------------------- |
+| OneNote       | Direct API      | Requires sign-in           |
+| Apple Notes   | Database        | macOS only                 |
+| Evernote      | .enex export    | Export from Evernote first |
+| Bear          | .bear2bk export | Export from Bear first     |
+| Roam Research | .json export    | Export from Roam first     |
+| Google Keep   | Google Takeout  | Download via Takeout       |
+
+After importing into an Obsidian vault, point `teamkb_vault_import` at that vault.
+
+## Plain Text / Code Documentation
+
+Already Markdown? Just import directly. For other text formats:
+
+```bash
+# RST → Markdown
+pandoc input.rst -t markdown -o output.md
+
+# HTML → Markdown
+pandoc input.html -t markdown -o output.md
+
+# EPUB → Markdown
+pandoc input.epub -t markdown -o output.md
+
+# ODT → Markdown
+pandoc input.odt -t markdown -o output.md
+```
+
+## Pandoc One-Liner (Any Supported Format)
+
+pandoc supports 40+ input formats. For any supported format:
+
+```bash
+pandoc input.FORMAT -t markdown -o output.md
+```
+
+Common formats: `.docx`, `.pptx`, `.html`, `.epub`, `.odt`, `.rtf`, `.rst`, `.textile`, `.mediawiki`, `.org`
+
+## Preview Before Import
+
+Always preview first:
+
+```
+teamkb_vault_preview { "sourcePath": "/path/to/converted" }
+```
+
+This reports:
+
+- Total file count
+- How many would be created vs. skipped (duplicates)
+- Per-file collision details
+
+## Rollback
+
+If an import went wrong:
+
+```
+teamkb_vault_rollback { "batchId": "uuid-from-import-result" }
+```
+
+This deletes all candidates created by the batch and marks it as rolled back.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-16
+
+### Added
+
+- **Knowledge Graph**: `memory_links` table with 5 link types (relates_to, supersedes, contradicts, depends_on, part_of), bidirectional neighbor queries, and recursive CTE graph traversal up to configurable depth.
+- **Import Batches**: `import_batches` table for batch lifecycle tracking (active → completed | rolled_back) with file/created/rejected/skipped counts.
+- **Vault Import Pipeline**: Recursive Markdown directory walker with `.obsidian/`, `.trash/`, `.git/` exclusion; YAML frontmatter parser (title, category, tags); content hash collision detection against curated memories, candidates, and intra-batch duplicates; batch-tracked candidate creation; rollback capability.
+- **Import API Routes**: `POST /api/import/preview` (dry-run), `POST /api/import` (execute), `GET /api/import/batches` (list), `GET /api/import/batches/:id` (detail), `DELETE /api/import/batches/:id` (rollback).
+- **Graph Traversal API**: `GET /api/memories/:id/neighbors` (bidirectional links), `GET /api/memories/:id/graph?depth=N` (recursive traversal, max depth 5).
+- **Wiki-Link Resolution**: Parser for `[[slug]]` and `[[slug|display]]` syntax with code-block awareness. Write-path: auto-creates `relates_to` graph edges during promotion. Read-path: `?resolve_links=true` query param on memory GET rewrites links to API URLs.
+- **MCP Tools**: `teamkb_vault_preview`, `teamkb_vault_import`, `teamkb_vault_rollback` for Obsidian vault import; `teamkb_neighbors` for graph exploration.
+- **Schema Enums**: `LinkType`, `LinkSource`, `ImportBatchStatus` for graph and import domain model.
+- **Repositories**: `MemoryLinksRepository` (CRUD + neighbors + traverse), `ImportBatchRepository` (CRUD + updateCounts + complete + rollback).
+- **Curator Supersession Edges**: Promoter persists `supersedes` graph edges with Jaccard similarity weight when `MemoryLinksRepository` is provided.
+- **Git Exporter**: `formatMemoryAsMarkdown` accepts optional `LinkResolver` callback for wiki-link resolution on export.
+- Import conversion recipes documentation (`000-docs/030-DR-GUID-import-conversion-recipes.md`) covering Obsidian, Notion, Google Docs, Confluence, and pandoc workflows.
+
+### Changed
+
+- **Zod 4 Migration**: `packages/schema` and `packages/repo-resolver` migrated from zod@3 to zod@4. Fixed `z.record(z.unknown())` → `z.record(z.string(), z.unknown())` and nested `.default({})` explicit full defaults for Zod 4 compatibility.
+- **MCP Server**: Removed inline enum workarounds — now imports `MemoryCategory` and `MemoryLifecycleState` directly from schema package.
+- `CandidateRepository.insert()` accepts optional `importBatchId` for batch association.
+- `CandidateRepository.deleteByBatch()` enables batch rollback.
+
+### Fixed
+
+- `MemoryLinksRepository.traverse()` uses `ROW_NUMBER` window function for deterministic results when multiple paths to the same node exist.
+
 ## [0.4.0] - 2026-04-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qmd-team-intent-kb/root",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "Governed team memory platform for Claude Code powered by qmd",
   "author": "Jeremy Longshore",


### PR DESCRIPTION
## Summary

- Import conversion recipes documentation (E13-B08)
- CHANGELOG for v0.5.0 covering all Epic 11-15 work
- Version bump to 0.5.0

## What's in v0.5.0

- Zod 4 migration across all packages
- Knowledge graph: memory_links table, repositories, graph traversal API
- Vault import pipeline: walk, parse, collision detect, batch track, rollback
- Wiki-link resolution: parser, write-path, read-path, git exporter hook
- 7 new REST API routes, 4 new MCP tools
- 148 new tests (1312 total)

Jeremy made me do it
-claude