### PR TITLE
docs: refresh qmd-version comments 2.0.1 → 2.x

### DIFF
--- a/apps/git-exporter/src/__tests__/cli-qmd-integration.test.ts
+++ b/apps/git-exporter/src/__tests__/cli-qmd-integration.test.ts
@@ -8,7 +8,7 @@
  * file-backed store, exactly the pattern the curator pipeline produces in
  * the live demo.
  *
- * It drives the REAL `qmd` binary (2.0.1+) with an isolated
+ * It drives the REAL `qmd` binary (2.x) with an isolated
  * XDG_CACHE_HOME so the test never touches the operator's personal qmd
  * index. The whole test is skipped if `qmd` is not on PATH (so CI without
  * qmd stays green) — but it runs locally + anywhere qmd is installed.

--- a/packages/qmd-adapter/src/__tests__/adapter-qmd-integration.test.ts
+++ b/packages/qmd-adapter/src/__tests__/adapter-qmd-integration.test.ts
@@ -7,7 +7,7 @@
  * returns curated memories with a `qmd://<collection>/...` citation. It closes
  * the original e3q root cause: the adapter used to register collections at a
  * per-tenant index path git-exporter never wrote to, and prepended a
- * `--data-dir` flag qmd 2.0.1 does not have.
+ * `--data-dir` flag qmd 2.x does not have.
  *
  * What it exercises:
  *   - `ensureCollections()` registers each `kb-*` collection at

--- a/packages/qmd-adapter/src/__tests__/real-executor.test.ts
+++ b/packages/qmd-adapter/src/__tests__/real-executor.test.ts
@@ -42,7 +42,7 @@ describe('RealQmdExecutor', () => {
     }, 15000);
 
     it('does not pass the (nonexistent) --data-dir flag to qmd', async () => {
-      // qmd 2.0.1 rejects unknown flags; --version must still succeed, proving
+      // qmd 2.x rejects unknown flags; --version must still succeed, proving
       // we no longer prepend --data-dir. Isolation is via XDG_* env instead.
       const exec = new RealQmdExecutor({
         env: { XDG_CONFIG_HOME: '/tmp/qmd-iso-cfg', XDG_CACHE_HOME: '/tmp/qmd-iso-cache' },

--- a/packages/qmd-adapter/src/config.ts
+++ b/packages/qmd-adapter/src/config.ts
@@ -23,7 +23,7 @@ export function getQmdCollectionIndexPath(tenantId: string, collection: string):
 /**
  * Environment overrides that isolate a tenant's qmd registry + index.
  *
- * qmd 2.0.1 reads its collection registry from `$XDG_CONFIG_HOME/qmd/index.yml`
+ * qmd 2.x reads its collection registry from `$XDG_CONFIG_HOME/qmd/index.yml`
  * and its BM25 index from `$XDG_CACHE_HOME/qmd/index.sqlite`. Pointing both at
  * tenant-scoped subdirs of the tenant index path gives full per-tenant
  * isolation without the (nonexistent) `--data-dir` flag, and keeps the team

--- a/packages/qmd-adapter/src/executor/real-executor.ts
+++ b/packages/qmd-adapter/src/executor/real-executor.ts
@@ -14,7 +14,7 @@ export class RealQmdExecutor implements QmdExecutor {
 
   /**
    * @param options.env Environment overrides merged over `process.env` for every
-   *   qmd invocation. qmd 2.0.1 has **no `--data-dir` flag** — per-tenant index
+   *   qmd invocation. qmd 2.x has **no `--data-dir` flag** — per-tenant index
    *   and registry isolation is achieved by pointing `XDG_CONFIG_HOME`
    *   (collection registry) and `XDG_CACHE_HOME` (BM25 index) at tenant-scoped
    *   dirs. See `getQmdTenantEnv` in `config.ts` and ADR

--- a/packages/qmd-adapter/src/search/result-parser.ts
+++ b/packages/qmd-adapter/src/search/result-parser.ts
@@ -1,7 +1,7 @@
 import type { QmdSearchResult } from '../types.js';
 
 /**
- * One entry of qmd 2.0.1's `search --json` output.
+ * One entry of qmd 2.x's `search --json` output.
  *
  * Example:
  * ```json
@@ -20,7 +20,7 @@ interface QmdJsonHit {
 /**
  * Parse qmd's `search --json` / `query --json` output into typed results.
  *
- * qmd 2.0.1's default (non-JSON) output is a human-readable block that is not
+ * qmd 2.x's default (non-JSON) output is a human-readable block that is not
  * machine-parseable; the adapter always passes `--json` and parses the array
  * here. Tolerant by design: empty input, non-array JSON, or a parse failure all
  * yield `[]` rather than throwing, so a malformed qmd response degrades to "no


### PR DESCRIPTION
Comment-only refresh. The adapter-contract comments (no `--data-dir`, `search --json`, XDG isolation) now read `qmd 2.x` instead of `qmd 2.0.1` — that behavior held across the 2.0.1→2.5.3 bump (#162), so version-agnostic wording won't re-stale on the next Dependabot bump.

Left untouched on purpose: the mock `--version` fixtures in health-check/adapter tests (test data, not comments) and ADR 037 (a point-in-time decision record that correctly documents the 2.0.1-era discovery).

No code change → behavior identical.