### PR TITLE
docs: add README banner (govern layer, constellation house style)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/banner-dark.svg">
+    <img alt="qmd-team-intent-kb — governed team memory for Claude Code. The govern layer." src="assets/banner-light.svg" width="860">
+  </picture>
+</p>
+
 # qmd-team-intent-kb
 
 **A governed team memory platform for Claude Code powered by qmd.**

--- a/assets/banner-dark.svg
+++ b/assets/banner-dark.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 340" width="1200" height="340" role="img" aria-label="qmd-team-intent-kb — the govern layer. Governed team memory for Claude Code.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0c1a2e"/><stop offset="1" stop-color="#070d18"/></linearGradient>
+    <radialGradient id="glow" cx="0.12" cy="0.08" r="0.55"><stop offset="0" stop-color="#0ea5e9" stop-opacity="0.32"/><stop offset="1" stop-color="#0ea5e9" stop-opacity="0"/></radialGradient>
+    <linearGradient id="rule" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#38bdf8"/><stop offset="1" stop-color="#0ea5e9"/></linearGradient>
+  </defs>
+  <rect width="1200" height="340" fill="url(#bg)"/>
+  <rect width="1200" height="340" fill="url(#glow)"/>
+  <text x="80" y="114" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="52" font-weight="700" fill="#f8fafc" letter-spacing="-1">qmd-team-intent-kb</text>
+  <rect x="84" y="136" width="134" height="5" rx="2.5" fill="url(#rule)"/>
+  <text x="84" y="190" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="27" font-weight="700" fill="#38bdf8">Governed team memory for Claude Code.</text>
+  <text x="84" y="224" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="19" fill="#94a3b8">Deterministic policy  &#183;  append-only audit  &#183;  qmd-backed retrieval</text>
+  <g font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="16" font-weight="700">
+    <rect x="84" y="276" width="150" height="42" rx="21" fill="none" stroke="#334155" stroke-width="1.5"/>
+    <text x="159" y="303" text-anchor="middle" fill="#475569">COMPILE</text>
+    <text x="250" y="304" text-anchor="middle" fill="#334155" font-size="20">&#8594;</text>
+    <rect x="266" y="276" width="150" height="42" rx="21" fill="#0ea5e9"/>
+    <text x="341" y="303" text-anchor="middle" fill="#ffffff">GOVERN</text>
+    <text x="432" y="304" text-anchor="middle" fill="#334155" font-size="20">&#8594;</text>
+    <rect x="448" y="276" width="150" height="42" rx="21" fill="none" stroke="#334155" stroke-width="1.5"/>
+    <text x="523" y="303" text-anchor="middle" fill="#475569">RETRIEVE</text>
+  </g>
+  <text x="636" y="303" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#64748b">the govern layer of compile-then-govern</text>
+</svg>

--- a/assets/banner-light.svg
+++ b/assets/banner-light.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 340" width="1200" height="340" role="img" aria-label="qmd-team-intent-kb — the govern layer. Governed team memory for Claude Code.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#eef6fb"/></linearGradient>
+    <radialGradient id="glow" cx="0.12" cy="0.08" r="0.55"><stop offset="0" stop-color="#0ea5e9" stop-opacity="0.18"/><stop offset="1" stop-color="#0ea5e9" stop-opacity="0"/></radialGradient>
+    <linearGradient id="rule" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#0ea5e9"/><stop offset="1" stop-color="#0284c7"/></linearGradient>
+  </defs>
+  <rect width="1200" height="340" fill="url(#bg)"/>
+  <rect width="1200" height="340" fill="url(#glow)"/>
+  <text x="80" y="114" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="52" font-weight="700" fill="#0f172a" letter-spacing="-1">qmd-team-intent-kb</text>
+  <rect x="84" y="136" width="134" height="5" rx="2.5" fill="url(#rule)"/>
+  <text x="84" y="190" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="27" font-weight="700" fill="#0284c7">Governed team memory for Claude Code.</text>
+  <text x="84" y="224" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="19" fill="#475569">Deterministic policy  &#183;  append-only audit  &#183;  qmd-backed retrieval</text>
+  <g font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="16" font-weight="700">
+    <rect x="84" y="276" width="150" height="42" rx="21" fill="none" stroke="#cbd5e1" stroke-width="1.5"/>
+    <text x="159" y="303" text-anchor="middle" fill="#94a3b8">COMPILE</text>
+    <text x="250" y="304" text-anchor="middle" fill="#cbd5e1" font-size="20">&#8594;</text>
+    <rect x="266" y="276" width="150" height="42" rx="21" fill="#0ea5e9"/>
+    <text x="341" y="303" text-anchor="middle" fill="#ffffff">GOVERN</text>
+    <text x="432" y="304" text-anchor="middle" fill="#cbd5e1" font-size="20">&#8594;</text>
+    <rect x="448" y="276" width="150" height="42" rx="21" fill="none" stroke="#cbd5e1" stroke-width="1.5"/>
+    <text x="523" y="303" text-anchor="middle" fill="#94a3b8">RETRIEVE</text>
+  </g>
+  <text x="636" y="303" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14" fill="#94a3b8">the govern layer of compile-then-govern</text>
+</svg>


### PR DESCRIPTION
Adds a theme-aware SVG banner to the README hero (dark/light via `<picture>`), matching the [Compile-Then-Govern umbrella](https://github.com/intent-solutions-io/compile-then-govern) house style — same sky-blue palette + COMPILE→GOVERN→RETRIEVE motif, with **GOVERN** highlighted to show INTKB's role. Visual consistency across the constellation. Docs/assets only.