### PR TITLE
feat(eval-surface): QMD functional eval surface — 3 evaluators

### DIFF
--- a/packages/eval-surface/package.json
+++ b/packages/eval-surface/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@qmd-team-intent-kb/eval-surface",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@qmd-team-intent-kb/common": "workspace:*",
+    "@qmd-team-intent-kb/schema": "workspace:*",
+    "@qmd-team-intent-kb/store": "workspace:*"
+  },
+  "devDependencies": {
+    "@qmd-team-intent-kb/test-fixtures": "workspace:*"
+  }
+}

--- a/packages/eval-surface/src/__tests__/eval-surface.test.ts
+++ b/packages/eval-surface/src/__tests__/eval-surface.test.ts
@@ -1,0 +1,150 @@
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import { AuditRepository, MemoryRepository, createTestDatabase } from '@qmd-team-intent-kb/store';
+import { DEFAULT_TENANT, makeMemory } from '@qmd-team-intent-kb/test-fixtures';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  evaluateDedupCatchRate,
+  evaluateMemoryUtility,
+  evaluateProvenanceIntegrity,
+} from '../index.js';
+
+// Infer the db type from the factory so this package needs no direct
+// better-sqlite3 dependency (it's a transitive dep of @qmd-team-intent-kb/store).
+let db: ReturnType<typeof createTestDatabase>;
+let memRepo: MemoryRepository;
+let auditRepo: AuditRepository;
+
+beforeEach(() => {
+  db = createTestDatabase();
+  memRepo = new MemoryRepository(db);
+  auditRepo = new AuditRepository(db);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+// ---------------------------------------------------------------------------
+// memory-utility
+// ---------------------------------------------------------------------------
+
+describe('evaluateMemoryUtility', () => {
+  it('passes vacuously with no probes', () => {
+    const r = evaluateMemoryUtility(memRepo, []);
+    expect(r.passed).toBe(true);
+    expect(r.score).toBe(1);
+  });
+
+  it('scores recall@k for the expected memory surfaced by search', () => {
+    const m = makeMemory({
+      content: 'Zod schemas validate every API endpoint input boundary',
+      title: 'validation',
+    });
+    memRepo.insert(m);
+
+    const r = evaluateMemoryUtility(memRepo, [
+      { query: 'Zod schemas validate input', tenantId: DEFAULT_TENANT, expectedMemoryIds: [m.id] },
+    ]);
+    expect(r.name).toBe('memory-utility');
+    expect(r.score).toBe(1);
+    expect(r.passed).toBe(true);
+    expect(r.details.probes_scored).toBe(1);
+  });
+
+  it('fails when the expected memory is not retrievable', () => {
+    memRepo.insert(makeMemory({ content: 'totally unrelated content about widgets' }));
+    const r = evaluateMemoryUtility(
+      memRepo,
+      [
+        {
+          query: 'nonexistent quantum entanglement topic',
+          tenantId: DEFAULT_TENANT,
+          expectedMemoryIds: ['missing-id'],
+        },
+      ],
+      { threshold: 0.8 },
+    );
+    expect(r.score).toBe(0);
+    expect(r.passed).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dedup-catch-rate
+// ---------------------------------------------------------------------------
+
+describe('evaluateDedupCatchRate', () => {
+  it('passes vacuously with no probes', () => {
+    expect(evaluateDedupCatchRate(memRepo, []).passed).toBe(true);
+  });
+
+  it('catches an exact-content duplicate of a stored memory', () => {
+    const content = 'Decisions are recorded as dated AT-DECR documents';
+    memRepo.insert(makeMemory({ content }));
+
+    const r = evaluateDedupCatchRate(memRepo, [
+      { nearDuplicateContent: content, tenantId: DEFAULT_TENANT, originalMemoryId: 'x' },
+    ]);
+    expect(r.name).toBe('dedup-catch-rate');
+    expect(r.details.caught).toBe(1);
+    expect(r.score).toBe(1);
+    expect(r.passed).toBe(true);
+  });
+
+  it('does NOT flag genuinely distinct content (false-positive guard)', () => {
+    memRepo.insert(makeMemory({ content: 'the original stored memory text' }));
+    const r = evaluateDedupCatchRate(memRepo, [
+      {
+        nearDuplicateContent: 'completely different memory text that was never stored',
+        tenantId: DEFAULT_TENANT,
+        originalMemoryId: 'x',
+      },
+    ]);
+    // A non-duplicate must NOT be caught — catch_rate 0 against a 1.0 threshold = fail,
+    // which correctly signals "this probe was not actually a duplicate".
+    expect(r.details.caught).toBe(0);
+  });
+
+  it('reports the honest scope (exact-hash, not semantic)', () => {
+    memRepo.insert(makeMemory({ content: 'a stored memory' }));
+    const r = evaluateDedupCatchRate(memRepo, [
+      { nearDuplicateContent: 'a stored memory', tenantId: DEFAULT_TENANT, originalMemoryId: 'x' },
+    ]);
+    expect(String(r.details.scope ?? '')).toContain('exact-content-hash');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// provenance-integrity
+// ---------------------------------------------------------------------------
+
+describe('evaluateProvenanceIntegrity', () => {
+  it('passes on a clean store (consistent hashes, intact chain)', () => {
+    memRepo.insert(makeMemory({ content: 'clean memory one' }));
+    memRepo.insert(makeMemory({ content: 'clean memory two' }));
+    const r = evaluateProvenanceIntegrity(memRepo, auditRepo, { tenantId: DEFAULT_TENANT });
+    expect(r.name).toBe('provenance-integrity');
+    expect(r.details.content_hash_mismatches).toBe(0);
+    expect(r.details.audit_chain_breaks).toBe(0);
+    expect(r.passed).toBe(true);
+  });
+
+  it('detects a content-hash mismatch (content altered after fingerprinting)', () => {
+    // Force an inconsistent record: contentHash does not match the content.
+    const tampered = makeMemory({
+      content: 'this is the real content',
+      contentHash: computeContentHash('a DIFFERENT string than the content'),
+    });
+    memRepo.insert(tampered);
+    const r = evaluateProvenanceIntegrity(memRepo, auditRepo, { tenantId: DEFAULT_TENANT });
+    expect(r.details.content_hash_mismatches).toBe(1);
+    expect(r.passed).toBe(false);
+  });
+
+  it('passes on an empty store', () => {
+    const r = evaluateProvenanceIntegrity(memRepo, auditRepo, { tenantId: DEFAULT_TENANT });
+    expect(r.passed).toBe(true);
+    expect(r.score).toBe(1);
+  });
+});

--- a/packages/eval-surface/src/dedup-catchrate.ts
+++ b/packages/eval-surface/src/dedup-catchrate.ts
@@ -1,0 +1,68 @@
+/**
+ * dedup-catch-rate evaluator — does the store's dedup mechanism catch duplicates?
+ *
+ * IMPORTANT scope note: QMD's promotion-time dedup is EXACT content-hash matching
+ * (SHA-256 via computeContentHash, compared against existing hashes) — it is NOT
+ * semantic / near-duplicate detection. This evaluator therefore measures the
+ * thing dedup actually does: it injects probes whose content is byte-identical to
+ * an already-stored memory and verifies the catch, and (as a false-positive
+ * guard) verifies that genuinely distinct content is NOT flagged. We do not claim
+ * to measure fuzzy near-dup catch the system doesn't perform.
+ *
+ * Pure: takes a MemoryRepository + probes, returns a verdict. No emit, no sign.
+ */
+
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type { MemoryRepository } from '@qmd-team-intent-kb/store';
+
+import type { DedupProbe, EvaluatorResult } from './types.js';
+
+const DEFAULT_THRESHOLD = 1.0; // exact-dup catch should be perfect; anything less is a real miss
+
+export interface DedupCatchRateOptions {
+  /** Catch-rate pass threshold in [0,1]. Default 1.0 (exact dedup must be perfect). */
+  readonly threshold?: number;
+}
+
+export function evaluateDedupCatchRate(
+  repo: MemoryRepository,
+  probes: readonly DedupProbe[],
+  options: DedupCatchRateOptions = {},
+): EvaluatorResult {
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD;
+
+  if (probes.length === 0) {
+    return {
+      name: 'dedup-catch-rate',
+      passed: true,
+      score: 1,
+      threshold,
+      details: { probes: 0, note: 'no probes — vacuously passes' },
+    };
+  }
+
+  // The store's existing-content fingerprint set — the same surface dedup checks.
+  const existingHashes = new Set(repo.getAllContentHashes());
+
+  let caught = 0;
+  for (const probe of probes) {
+    const hash = computeContentHash(probe.nearDuplicateContent);
+    if (existingHashes.has(hash)) caught += 1;
+  }
+
+  const catchRate = caught / probes.length;
+
+  return {
+    name: 'dedup-catch-rate',
+    passed: catchRate >= threshold,
+    score: catchRate,
+    threshold,
+    details: {
+      probes: probes.length,
+      caught,
+      missed: probes.length - caught,
+      catch_rate: Number(catchRate.toFixed(4)),
+      scope: 'exact-content-hash (not semantic near-dup)',
+    },
+  };
+}

--- a/packages/eval-surface/src/index.ts
+++ b/packages/eval-surface/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @qmd-team-intent-kb/eval-surface — QMD's functional eval surface.
+ *
+ * Three pure evaluators that measure whether the curated memory store is doing
+ * its job, each returning an Evidence-Bundle-friendly EvaluatorResult:
+ *  - memory-utility       — retrieval recall@k against held-out probes
+ *  - dedup-catch-rate     — exact content-hash dedup catch (+ false-positive guard)
+ *  - provenance-integrity — per-memory content-hash consistency + audit-chain intactness
+ *
+ * This package MEASURES. It does not emit or sign Evidence Bundles — wiring the
+ * results into a signed bundle at promotion time is bead tr08.19. Keeping
+ * measurement pure (no I/O beyond the repositories handed in) makes each
+ * evaluator independently testable and side-effect-free.
+ */
+
+export { evaluateMemoryUtility, type MemoryUtilityOptions } from './memory-utility.js';
+export { evaluateDedupCatchRate, type DedupCatchRateOptions } from './dedup-catchrate.js';
+export {
+  evaluateProvenanceIntegrity,
+  type ProvenanceIntegrityOptions,
+} from './provenance-integrity.js';
+export type { EvaluatorResult, RetrievalProbe, DedupProbe } from './types.js';

--- a/packages/eval-surface/src/memory-utility.ts
+++ b/packages/eval-surface/src/memory-utility.ts
@@ -1,0 +1,69 @@
+/**
+ * memory-utility evaluator — does the curated store actually retrieve the right
+ * memories for a query?
+ *
+ * For each probe (query + the memory ids that should surface), we run the store's
+ * real text search and measure recall@k: of the expected memories, how many
+ * appear in the top-k results. The aggregate score is mean recall across probes;
+ * the verdict passes iff mean recall >= threshold.
+ *
+ * Pure: takes a MemoryRepository and probes, returns a verdict. No emit, no sign.
+ */
+
+import type { MemoryRepository } from '@qmd-team-intent-kb/store';
+
+import type { EvaluatorResult, RetrievalProbe } from './types.js';
+
+const DEFAULT_K = 5;
+const DEFAULT_THRESHOLD = 0.8;
+
+export interface MemoryUtilityOptions {
+  /** Mean-recall pass threshold in [0,1]. Default 0.8. */
+  readonly threshold?: number;
+}
+
+export function evaluateMemoryUtility(
+  repo: MemoryRepository,
+  probes: readonly RetrievalProbe[],
+  options: MemoryUtilityOptions = {},
+): EvaluatorResult {
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD;
+
+  if (probes.length === 0) {
+    return {
+      name: 'memory-utility',
+      passed: true,
+      score: 1,
+      threshold,
+      details: { probes: 0, note: 'no probes — vacuously passes' },
+    };
+  }
+
+  let recallSum = 0;
+  let probesWithExpectations = 0;
+
+  for (const probe of probes) {
+    const k = probe.k ?? DEFAULT_K;
+    if (probe.expectedMemoryIds.length === 0) continue;
+    probesWithExpectations += 1;
+
+    const hits = repo.searchByText(probe.query, probe.tenantId);
+    const topKIds = new Set(hits.slice(0, k).map((m) => m.id));
+    const found = probe.expectedMemoryIds.filter((id) => topKIds.has(id)).length;
+    recallSum += found / probe.expectedMemoryIds.length;
+  }
+
+  const meanRecall = probesWithExpectations === 0 ? 1 : recallSum / probesWithExpectations;
+
+  return {
+    name: 'memory-utility',
+    passed: meanRecall >= threshold,
+    score: meanRecall,
+    threshold,
+    details: {
+      probes: probes.length,
+      probes_scored: probesWithExpectations,
+      mean_recall_at_k: Number(meanRecall.toFixed(4)),
+    },
+  };
+}

--- a/packages/eval-surface/src/provenance-integrity.ts
+++ b/packages/eval-surface/src/provenance-integrity.ts
@@ -1,0 +1,83 @@
+/**
+ * provenance-integrity evaluator — is every curated memory's provenance sound,
+ * and is the audit chain intact?
+ *
+ * Two layers of "can you trust this memory":
+ *  1. Per-memory content integrity — does each memory's stored `contentHash`
+ *     actually match the SHA-256 of its `content`? A mismatch means the content
+ *     was altered after the fingerprint was recorded (tampering / corruption).
+ *  2. Audit-chain integrity — does the store's append-only SHA-256 audit chain
+ *     verify end to end (no broken links)?
+ *
+ * The verdict passes iff every memory's content hash is consistent AND the audit
+ * chain has zero breaks.
+ *
+ * Pure: takes the memory + audit repositories, returns a verdict. No emit, no
+ * sign. (Note: `verifyAuditChain` walks the global chain by design — it is a
+ * single append-only ledger across tenants. A tenant-scoped bundle-exposing API
+ * is a separate hardening concern, tracked at bead tr08.21.)
+ */
+
+import { computeContentHash } from '@qmd-team-intent-kb/common';
+import type { AuditRepository, MemoryRepository } from '@qmd-team-intent-kb/store';
+import { verifyAuditChain } from '@qmd-team-intent-kb/store';
+
+import type { EvaluatorResult } from './types.js';
+
+const VALID_SOURCES = new Set(['claude_session', 'manual', 'import', 'mcp']);
+
+export interface ProvenanceIntegrityOptions {
+  /** Tenant to scope the per-memory content-integrity walk. Omit = all tenants. */
+  readonly tenantId?: string;
+}
+
+export function evaluateProvenanceIntegrity(
+  memoryRepo: MemoryRepository,
+  auditRepo: AuditRepository,
+  options: ProvenanceIntegrityOptions = {},
+): EvaluatorResult {
+  const memories =
+    options.tenantId !== undefined
+      ? memoryRepo.findByTenant(options.tenantId)
+      : allMemories(memoryRepo);
+
+  let contentHashMismatches = 0;
+  let invalidSources = 0;
+  for (const m of memories) {
+    if (computeContentHash(m.content) !== m.contentHash) contentHashMismatches += 1;
+    if (!VALID_SOURCES.has(m.source)) invalidSources += 1;
+  }
+
+  const chain = verifyAuditChain(auditRepo);
+  const chainBreaks = chain.breaks.length;
+
+  const passed = contentHashMismatches === 0 && invalidSources === 0 && chainBreaks === 0;
+  // Score: fraction of all integrity checks that held (memories × 2 checks + chain).
+  const totalChecks = memories.length * 2 + 1;
+  const failedChecks = contentHashMismatches + invalidSources + (chainBreaks > 0 ? 1 : 0);
+  const score = totalChecks === 0 ? 1 : (totalChecks - failedChecks) / totalChecks;
+
+  return {
+    name: 'provenance-integrity',
+    passed,
+    score: Number(score.toFixed(4)),
+    threshold: 1.0,
+    details: {
+      memories_checked: memories.length,
+      content_hash_mismatches: contentHashMismatches,
+      invalid_sources: invalidSources,
+      audit_chain_rows: chain.totalRows,
+      audit_chain_breaks: chainBreaks,
+    },
+  };
+}
+
+/** Gather memories across all tenants via the per-tenant index. */
+function allMemories(repo: MemoryRepository): ReturnType<MemoryRepository['findByTenant']> {
+  const byTenant = repo.countByTenant();
+  const out: ReturnType<MemoryRepository['findByTenant']> = [];
+  for (const tenantId of Object.keys(byTenant)) {
+    out.push(...repo.findByTenant(tenantId));
+  }
+  return out;
+}

--- a/packages/eval-surface/src/types.ts
+++ b/packages/eval-surface/src/types.ts
@@ -1,0 +1,46 @@
+/**
+ * eval-surface types — the structured results the three evaluators produce.
+ *
+ * These shapes are deliberately Evidence-Bundle-friendly: each evaluator yields
+ * an `EvaluatorResult` with a stable `name`, a binary `passed`, a numeric
+ * `score` in [0,1], a `threshold`, and a `details` map. The wiring bead
+ * (tr08.19) rolls a set of these into a canonical Evidence Bundle via
+ * @intentsolutions/core, naming each subject `qmd:<name>` and hashing the
+ * verdict. This package stays pure: it measures, it does not emit or sign.
+ */
+
+/** A single evaluator's verdict. */
+export interface EvaluatorResult {
+  /** Stable evaluator id, e.g. `memory-utility`. Used in the bundle subject name. */
+  readonly name: string;
+  /** Binary outcome — the platform refuses gradient "scores" as the verdict. */
+  readonly passed: boolean;
+  /** Continuous quality measure in [0,1] for reporting (NOT the pass/fail decision). */
+  readonly score: number;
+  /** Pass threshold the score was compared against. */
+  readonly threshold: number;
+  /** Structured, JSON-serializable detail for the report + bundle payload. */
+  readonly details: Record<string, number | string | boolean>;
+}
+
+/** One query→expected-memory probe for the memory-utility evaluator. */
+export interface RetrievalProbe {
+  /** Natural-language query fed to the store's text search. */
+  readonly query: string;
+  /** Tenant scope for the search (isolation is per-tenant by design). */
+  readonly tenantId: string;
+  /** Ids of memories that SHOULD appear in the top-k results. */
+  readonly expectedMemoryIds: readonly string[];
+  /** Top-k cutoff. Defaults applied by the evaluator when omitted. */
+  readonly k?: number;
+}
+
+/** One near-duplicate probe for the dedup-catch-rate evaluator. */
+export interface DedupProbe {
+  /** Content known to be a near-duplicate of an already-stored memory. */
+  readonly nearDuplicateContent: string;
+  /** Tenant scope. */
+  readonly tenantId: string;
+  /** Id of the original memory this should be recognized as a duplicate of. */
+  readonly originalMemoryId: string;
+}

--- a/packages/eval-surface/tsconfig.json
+++ b/packages/eval-surface/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../schema" },
+    { "path": "../store" },
+    { "path": "../common" },
+    { "path": "../test-fixtures" }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,6 +264,22 @@ importers:
 
   packages/common: {}
 
+  packages/eval-surface:
+    dependencies:
+      '@qmd-team-intent-kb/common':
+        specifier: workspace:*
+        version: link:../common
+      '@qmd-team-intent-kb/schema':
+        specifier: workspace:*
+        version: link:../schema
+      '@qmd-team-intent-kb/store':
+        specifier: workspace:*
+        version: link:../store
+    devDependencies:
+      '@qmd-team-intent-kb/test-fixtures':
+        specifier: workspace:*
+        version: link:../test-fixtures
+
   packages/policy-engine:
     dependencies:
       '@qmd-team-intent-kb/claude-runtime':


### PR DESCRIPTION
Bead `bd_000-projects-tr08.17` (Move 3). New `packages/eval-surface` with three pure, testable evaluators measuring whether the curated store works. Each returns an Evidence-Bundle-friendly result; wiring into a signed bundle at promotion is the next bead (tr08.19). **Measures only — no emit, no sign.**

- **memory-utility** — retrieval recall@k via the store's real `searchByText`.
- **dedup-catch-rate** — drives the *actual* dedup (exact SHA-256 content-hash). Honestly scoped: exact-dup catch, NOT semantic near-dup the system doesn't do; scope stated in details + docs. False-positive guard included.
- **provenance-integrity** — per-memory content-hash consistency + audit-chain intactness (`verifyAuditChain`).

Grounded in the real store API + `makeMemory` fixture. 10 tests (recall, exact-dup catch + false-positive, provenance clean/tampered/empty). Build + typecheck + lint clean; dist emits. No new third-party deps. Tenant-scoping a bundle-exposing read API tracked separately at tr08.21.

Refs `bd_000-projects-tr08.17`.

- Jeremy Longshore
intentsolutions.io