### PR TITLE
fix(qmd-adapter): bridge git-exporter layout to qmd collections (e3q)

### DIFF
--- a/000-docs/037-AT-DSGN-qmd-adapter-source-index-separation.md
+++ b/000-docs/037-AT-DSGN-qmd-adapter-source-index-separation.md
@@ -1,0 +1,114 @@
+# 037-AT-DSGN — qmd-adapter source/index separation
+
+**Status:** Accepted (2026-05-31)
+**Type:** Architecture Decision Record
+**Bead:** `qmd-team-intent-kb-e3q` — _Bridge git-exporter output layout to qmd-adapter collection paths so edge-daemon index-update actually indexes curated memories (demo stages 5-6)_
+**Supersedes/relates:** `015-AA-AACR-phase3-adapter.md`, `027-OD-OPSM-edge-daemon-runbook.md`
+
+## Context
+
+The edge-daemon cycle is `ingest → curate → export → index-update`. Two
+components on that chain had drifted out of agreement, so a curated memory could
+be exported but never become searchable:
+
+1. **git-exporter** writes curated memories to
+   `<exportDir>/{decisions,curated,guides,archive}/<id>.md`
+   (`apps/git-exporter/src/formatter/directory-mapper.ts` maps category +
+   lifecycle → subdir).
+
+2. **qmd-adapter** registered its five `kb-*` collections at
+   `getQmdTenantIndexPath(tenant)/{kb-curated,kb-decisions,kb-guides,kb-inbox,kb-archive}`
+   — a **different base path** _and_ **different subdir names** from what the
+   exporter writes.
+
+Result: `ensureCollections()` pointed qmd at directories git-exporter never
+populated, and `qmd update` indexed empty/nonexistent dirs. `qmd search`
+returned nothing — demo stages 5–6 could not surface a curated memory.
+
+Two further defects compounded the disconnect, both rooted in the adapter never
+having been exercised against a real qmd 2.0.1 binary:
+
+- **`--data-dir` does not exist in qmd 2.0.1.** `RealQmdExecutor` prepended
+  `['--data-dir', dataDir, ...args]` to every invocation; qmd rejects the
+  unknown flag, so _every_ adapter command failed.
+- **The search parser assumed tab-separated output.** qmd's default `search`
+  output is a human-readable block, not `score\tfile\tsnippet`. `adapter.query()`
+  parsed zero results even when qmd found matches.
+
+## Decision
+
+**Option A — keep git-exporter's category layout as the source of truth; teach
+the qmd-adapter to index it.** The exporter owns the _content layout_; the
+adapter owns the _index_. Three coordinated changes:
+
+1. **Collection source = export tree.** Each `kb-*` collection carries a
+   `sourceSubdir` (`collection-registry.ts`) naming its git-exporter subdir:
+
+   | collection     | sourceSubdir | in default search |
+   | -------------- | ------------ | ----------------- |
+   | `kb-curated`   | `curated`    | yes               |
+   | `kb-decisions` | `decisions`  | yes               |
+   | `kb-guides`    | `guides`     | yes               |
+   | `kb-archive`   | `archive`    | no                |
+   | `kb-inbox`     | `null`       | — (not exported)  |
+
+   `ensureCollections(exportBaseDir)` registers each exportable collection at
+   `<exportBaseDir>/<sourceSubdir>` under its `kb-*` name. The adapter facade
+   `mkdir -p`s each subdir first, so empty categories (e.g. no archived
+   memories) register cleanly rather than failing `qmd collection add`.
+
+   The collection **name** (`kb-curated`) is preserved — search-scope
+   enforcement and the `qmd://<name>/...` citation both key off it — while the
+   **source path** moves to the exporter's subdir.
+
+2. **Per-tenant isolation via XDG, not `--data-dir`.** `RealQmdExecutor` takes
+   an `env` override merged over `process.env`. `getQmdTenantEnv(tenant)` points
+   `XDG_CONFIG_HOME` (qmd's collection registry) and `XDG_CACHE_HOME` (qmd's
+   BM25 index) at tenant-scoped subdirs of the tenant index path. This isolates
+   tenants from each other _and_ keeps the team KB's qmd state out of the
+   operator's personal `~/.config/qmd` / `~/.cache/qmd`. **Both** XDG vars are
+   required — setting only the cache var leaks `collection add` entries into the
+   operator's global registry.
+
+3. **Parse qmd `--json`.** The search client requests `search --json` and parses
+   the structured array (`{file, score, snippet, ...}`), tolerant of empty /
+   malformed output (degrades to "no results", never throws).
+
+`kb-inbox` is no longer registered as a qmd collection: unreviewed candidates
+live in SQLite pre-governance and are never written to the export tree. The
+`inbox` search scope consequently returns nothing from qmd — correct, since
+nothing pre-governance is indexed.
+
+## Alternatives considered
+
+- **Option B — git-exporter writes into the qmd collection source dirs
+  directly.** Rejected: couples the exporter to the adapter's index layout and
+  forces the `kb-*` naming into the content tree.
+- **Option C — a bridging sync step in edge-daemon** that copies export output
+  into collection source dirs before `qmd update`. Rejected: an extra copy of
+  every memory on every cycle, plus a third place for paths to drift.
+
+Option A keeps a single content tree (the exporter's) and makes the adapter a
+pure consumer of it.
+
+## Consequences
+
+- **edge-daemon wiring:** `main.ts` constructs
+  `new QmdAdapter({ tenantId, exportDir: resolve(config.exportOutputDir) })` —
+  the adapter and exporter now share one resolved export path.
+- **Coupling to document:** the `sourceSubdir` values are the git-exporter
+  output contract and MUST track `getCategoryDirectory` / `getDirectory` in
+  `directory-mapper.ts`. The coupling is commented at both ends and asserted in
+  `collection-manager.test.ts`.
+- **Proof:** `packages/qmd-adapter/src/__tests__/adapter-qmd-integration.test.ts`
+  drives the real qmd binary through the production adapter (curated memory in
+  `curated/` → `ensureCollections` → `update` → `query` → `qmd://kb-curated/...`
+  citation) and verifies per-tenant isolation. Skipped when qmd is absent so CI
+  without qmd stays green; runs locally and anywhere qmd 2.0.1+ is installed.
+- **Validation constraint (unchanged):** a _full-green_ `demo-e2e.sh` run still
+  needs a real `ANTHROPIC_API_KEY` so stages 1–2 produce non-empty wiki/spool
+  content (ICO bead `u0j`). The adapter fix is independently verified with
+  hand-crafted curated memories, no key required.
+
+- Jeremy Longshore
+  intentsolutions.io

--- a/apps/edge-daemon/src/main.ts
+++ b/apps/edge-daemon/src/main.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+
 import { createDatabase } from '@qmd-team-intent-kb/store';
 import {
   CandidateRepository,
@@ -42,7 +44,14 @@ async function main(): Promise<void> {
     policyRepo: new PolicyRepository(db),
     auditRepo: new AuditRepository(db),
     exportStateRepo: new ExportStateRepository(db),
-    qmdAdapter: new QmdAdapter({ tenantId: config.tenantId }),
+    // Point the adapter at the SAME dir the exporter writes to (resolved to
+    // absolute so qmd's collection sources match git-exporter's output
+    // regardless of cwd). git-exporter's file-writer resolves the same
+    // relative `exportOutputDir` from this process's cwd.
+    qmdAdapter: new QmdAdapter({
+      tenantId: config.tenantId,
+      exportDir: resolve(config.exportOutputDir),
+    }),
   };
 
   const exitCode = await dispatch(process.argv.slice(2), { config, daemonDeps, logger });

--- a/packages/qmd-adapter/src/__tests__/adapter-qmd-integration.test.ts
+++ b/packages/qmd-adapter/src/__tests__/adapter-qmd-integration.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Integration test for the PRODUCTION qmd-adapter against the real qmd binary
+ * (bead `qmd-team-intent-kb-e3q`).
+ *
+ * This is the proof that the edge-daemon's `QmdAdapter` — not the demo's
+ * direct-qmd sequence — actually indexes the git-exporter output tree and
+ * returns curated memories with a `qmd://<collection>/...` citation. It closes
+ * the original e3q root cause: the adapter used to register collections at a
+ * per-tenant index path git-exporter never wrote to, and prepended a
+ * `--data-dir` flag qmd 2.0.1 does not have.
+ *
+ * What it exercises:
+ *   - `ensureCollections()` registers each `kb-*` collection at
+ *     `<exportDir>/<sourceSubdir>` (the git-exporter layout), mkdir'ing the
+ *     subdirs first so empty categories register cleanly.
+ *   - per-tenant XDG isolation via `getQmdTenantEnv` (no `--data-dir`).
+ *   - `update()` indexes the real files.
+ *   - `query()` parses qmd's `--json` output and surfaces the citation.
+ *
+ * Fully isolated: `TEAMKB_BASE_PATH` is repointed at a tmp dir so the tenant's
+ * XDG_CONFIG_HOME / XDG_CACHE_HOME (and thus the qmd registry + index) live in
+ * tmp and never touch the operator's personal `~/.config/qmd` / `~/.cache/qmd`.
+ * Skipped entirely when qmd is not on PATH (keeps CI without qmd green).
+ *
+ * @module __tests__/adapter-qmd-integration.test
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { QmdAdapter } from '../adapter.js';
+
+function qmdAvailable(): boolean {
+  try {
+    execFileSync('qmd', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const HAS_QMD = qmdAvailable();
+
+let workDir: string;
+let exportDir: string;
+let originalBasePath: string | undefined;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'qmd-adapter-int-'));
+  exportDir = join(workDir, 'kb-export');
+  // Repoint the team-KB base so getQmdTenantEnv → tmp XDG dirs (full isolation).
+  originalBasePath = process.env['TEAMKB_BASE_PATH'];
+  process.env['TEAMKB_BASE_PATH'] = join(workDir, 'teamkb');
+});
+
+afterEach(() => {
+  if (originalBasePath === undefined) delete process.env['TEAMKB_BASE_PATH'];
+  else process.env['TEAMKB_BASE_PATH'] = originalBasePath;
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+/** Write a markdown file into a git-exporter output subdir. */
+function writeExport(subdir: string, name: string, body: string): void {
+  const dir = join(exportDir, subdir);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), body, 'utf8');
+}
+
+describe.skipIf(!HAS_QMD)('QmdAdapter ↔ real qmd (production index path)', () => {
+  it('indexes the git-exporter output tree and returns a kb-curated citation', async () => {
+    // git-exporter writes an architecture memory into curated/
+    writeExport(
+      'curated',
+      'transformers.md',
+      '# Transformer attention mechanism\n\n' +
+        'The transformer attention mechanism computes scaled dot-product attention ' +
+        'over query, key, and value matrices. Self-attention lets the model weigh ' +
+        'sequence positions when producing each output representation.\n',
+    );
+
+    const adapter = new QmdAdapter({ tenantId: 'demo-e2e', exportDir });
+
+    const ensured = await adapter.ensureCollections();
+    expect(ensured.ok).toBe(true);
+    if (ensured.ok) {
+      // kb-inbox has no exported source, so it is NOT registered
+      expect(ensured.value).toEqual(['kb-curated', 'kb-decisions', 'kb-guides', 'kb-archive']);
+    }
+
+    const updated = await adapter.update();
+    expect(updated.ok).toBe(true);
+
+    const found = await adapter.query('attention');
+    expect(found.ok).toBe(true);
+    if (found.ok) {
+      expect(found.value.length).toBeGreaterThan(0);
+      const hit = found.value.find((r) => r.collection === 'kb-curated');
+      expect(hit).toBeDefined();
+      // The qmd:// URI is the citation: collection name + exported file path.
+      expect(hit!.file).toMatch(/qmd:\/\/kb-curated\/.*transformers\.md/);
+    }
+  }, 30000);
+
+  it('isolates tenants: a second tenant does not see the first tenant content', async () => {
+    writeExport(
+      'curated',
+      'transformers.md',
+      '# Transformer attention\n\nScaled dot-product attention over query/key/value.\n',
+    );
+
+    // Tenant A indexes the export tree.
+    const tenantA = new QmdAdapter({ tenantId: 'tenant-a', exportDir });
+    expect((await tenantA.ensureCollections()).ok).toBe(true);
+    expect((await tenantA.update()).ok).toBe(true);
+    const aHit = await tenantA.query('attention');
+    expect(aHit.ok).toBe(true);
+    if (aHit.ok) expect(aHit.value.length).toBeGreaterThan(0);
+
+    // Tenant B has its own (empty) export tree + its own XDG dirs → finds nothing.
+    const tenantBExport = join(workDir, 'kb-export-b');
+    const tenantB = new QmdAdapter({ tenantId: 'tenant-b', exportDir: tenantBExport });
+    expect((await tenantB.ensureCollections()).ok).toBe(true);
+    expect((await tenantB.update()).ok).toBe(true);
+    const bHit = await tenantB.query('attention');
+    expect(bHit.ok).toBe(true);
+    if (bHit.ok) expect(bHit.value).toHaveLength(0);
+  }, 30000);
+});

--- a/packages/qmd-adapter/src/__tests__/adapter.test.ts
+++ b/packages/qmd-adapter/src/__tests__/adapter.test.ts
@@ -1,18 +1,29 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { MockQmdExecutor } from '../executor/mock-executor.js';
 import { QmdAdapter } from '../adapter.js';
 
 describe('QmdAdapter', () => {
   let mock: MockQmdExecutor;
   let adapter: QmdAdapter;
+  let exportDir: string;
 
   beforeEach(() => {
     mock = new MockQmdExecutor();
-    adapter = new QmdAdapter({ tenantId: 'test-tenant' }, mock);
+    exportDir = mkdtempSync(join(tmpdir(), 'qmd-adapter-test-'));
+    adapter = new QmdAdapter({ tenantId: 'test-tenant', exportDir }, mock);
+  });
+
+  afterEach(() => {
+    rmSync(exportDir, { recursive: true, force: true });
   });
 
   it('delegates query to search client', async () => {
-    mock.queueSuccess('0.9\t/kb-curated/doc.md\tResult snippet');
+    mock.queueSuccess(
+      JSON.stringify([{ score: 0.9, file: 'qmd://kb-curated/doc.md', snippet: 'Result snippet' }]),
+    );
     const result = await adapter.query('test query');
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -33,15 +44,26 @@ describe('QmdAdapter', () => {
     expect(result.ok).toBe(true);
   });
 
-  it('delegates ensureCollections to collection manager', async () => {
+  it('delegates ensureCollections to collection manager (4 exportable collections)', async () => {
     mock.queueSuccess(''); // list
-    for (let i = 0; i < 5; i++) mock.queueSuccess(''); // adds
+    for (let i = 0; i < 4; i++) mock.queueSuccess(''); // adds
     const result = await adapter.ensureCollections();
     expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual(['kb-curated', 'kb-decisions', 'kb-guides', 'kb-archive']);
+    }
+    // Sources point at the export tree, not a per-tenant index dir
+    const firstAdd = mock.commands.find((c) => c[0] === 'collection' && c[1] === 'add');
+    expect(firstAdd?.[2]).toBe(join(exportDir, 'curated'));
   });
 
   it('enforces curated-only default on query', async () => {
-    mock.queueSuccess('0.9\t/kb-curated/a.md\tA\n0.8\t/kb-inbox/b.md\tB');
+    mock.queueSuccess(
+      JSON.stringify([
+        { score: 0.9, file: 'qmd://kb-curated/a.md', snippet: 'A' },
+        { score: 0.8, file: 'qmd://kb-inbox/b.md', snippet: 'B' },
+      ]),
+    );
     const result = await adapter.query('test');
     expect(result.ok).toBe(true);
     if (result.ok) {

--- a/packages/qmd-adapter/src/__tests__/collection-manager.test.ts
+++ b/packages/qmd-adapter/src/__tests__/collection-manager.test.ts
@@ -8,7 +8,7 @@ describe('CollectionManager', () => {
 
   beforeEach(() => {
     mock = new MockQmdExecutor();
-    manager = new CollectionManager(mock, '/tmp/test-data');
+    manager = new CollectionManager(mock);
   });
 
   describe('addCollection', () => {
@@ -65,24 +65,51 @@ describe('CollectionManager', () => {
   });
 
   describe('ensureCollections', () => {
-    it('creates missing collections', async () => {
+    it('creates the 4 exportable collections, sourced from export subdirs', async () => {
       // listCollections returns empty
       mock.queueSuccess('');
-      // 5 addCollection calls
-      for (let i = 0; i < 5; i++) {
+      // 4 addCollection calls (kb-inbox has no exported source)
+      for (let i = 0; i < 4; i++) {
         mock.queueSuccess('');
       }
-      const result = await manager.ensureCollections('/base/path');
+      const result = await manager.ensureCollections('/exports');
       expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.value).toHaveLength(5);
+        expect(result.value).toEqual(['kb-curated', 'kb-decisions', 'kb-guides', 'kb-archive']);
       }
+      // Each collection sources from its git-exporter subdir, not <base>/<name>
+      const addCommands = mock.commands.filter((c) => c[0] === 'collection' && c[1] === 'add');
+      expect(addCommands).toContainEqual([
+        'collection',
+        'add',
+        '/exports/curated',
+        '--name',
+        'kb-curated',
+      ]);
+      expect(addCommands).toContainEqual([
+        'collection',
+        'add',
+        '/exports/archive',
+        '--name',
+        'kb-archive',
+      ]);
+    });
+
+    it('does not register kb-inbox (no exported source)', async () => {
+      mock.queueSuccess(''); // list
+      for (let i = 0; i < 4; i++) mock.queueSuccess(''); // adds
+      const result = await manager.ensureCollections('/exports');
+      expect(result.ok).toBe(true);
+      const addedNames = mock.commands
+        .filter((c) => c[0] === 'collection' && c[1] === 'add')
+        .map((c) => c[c.length - 1]);
+      expect(addedNames).not.toContain('kb-inbox');
     });
 
     it('skips existing collections', async () => {
-      // listCollections returns all 5
-      mock.queueSuccess('kb-curated\nkb-decisions\nkb-guides\nkb-inbox\nkb-archive');
-      const result = await manager.ensureCollections('/base/path');
+      // listCollections returns all exportable collections already present
+      mock.queueSuccess('kb-curated\nkb-decisions\nkb-guides\nkb-archive');
+      const result = await manager.ensureCollections('/exports');
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.value).toHaveLength(0);

--- a/packages/qmd-adapter/src/__tests__/config.test.ts
+++ b/packages/qmd-adapter/src/__tests__/config.test.ts
@@ -6,6 +6,7 @@ import {
   getQmdIndexBasePath,
   getQmdTenantIndexPath,
   getQmdCollectionIndexPath,
+  getQmdTenantEnv,
 } from '../config.js';
 
 describe('qmd-adapter config', () => {
@@ -45,5 +46,13 @@ describe('qmd-adapter config', () => {
   it('respects TEAMKB_BASE_PATH override', () => {
     process.env['TEAMKB_BASE_PATH'] = '/custom';
     expect(getQmdTenantIndexPath('t1')).toBe('/custom/qmd-index/t1');
+  });
+
+  it('getQmdTenantEnv points XDG dirs at the tenant index path', () => {
+    process.env['TEAMKB_BASE_PATH'] = '/custom';
+    expect(getQmdTenantEnv('t1')).toEqual({
+      XDG_CONFIG_HOME: '/custom/qmd-index/t1/config',
+      XDG_CACHE_HOME: '/custom/qmd-index/t1/cache',
+    });
   });
 });

--- a/packages/qmd-adapter/src/__tests__/real-executor.test.ts
+++ b/packages/qmd-adapter/src/__tests__/real-executor.test.ts
@@ -17,8 +17,10 @@ const qmdAvailable = isQmdAvailable();
 describe('RealQmdExecutor', () => {
   const executor = new RealQmdExecutor();
 
-  it('respects dataDir option', () => {
-    const exec = new RealQmdExecutor({ dataDir: '/tmp/test-qmd' });
+  it('accepts an env option for XDG isolation', () => {
+    const exec = new RealQmdExecutor({
+      env: { XDG_CONFIG_HOME: '/tmp/cfg', XDG_CACHE_HOME: '/tmp/cache' },
+    });
     expect(exec).toBeDefined();
   });
 
@@ -37,6 +39,17 @@ describe('RealQmdExecutor', () => {
     it('handles invalid commands gracefully', async () => {
       const result = await executor.execute(['invalid-command-that-does-not-exist']);
       expect(result.exitCode).not.toBe(0);
+    }, 15000);
+
+    it('does not pass the (nonexistent) --data-dir flag to qmd', async () => {
+      // qmd 2.0.1 rejects unknown flags; --version must still succeed, proving
+      // we no longer prepend --data-dir. Isolation is via XDG_* env instead.
+      const exec = new RealQmdExecutor({
+        env: { XDG_CONFIG_HOME: '/tmp/qmd-iso-cfg', XDG_CACHE_HOME: '/tmp/qmd-iso-cache' },
+      });
+      const result = await exec.execute(['--version']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('qmd');
     }, 15000);
   });
 });

--- a/packages/qmd-adapter/src/__tests__/result-parser.test.ts
+++ b/packages/qmd-adapter/src/__tests__/result-parser.test.ts
@@ -2,37 +2,57 @@ import { describe, it, expect } from 'vitest';
 import { parseQueryOutput, deriveCollectionFromPath } from '../search/result-parser.js';
 
 describe('parseQueryOutput', () => {
-  it('parses tab-separated output', () => {
-    const output = '0.95\t/data/kb-curated/doc.md\tSome relevant snippet';
+  it('parses qmd --json output', () => {
+    const output = JSON.stringify([
+      {
+        docid: '#ba1275',
+        score: 0.95,
+        file: 'qmd://kb-curated/doc.md',
+        title: 'Doc',
+        snippet: 'Some relevant snippet',
+      },
+    ]);
     const results = parseQueryOutput(output);
     expect(results).toHaveLength(1);
     expect(results[0]!.score).toBe(0.95);
-    expect(results[0]!.file).toBe('/data/kb-curated/doc.md');
+    expect(results[0]!.file).toBe('qmd://kb-curated/doc.md');
     expect(results[0]!.snippet).toBe('Some relevant snippet');
     expect(results[0]!.collection).toBe('kb-curated');
   });
 
-  it('parses multiple lines', () => {
-    const output = '0.9\t/kb-curated/a.md\tA\n0.8\t/kb-guides/b.md\tB\n0.7\t/kb-inbox/c.md\tC';
+  it('parses multiple hits', () => {
+    const output = JSON.stringify([
+      { score: 0.9, file: 'qmd://kb-curated/a.md', snippet: 'A' },
+      { score: 0.8, file: 'qmd://kb-guides/b.md', snippet: 'B' },
+      { score: 0.7, file: 'qmd://kb-inbox/c.md', snippet: 'C' },
+    ]);
     const results = parseQueryOutput(output);
     expect(results).toHaveLength(3);
   });
 
-  it('handles empty output', () => {
+  it('handles empty / non-JSON / non-array output without throwing', () => {
     expect(parseQueryOutput('')).toHaveLength(0);
     expect(parseQueryOutput('\n')).toHaveLength(0);
+    expect(parseQueryOutput('not json at all')).toHaveLength(0);
+    expect(parseQueryOutput('{"file":"x"}')).toHaveLength(0); // object, not array
+    expect(parseQueryOutput('[]')).toHaveLength(0);
   });
 
-  it('handles non-numeric scores', () => {
-    const output = 'NaN\t/kb-curated/doc.md\tSnippet';
+  it('defaults missing / non-numeric scores to 0 and skips hits with no file', () => {
+    const output = JSON.stringify([
+      { file: 'qmd://kb-curated/doc.md', snippet: 'Snippet' }, // no score
+      { score: 0.5, snippet: 'orphan' }, // no file → skipped
+    ]);
     const results = parseQueryOutput(output);
+    expect(results).toHaveLength(1);
     expect(results[0]!.score).toBe(0);
+    expect(results[0]!.file).toBe('qmd://kb-curated/doc.md');
   });
 });
 
 describe('deriveCollectionFromPath', () => {
   it('derives kb-curated', () => {
-    expect(deriveCollectionFromPath('/data/kb-curated/doc.md')).toBe('kb-curated');
+    expect(deriveCollectionFromPath('qmd://kb-curated/doc.md')).toBe('kb-curated');
   });
 
   it('derives kb-inbox', () => {

--- a/packages/qmd-adapter/src/__tests__/search-client.test.ts
+++ b/packages/qmd-adapter/src/__tests__/search-client.test.ts
@@ -1,6 +1,20 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { MockQmdExecutor } from '../executor/mock-executor.js';
 import { SearchClient } from '../search/search-client.js';
+import type { QmdSearchResult } from '../types.js';
+
+/** Build a qmd `search --json` stdout payload from partial hits. */
+function jsonHits(hits: Array<Partial<QmdSearchResult>>): string {
+  return JSON.stringify(
+    hits.map((h, i) => ({
+      docid: `#${i}`,
+      score: h.score ?? 0.9,
+      file: h.file ?? '',
+      title: 'T',
+      snippet: h.snippet ?? '',
+    })),
+  );
+}
 
 describe('SearchClient', () => {
   let mock: MockQmdExecutor;
@@ -11,8 +25,10 @@ describe('SearchClient', () => {
     client = new SearchClient(mock);
   });
 
-  it('executes a search and returns results', async () => {
-    mock.queueSuccess('0.95\t/path/kb-curated/doc.md\tSome snippet');
+  it('executes a search (with --json) and returns results', async () => {
+    mock.queueSuccess(
+      jsonHits([{ score: 0.95, file: 'qmd://kb-curated/doc.md', snippet: 'snip' }]),
+    );
     const result = await client.search('test query');
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -20,15 +36,21 @@ describe('SearchClient', () => {
       expect(result.value[0]!.score).toBe(0.95);
       expect(result.value[0]!.collection).toBe('kb-curated');
     }
+    // The client must request JSON output and terminate option parsing
+    expect(mock.lastCommand).toEqual(['search', '--json', '--', 'test query']);
   });
 
   it('defaults scope to curated', async () => {
-    // Return results from mixed collections
-    mock.queueSuccess('0.9\t/kb-curated/a.md\tA\n0.8\t/kb-inbox/b.md\tB\n0.7\t/kb-guides/c.md\tC');
+    mock.queueSuccess(
+      jsonHits([
+        { file: 'qmd://kb-curated/a.md' },
+        { file: 'qmd://kb-inbox/b.md' },
+        { file: 'qmd://kb-guides/c.md' },
+      ]),
+    );
     const result = await client.search('test');
     expect(result.ok).toBe(true);
     if (result.ok) {
-      // Should filter out kb-inbox
       const collections = result.value.map((r) => r.collection);
       expect(collections).not.toContain('kb-inbox');
       expect(collections).toContain('kb-curated');
@@ -37,7 +59,13 @@ describe('SearchClient', () => {
   });
 
   it('scope "all" returns everything', async () => {
-    mock.queueSuccess('0.9\t/kb-curated/a.md\tA\n0.8\t/kb-inbox/b.md\tB\n0.7\t/kb-archive/c.md\tC');
+    mock.queueSuccess(
+      jsonHits([
+        { file: 'qmd://kb-curated/a.md' },
+        { file: 'qmd://kb-inbox/b.md' },
+        { file: 'qmd://kb-archive/c.md' },
+      ]),
+    );
     const result = await client.search('test', 'all');
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -46,7 +74,9 @@ describe('SearchClient', () => {
   });
 
   it('scope "inbox" only returns inbox results', async () => {
-    mock.queueSuccess('0.9\t/kb-curated/a.md\tA\n0.8\t/kb-inbox/b.md\tB');
+    mock.queueSuccess(
+      jsonHits([{ file: 'qmd://kb-curated/a.md' }, { file: 'qmd://kb-inbox/b.md' }]),
+    );
     const result = await client.search('test', 'inbox');
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -56,7 +86,9 @@ describe('SearchClient', () => {
   });
 
   it('scope "archived" only returns archive results', async () => {
-    mock.queueSuccess('0.9\t/kb-curated/a.md\tA\n0.8\t/kb-archive/b.md\tB');
+    mock.queueSuccess(
+      jsonHits([{ file: 'qmd://kb-curated/a.md' }, { file: 'qmd://kb-archive/b.md' }]),
+    );
     const result = await client.search('test', 'archived');
     expect(result.ok).toBe(true);
     if (result.ok) {

--- a/packages/qmd-adapter/src/adapter.ts
+++ b/packages/qmd-adapter/src/adapter.ts
@@ -1,3 +1,6 @@
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
 import type { Result } from '@qmd-team-intent-kb/common';
 import type { SearchScope } from '@qmd-team-intent-kb/schema';
 import type { QmdError, QmdHealthStatus, QmdSearchResult } from './types.js';
@@ -5,10 +8,11 @@ import type { QmdExecutor } from './executor/executor.js';
 import type { QmdAdapterConfig } from './config.js';
 import { RealQmdExecutor } from './executor/real-executor.js';
 import { CollectionManager } from './collections/collection-manager.js';
+import { getExportableCollections } from './collections/collection-registry.js';
 import { SearchClient } from './search/search-client.js';
 import { IndexLifecycleManager } from './index-manager/index-lifecycle.js';
 import { checkHealth } from './health/health-check.js';
-import { getQmdTenantIndexPath } from './config.js';
+import { getQmdTenantEnv } from './config.js';
 
 /** Facade class composing all qmd adapter managers */
 export class QmdAdapter {
@@ -16,18 +20,19 @@ export class QmdAdapter {
   readonly collections: CollectionManager;
   readonly search: SearchClient;
   readonly indexLifecycle: IndexLifecycleManager;
-  private readonly dataPath: string;
+  private readonly exportDir: string;
 
   constructor(config: QmdAdapterConfig, executor?: QmdExecutor) {
-    this.dataPath = getQmdTenantIndexPath(config.tenantId);
+    this.exportDir = config.exportDir;
     this.executor =
       executor ??
       new RealQmdExecutor({
         binary: config.qmdBinary,
         timeout: config.timeout,
-        dataDir: this.dataPath,
+        // Per-tenant isolation via XDG_* env, not the nonexistent --data-dir.
+        env: getQmdTenantEnv(config.tenantId),
       });
-    this.collections = new CollectionManager(this.executor, this.dataPath);
+    this.collections = new CollectionManager(this.executor);
     this.search = new SearchClient(this.executor);
     this.indexLifecycle = new IndexLifecycleManager(this.executor);
   }
@@ -50,8 +55,16 @@ export class QmdAdapter {
     return this.indexLifecycle.update();
   }
 
-  /** Ensure all known collections are set up */
+  /**
+   * Ensure all exportable collections are registered against the git-exporter
+   * output tree. Creates each collection's source subdir first so empty
+   * categories (e.g. no archived memories yet) still register cleanly —
+   * `qmd collection add` against a missing dir would fail.
+   */
   async ensureCollections(): Promise<Result<string[], QmdError>> {
-    return this.collections.ensureCollections(this.dataPath);
+    for (const def of getExportableCollections()) {
+      mkdirSync(join(this.exportDir, def.sourceSubdir), { recursive: true });
+    }
+    return this.collections.ensureCollections(this.exportDir);
   }
 }

--- a/packages/qmd-adapter/src/collections/collection-manager.ts
+++ b/packages/qmd-adapter/src/collections/collection-manager.ts
@@ -1,14 +1,13 @@
+import { join } from 'node:path';
+
 import type { Result } from '@qmd-team-intent-kb/common';
 import type { QmdError } from '../types.js';
 import type { QmdExecutor } from '../executor/executor.js';
-import { getAllCollectionNames } from './collection-registry.js';
+import { getExportableCollections } from './collection-registry.js';
 
 /** Manage qmd collections (add, remove, list) */
 export class CollectionManager {
-  constructor(
-    private readonly executor: QmdExecutor,
-    readonly dataPath: string,
-  ) {}
+  constructor(private readonly executor: QmdExecutor) {}
 
   /** Add a collection pointing to a directory */
   async addCollection(name: string, path: string): Promise<Result<void, QmdError>> {
@@ -66,18 +65,27 @@ export class CollectionManager {
     return { ok: true, value: collections };
   }
 
-  /** Ensure all known collections exist, creating missing ones */
-  async ensureCollections(basePath: string): Promise<Result<string[], QmdError>> {
+  /**
+   * Ensure every exportable collection exists, creating missing ones.
+   *
+   * Each collection's source is `<exportBaseDir>/<sourceSubdir>` — the
+   * git-exporter output tree — so `qmd update` indexes the markdown the
+   * exporter actually writes. Collections with no exported source (e.g.
+   * `kb-inbox`) are skipped. Callers must ensure the source subdirs exist
+   * before this runs (the adapter facade does this); `qmd collection add`
+   * against a missing dir would fail.
+   */
+  async ensureCollections(exportBaseDir: string): Promise<Result<string[], QmdError>> {
     const listResult = await this.listCollections();
     const existing = listResult.ok ? listResult.value : [];
 
     const created: string[] = [];
-    for (const name of getAllCollectionNames()) {
-      if (!existing.some((e) => e.includes(name))) {
-        const path = `${basePath}/${name}`;
-        const addResult = await this.addCollection(name, path);
+    for (const def of getExportableCollections()) {
+      if (!existing.some((e) => e.includes(def.name))) {
+        const path = join(exportBaseDir, def.sourceSubdir);
+        const addResult = await this.addCollection(def.name, path);
         if (!addResult.ok) return { ok: false, error: addResult.error };
-        created.push(name);
+        created.push(def.name);
       }
     }
     return { ok: true, value: created };

--- a/packages/qmd-adapter/src/collections/collection-registry.ts
+++ b/packages/qmd-adapter/src/collections/collection-registry.ts
@@ -3,6 +3,20 @@ export interface CollectionDef {
   name: string;
   description: string;
   includeInDefaultSearch: boolean;
+  /**
+   * Subdirectory under the git-exporter output dir that this collection's
+   * source markdown lives in, or `null` if the collection has no exported
+   * source (e.g. `kb-inbox` — unreviewed candidates stay in SQLite pre-
+   * governance and are never written to the export tree).
+   *
+   * These subdir names are the git-exporter output contract — they MUST stay
+   * in lock-step with `getCategoryDirectory` / `getDirectory` in
+   * `apps/git-exporter/src/formatter/directory-mapper.ts`. The qmd-adapter
+   * registers each collection's source at `<exportDir>/<sourceSubdir>` so
+   * `qmd update` indexes the files git-exporter actually writes. See ADR
+   * `000-docs/037-AT-DSGN-qmd-adapter-source-index-separation.md`.
+   */
+  sourceSubdir: string | null;
 }
 
 /** The 5 known collections with their default search inclusion */
@@ -11,26 +25,31 @@ export const KNOWN_COLLECTIONS: CollectionDef[] = [
     name: 'kb-curated',
     description: 'Curated, governance-approved team knowledge',
     includeInDefaultSearch: true,
+    sourceSubdir: 'curated',
   },
   {
     name: 'kb-decisions',
     description: 'Architectural and design decisions',
     includeInDefaultSearch: true,
+    sourceSubdir: 'decisions',
   },
   {
     name: 'kb-guides',
     description: 'How-to guides and onboarding documentation',
     includeInDefaultSearch: true,
+    sourceSubdir: 'guides',
   },
   {
     name: 'kb-inbox',
     description: 'Unreviewed memory candidates awaiting governance',
     includeInDefaultSearch: false,
+    sourceSubdir: null,
   },
   {
     name: 'kb-archive',
     description: 'Deprecated, superseded, or archived memories',
     includeInDefaultSearch: false,
+    sourceSubdir: 'archive',
   },
 ];
 
@@ -42,6 +61,18 @@ export function getDefaultSearchCollections(): string[] {
 /** Get all known collection names */
 export function getAllCollectionNames(): string[] {
   return KNOWN_COLLECTIONS.map((c) => c.name);
+}
+
+/** A collection that has a non-null exported source subdirectory. */
+export type ExportableCollectionDef = CollectionDef & { sourceSubdir: string };
+
+/**
+ * Get the collections that have an exported source directory, i.e. those the
+ * qmd-adapter can register against the git-exporter output tree. Excludes
+ * collections with a null `sourceSubdir` (e.g. `kb-inbox`).
+ */
+export function getExportableCollections(): ExportableCollectionDef[] {
+  return KNOWN_COLLECTIONS.filter((c): c is ExportableCollectionDef => c.sourceSubdir !== null);
 }
 
 /** Check if a collection name is known */

--- a/packages/qmd-adapter/src/config.ts
+++ b/packages/qmd-adapter/src/config.ts
@@ -1,3 +1,5 @@
+import { join } from 'node:path';
+
 import { resolveTeamKbPath } from '@qmd-team-intent-kb/common';
 
 /** Base directory for qmd indexes, isolated from personal qmd usage */
@@ -18,9 +20,34 @@ export function getQmdCollectionIndexPath(tenantId: string, collection: string):
   return resolveTeamKbPath(`${QMD_INDEX_DIR}/${tenantId}/${collection}`);
 }
 
+/**
+ * Environment overrides that isolate a tenant's qmd registry + index.
+ *
+ * qmd 2.0.1 reads its collection registry from `$XDG_CONFIG_HOME/qmd/index.yml`
+ * and its BM25 index from `$XDG_CACHE_HOME/qmd/index.sqlite`. Pointing both at
+ * tenant-scoped subdirs of the tenant index path gives full per-tenant
+ * isolation without the (nonexistent) `--data-dir` flag, and keeps the team
+ * KB's qmd state out of the operator's personal `~/.config/qmd` / `~/.cache/qmd`.
+ */
+export function getQmdTenantEnv(tenantId: string): Record<string, string> {
+  const base = getQmdTenantIndexPath(tenantId);
+  return {
+    XDG_CONFIG_HOME: join(base, 'config'),
+    XDG_CACHE_HOME: join(base, 'cache'),
+  };
+}
+
 /** Adapter configuration */
 export interface QmdAdapterConfig {
   tenantId: string;
+  /**
+   * Absolute path to the git-exporter output directory. The adapter registers
+   * each collection's source at `<exportDir>/<sourceSubdir>` so `qmd update`
+   * indexes the markdown git-exporter writes. Must resolve to the same dir the
+   * exporter writes to (the edge-daemon resolves `exportOutputDir` and passes
+   * it here).
+   */
+  exportDir: string;
   qmdBinary?: string;
   timeout?: number;
 }

--- a/packages/qmd-adapter/src/executor/real-executor.ts
+++ b/packages/qmd-adapter/src/executor/real-executor.ts
@@ -10,21 +10,30 @@ const execFileAsync = promisify(execFile);
 export class RealQmdExecutor implements QmdExecutor {
   private readonly binary: string;
   private readonly timeout: number;
-  private readonly dataDir: string | null;
+  private readonly env: Record<string, string> | null;
 
-  constructor(options?: { binary?: string; timeout?: number; dataDir?: string }) {
+  /**
+   * @param options.env Environment overrides merged over `process.env` for every
+   *   qmd invocation. qmd 2.0.1 has **no `--data-dir` flag** — per-tenant index
+   *   and registry isolation is achieved by pointing `XDG_CONFIG_HOME`
+   *   (collection registry) and `XDG_CACHE_HOME` (BM25 index) at tenant-scoped
+   *   dirs. See `getQmdTenantEnv` in `config.ts` and ADR
+   *   `000-docs/037-AT-DSGN-qmd-adapter-source-index-separation.md`.
+   */
+  constructor(options?: { binary?: string; timeout?: number; env?: Record<string, string> }) {
     this.binary = options?.binary ?? DEFAULT_QMD_BINARY;
     this.timeout = options?.timeout ?? DEFAULT_TIMEOUT;
-    this.dataDir = options?.dataDir ?? null;
+    this.env = options?.env ?? null;
   }
 
   async execute(args: string[]): Promise<CommandResult> {
-    const fullArgs = this.dataDir ? ['--data-dir', this.dataDir, ...args] : args;
-
     try {
-      const { stdout, stderr } = await execFileAsync(this.binary, fullArgs, {
+      const { stdout, stderr } = await execFileAsync(this.binary, args, {
         timeout: this.timeout,
         maxBuffer: 10 * 1024 * 1024,
+        // Merge over process.env so PATH (qmd discovery) is preserved while
+        // tenant-scoped XDG_* vars isolate the registry + index.
+        ...(this.env ? { env: { ...process.env, ...this.env } } : {}),
       });
       return { stdout, stderr, exitCode: 0 };
     } catch (e: unknown) {

--- a/packages/qmd-adapter/src/index.ts
+++ b/packages/qmd-adapter/src/index.ts
@@ -8,6 +8,7 @@ export {
   getQmdIndexBasePath,
   getQmdTenantIndexPath,
   getQmdCollectionIndexPath,
+  getQmdTenantEnv,
   DEFAULT_QMD_BINARY,
   DEFAULT_TIMEOUT,
 } from './config.js';
@@ -23,6 +24,7 @@ export {
   KNOWN_COLLECTIONS,
   getDefaultSearchCollections,
   getAllCollectionNames,
+  getExportableCollections,
   isKnownCollection,
   isDefaultSearchCollection,
 } from './collections/collection-registry.js';

--- a/packages/qmd-adapter/src/search/result-parser.ts
+++ b/packages/qmd-adapter/src/search/result-parser.ts
@@ -1,31 +1,60 @@
 import type { QmdSearchResult } from '../types.js';
 
-/** Parse qmd query output (which may include scores and metadata) */
+/**
+ * One entry of qmd 2.0.1's `search --json` output.
+ *
+ * Example:
+ * ```json
+ * { "docid": "#ba1275", "score": 0, "file": "qmd://kb-curated/transformers.md",
+ *   "title": "Transformer attention mechanism", "snippet": "@@ -1,3 @@ ..." }
+ * ```
+ */
+interface QmdJsonHit {
+  docid?: string;
+  score?: number;
+  file?: string;
+  title?: string;
+  snippet?: string;
+}
+
+/**
+ * Parse qmd's `search --json` / `query --json` output into typed results.
+ *
+ * qmd 2.0.1's default (non-JSON) output is a human-readable block that is not
+ * machine-parseable; the adapter always passes `--json` and parses the array
+ * here. Tolerant by design: empty input, non-array JSON, or a parse failure all
+ * yield `[]` rather than throwing, so a malformed qmd response degrades to "no
+ * results" instead of crashing the cycle.
+ */
 export function parseQueryOutput(stdout: string): QmdSearchResult[] {
-  const results: QmdSearchResult[] = [];
-  const lines = stdout.trim().split('\n').filter(Boolean);
+  const trimmed = stdout.trim();
+  if (!trimmed) return [];
 
-  for (const line of lines) {
-    // qmd query output: various formats, try tab-separated first
-    const tabParts = line.split('\t');
-    if (tabParts.length >= 2) {
-      const score = parseFloat(tabParts[0] ?? '0');
-      const file = tabParts[1] ?? '';
-      const snippet = tabParts.slice(2).join('\t');
-      const collection = deriveCollectionFromPath(file);
-      results.push({
-        file,
-        score: isNaN(score) ? 0 : score,
-        snippet,
-        collection,
-      });
-    }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return [];
   }
+  if (!Array.isArray(parsed)) return [];
 
+  const results: QmdSearchResult[] = [];
+  for (const raw of parsed) {
+    if (!raw || typeof raw !== 'object') continue;
+    const hit = raw as QmdJsonHit;
+    if (typeof hit.file !== 'string' || hit.file.length === 0) continue;
+    const score = typeof hit.score === 'number' && !Number.isNaN(hit.score) ? hit.score : 0;
+    results.push({
+      file: hit.file,
+      score,
+      snippet: typeof hit.snippet === 'string' ? hit.snippet : '',
+      collection: deriveCollectionFromPath(hit.file),
+    });
+  }
   return results;
 }
 
-/** Derive collection name from a file path */
+/** Derive collection name from a file path (qmd:// URI or filesystem path) */
 export function deriveCollectionFromPath(filePath: string): string {
   const knownCollections = ['kb-curated', 'kb-decisions', 'kb-guides', 'kb-inbox', 'kb-archive'];
   for (const name of knownCollections) {

--- a/packages/qmd-adapter/src/search/search-client.ts
+++ b/packages/qmd-adapter/src/search/search-client.ts
@@ -3,6 +3,7 @@ import type { SearchScope } from '@qmd-team-intent-kb/schema';
 import type { QmdError, QmdSearchResult } from '../types.js';
 import type { QmdExecutor } from '../executor/executor.js';
 import { getDefaultSearchCollections } from '../collections/collection-registry.js';
+import { parseQueryOutput } from './result-parser.js';
 
 /** Search client with curated-only default scope enforcement */
 export class SearchClient {
@@ -15,9 +16,10 @@ export class SearchClient {
   ): Promise<Result<QmdSearchResult[], QmdError>> {
     const collections = this.resolveCollections(scope);
 
-    // Use '--' to terminate option parsing so query strings like '--version'
-    // are not interpreted as CLI flags
-    const args = ['search', '--', query];
+    // `--json` gives machine-parseable output (qmd's default output is a
+    // human-readable block). `--` terminates option parsing so a query like
+    // '--version' is treated as a search term, not a flag.
+    const args = ['search', '--json', '--', query];
     const result = await this.executor.execute(args);
 
     if (result.exitCode !== 0) {
@@ -32,7 +34,7 @@ export class SearchClient {
       };
     }
 
-    const parsed = this.parseSearchResults(result.stdout);
+    const parsed = parseQueryOutput(result.stdout);
     // Filter to only allowed collections based on scope
     const filtered =
       scope === 'all' ? parsed : parsed.filter((r) => collections.includes(r.collection));
@@ -54,36 +56,5 @@ export class SearchClient {
       default:
         return getDefaultSearchCollections();
     }
-  }
-
-  /** Parse qmd search output into typed results */
-  private parseSearchResults(stdout: string): QmdSearchResult[] {
-    const results: QmdSearchResult[] = [];
-    const lines = stdout.trim().split('\n').filter(Boolean);
-
-    for (const line of lines) {
-      // qmd search output format: score\tfile\tsnippet
-      const parts = line.split('\t');
-      if (parts.length >= 2) {
-        const score = parseFloat(parts[0] ?? '0');
-        const file = parts[1] ?? '';
-        const snippet = parts.slice(2).join('\t');
-
-        // Derive collection from file path
-        const collection = this.deriveCollection(file);
-
-        results.push({ file, score: isNaN(score) ? 0 : score, snippet, collection });
-      }
-    }
-
-    return results;
-  }
-
-  /** Derive collection name from file path */
-  private deriveCollection(filePath: string): string {
-    for (const name of ['kb-curated', 'kb-decisions', 'kb-guides', 'kb-inbox', 'kb-archive']) {
-      if (filePath.includes(name)) return name;
-    }
-    return 'unknown';
   }
 }


### PR DESCRIPTION
## What

Closes the `e3q` root cause: the edge-daemon `QmdAdapter` never actually indexed curated memories. Three coupled defects, all from the adapter never being exercised against a real qmd 2.0.1 binary:

1. **Path disconnect** — collections were registered at `getQmdTenantIndexPath(tenant)/kb-*`, dirs git-exporter never wrote to (exporter writes `<exportDir>/{curated,decisions,guides,archive}/`).
2. **`--data-dir` doesn't exist in qmd 2.0.1** — `RealQmdExecutor` prepended it to every call → every command failed.
3. **Search parser assumed tab-separated output** — qmd emits a human-readable block, so `query()` returned `[]` even on a hit.

## How (Option A — see `037-AT-DSGN`)

Keep git-exporter's category layout as the source of truth; teach the adapter to index it.

- **collection-registry**: each `kb-*` collection carries a `sourceSubdir` (`curated`/`decisions`/`guides`/`archive`); `kb-inbox` has none (pre-governance candidates aren't exported). New `getExportableCollections()`.
- **collection-manager**: `ensureCollections(exportBaseDir)` registers each collection at `<exportBaseDir>/<sourceSubdir>` under its `kb-*` name.
- **adapter**: `mkdir -p` each source subdir first (empty categories register cleanly); per-tenant isolation via `getQmdTenantEnv` (`XDG_CONFIG_HOME` + `XDG_CACHE_HOME`), not `--data-dir`.
- **real-executor**: drop `--data-dir`; accept `env` merged over `process.env`.
- **search-client + result-parser**: request `search --json` and parse the structured array (tolerant of empty/malformed → `[]`).
- **edge-daemon main**: construct `QmdAdapter` with `exportDir = resolve(exportOutputDir)` so adapter + exporter share one path.

## Proof

`packages/qmd-adapter/src/__tests__/adapter-qmd-integration.test.ts` drives the **real qmd binary** through the production adapter: curated memory in `curated/` → `ensureCollections` → `update` → `query` → asserts a `qmd://kb-curated/...` citation, plus a per-tenant isolation case. Skipped when qmd is absent (CI without qmd stays green); runs locally + anywhere qmd 2.0.1+ is installed.

- **1389/1389 tests pass** (incl. 2 real-qmd integration tests), typecheck + lint clean.

## Out of scope

A *full-green* `demo-e2e.sh` run still needs a real `ANTHROPIC_API_KEY` for non-empty stage 1-2 content (ICO bead `u0j`). The adapter fix is verified independently with hand-crafted curated memories — no key required. The demo's stages 5-6 already prove the flow via the direct-qmd path (#158/#122); this PR makes the **production daemon adapter** correct.

Bead: `qmd-team-intent-kb-e3q`