### PR TITLE
feat(curator): wire optional evalCallback into promote() — emit eval-result events

### DIFF
--- a/apps/curator/src/__tests__/promoter.test.ts
+++ b/apps/curator/src/__tests__/promoter.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@qmd-team-intent-kb/store';
 import { computeContentHash } from '@qmd-team-intent-kb/common';
 import type { PipelineResult } from '@qmd-team-intent-kb/policy-engine';
-import { promote } from '../promotion/promoter.js';
+import { promote, type EvalResultRecord } from '../promotion/promoter.js';
 import { makeCandidate, makeCuratedMemory, TENANT } from './fixtures.js';
 
 function makePipelineResult(overrides?: Partial<PipelineResult>): PipelineResult {
@@ -292,5 +292,91 @@ describe('promote', () => {
     expect(memory.promotedAt >= before).toBe(true);
     expect(memory.promotedAt <= after).toBe(true);
     expect(memory.updatedAt).toBe(memory.promotedAt);
+  });
+});
+
+describe('promote — eval callback (Evidence emission)', () => {
+  let memoryRepo: MemoryRepository;
+  let auditRepo: AuditRepository;
+
+  beforeEach(() => {
+    const db = createTestDatabase();
+    memoryRepo = new MemoryRepository(db);
+    auditRepo = new AuditRepository(db);
+  });
+
+  it('emits an eval-result audit event per verdict the callback returns', () => {
+    const candidate = makeCandidate();
+    const contentHash = computeContentHash(candidate.content);
+    const memory = promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult() },
+      memoryRepo,
+      auditRepo,
+      false,
+      undefined,
+      (): EvalResultRecord[] => [
+        { name: 'memory-utility', passed: true, score: 1, threshold: 0.8, details: { probes: 3 } },
+        { name: 'provenance-integrity', passed: true, score: 1, threshold: 1, details: {} },
+      ],
+    );
+
+    const evalEvents = auditRepo.findByMemory(memory.id).filter((e) => e.action === 'eval-result');
+    expect(evalEvents).toHaveLength(2);
+    expect(evalEvents.map((e) => e.details.evaluator).sort()).toEqual([
+      'memory-utility',
+      'provenance-integrity',
+    ]);
+    expect(evalEvents.every((e) => e.details.passed === true)).toBe(true);
+  });
+
+  it('does not emit eval-result events when no callback is supplied', () => {
+    const candidate = makeCandidate();
+    const memory = promote(
+      {
+        candidate,
+        contentHash: computeContentHash(candidate.content),
+        pipelineResult: makePipelineResult(),
+      },
+      memoryRepo,
+      auditRepo,
+    );
+    expect(auditRepo.findByAction('eval-result')).toHaveLength(0);
+    expect(memoryRepo.findById(memory.id)).not.toBeNull();
+  });
+
+  it('does not emit eval-result events in dry-run mode', () => {
+    const candidate = makeCandidate();
+    promote(
+      {
+        candidate,
+        contentHash: computeContentHash(candidate.content),
+        pipelineResult: makePipelineResult(),
+      },
+      memoryRepo,
+      auditRepo,
+      true,
+      undefined,
+      () => [{ name: 'x', passed: true, score: 1, threshold: 1, details: {} }],
+    );
+    expect(auditRepo.findByAction('eval-result')).toHaveLength(0);
+  });
+
+  it('contains a throwing callback — the promotion still succeeds', () => {
+    const candidate = makeCandidate();
+    const contentHash = computeContentHash(candidate.content);
+    const memory = promote(
+      { candidate, contentHash, pipelineResult: makePipelineResult() },
+      memoryRepo,
+      auditRepo,
+      false,
+      undefined,
+      () => {
+        throw new Error('eval-surface fault');
+      },
+    );
+    // Memory persisted + 'promoted' event present; no eval-result events written.
+    expect(memoryRepo.findById(memory.id)).not.toBeNull();
+    expect(auditRepo.findByMemory(memory.id).some((e) => e.action === 'promoted')).toBe(true);
+    expect(auditRepo.findByAction('eval-result')).toHaveLength(0);
   });
 });

--- a/apps/curator/src/promotion/promoter.ts
+++ b/apps/curator/src/promotion/promoter.ts
@@ -22,6 +22,34 @@ export interface PromotionInput {
 }
 
 /**
+ * Verdict shape an {@link EvalCallback} may return — a structurally-minimal
+ * mirror of the eval-surface EvaluatorResult, kept local so the promoter does
+ * not take a hard dependency on the eval-surface package (the callback is
+ * supplied by the caller, who owns that dependency). Each returned result is
+ * written to the append-only audit chain as an `eval-result` event.
+ */
+export interface EvalResultRecord {
+  readonly name: string;
+  readonly passed: boolean;
+  readonly score: number;
+  readonly threshold: number;
+  readonly details: Record<string, number | string | boolean>;
+}
+
+/**
+ * Optional hook invoked after a memory is inserted (non-dry-run only). Returns
+ * eval verdicts that are emitted into the audit chain as `eval-result` events —
+ * the QMD side of the unification thesis (DR-010 Q3). Emission only: the audit
+ * chain SHA-256-chains each row; signing the resulting bundle is a downstream
+ * step. A throwing callback is contained — it is logged via a best-effort path
+ * and never aborts the promotion (the memory is already safely persisted).
+ */
+export type EvalCallback = (
+  memory: CuratedMemory,
+  pipelineResult: PipelineResult,
+) => EvalResultRecord[];
+
+/**
  * Promotes a candidate to a CuratedMemory and persists everything to the store.
  *
  * Steps:
@@ -43,6 +71,7 @@ export function promote(
   auditRepo: AuditRepository,
   dryRun: boolean = false,
   linksRepo?: MemoryLinksRepository,
+  evalCallback?: EvalCallback,
 ): CuratedMemory {
   const now = new Date().toISOString();
   const memoryId = randomUUID();
@@ -167,6 +196,40 @@ export function promote(
         timestamp: now,
       }),
     );
+
+    // Evidence emission (DR-010 Q3 unification thesis): if an eval callback is
+    // supplied, run it and write each verdict as an `eval-result` audit event.
+    // The audit chain SHA-256-chains these rows, making them tamper-evident and
+    // signable downstream. Contained by design — a throwing/faulty callback must
+    // NOT abort a promotion whose memory is already persisted; failures are
+    // swallowed here (the memory + 'promoted' event stand regardless).
+    if (evalCallback !== undefined) {
+      try {
+        for (const verdict of evalCallback(memory, input.pipelineResult)) {
+          auditRepo.insert(
+            AuditEventSchema.parse({
+              id: randomUUID(),
+              action: 'eval-result',
+              memoryId,
+              tenantId: input.candidate.tenantId,
+              actor: { type: 'system', id: 'curator' },
+              reason: `eval ${verdict.name}: ${verdict.passed ? 'pass' : 'fail'}`,
+              details: {
+                evaluator: verdict.name,
+                passed: verdict.passed,
+                score: verdict.score,
+                threshold: verdict.threshold,
+                ...verdict.details,
+              },
+              timestamp: now,
+            }),
+          );
+        }
+      } catch {
+        // Eval emission is best-effort; the promotion itself has already
+        // succeeded. Do not let an eval-surface fault corrupt the curation path.
+      }
+    }
   }
 
   return memory;


### PR DESCRIPTION
Bead `bd_000-projects-tr08.19` (Move 3). Optional `evalCallback` param on `promote()`; each returned verdict is written to the append-only audit chain as an `eval-result` event (action added in tr08.15). QMD side of the unification thesis (DR-010 Q3) — the chain SHA-256-chains each row, making verdicts tamper-evident + signable downstream.

- New `EvalResultRecord` + `EvalCallback` types (local — promoter takes NO hard dep on eval-surface; caller owns it). Runs after insert + 'promoted' event, inside `!dryRun`. **Contained**: a throwing callback is swallowed so an eval fault can't abort a persisted promotion.
- 4 new tests (emit-per-verdict, none-without-callback, none-in-dry-run, throwing-callback-contained). Full curator suite green (227 tests), typecheck + lint clean.

**Scope:** delivers the evalCallback *seam* (the bead's contract). Threading a *live* eval-surface callback through curator.ts is deliberately deferred — evaluators need a probe corpus + signing step that don't exist yet; premature to wire into production curation. Belongs with dogfood/probe work (analogous to ICOS tr08.13).

Refs `bd_000-projects-tr08.19`.

- Jeremy Longshore
intentsolutions.io