### PR TITLE
fix(security): tenant-scope the audit read API — close cross-tenant leak (tr08.21)

### DIFF
--- a/apps/api/src/__tests__/audit.test.ts
+++ b/apps/api/src/__tests__/audit.test.ts
@@ -38,11 +38,27 @@ describe('GET /api/audit', () => {
     db.close();
   });
 
-  it('returns empty array when no events match', async () => {
+  it('requires tenantId — returns 400 without it (no cross-tenant dump)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/audit' });
+    expect(res.statusCode).toBe(400);
+    expect(res.json<{ error: string }>().error).toContain('tenantId');
+  });
+
+  it('returns 400 for a bare memoryId query (must be tenant-scoped)', async () => {
     const res = await app.inject({
       method: 'GET',
-      url: '/api/audit?tenantId=nobody',
+      url: `/api/audit?memoryId=${randomUUID()}`,
     });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 400 for a bare action query (must be tenant-scoped)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/audit?action=promoted' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns empty array for a tenant with no events', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/audit?tenantId=nobody' });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual([]);
   });
@@ -51,25 +67,24 @@ describe('GET /api/audit', () => {
     auditRepo.insert(makeEvent({ tenantId: 'team-alpha', action: 'promoted' }));
     auditRepo.insert(makeEvent({ tenantId: 'team-beta', action: 'archived' }));
 
-    const res = await app.inject({
-      method: 'GET',
-      url: '/api/audit?tenantId=team-alpha',
-    });
+    const res = await app.inject({ method: 'GET', url: '/api/audit?tenantId=team-alpha' });
     expect(res.statusCode).toBe(200);
     const events = res.json<Array<{ tenantId: string }>>();
     expect(events.every((e) => e.tenantId === 'team-alpha')).toBe(true);
     expect(events.length).toBe(1);
   });
 
-  it('returns events filtered by memoryId', async () => {
+  it('memoryId narrows WITHIN the tenant', async () => {
     const memoryId = randomUUID();
-    auditRepo.insert(makeEvent({ memoryId, action: 'promoted' }));
-    auditRepo.insert(makeEvent({ memoryId, action: 'demoted' }));
-    auditRepo.insert(makeEvent({ memoryId: randomUUID(), action: 'archived' }));
+    auditRepo.insert(makeEvent({ memoryId, tenantId: 'team-alpha', action: 'promoted' }));
+    auditRepo.insert(makeEvent({ memoryId, tenantId: 'team-alpha', action: 'demoted' }));
+    auditRepo.insert(
+      makeEvent({ memoryId: randomUUID(), tenantId: 'team-alpha', action: 'archived' }),
+    );
 
     const res = await app.inject({
       method: 'GET',
-      url: `/api/audit?memoryId=${memoryId}`,
+      url: `/api/audit?tenantId=team-alpha&memoryId=${memoryId}`,
     });
     expect(res.statusCode).toBe(200);
     const events = res.json<Array<{ memoryId: string }>>();
@@ -77,14 +92,16 @@ describe('GET /api/audit', () => {
     expect(events.length).toBe(2);
   });
 
-  it('returns events filtered by action', async () => {
-    auditRepo.insert(makeEvent({ action: 'promoted' }));
-    auditRepo.insert(makeEvent({ action: 'archived' }));
-    auditRepo.insert(makeEvent({ action: 'promoted', memoryId: randomUUID() }));
+  it('action narrows WITHIN the tenant', async () => {
+    auditRepo.insert(makeEvent({ tenantId: 'team-alpha', action: 'promoted' }));
+    auditRepo.insert(makeEvent({ tenantId: 'team-alpha', action: 'archived' }));
+    auditRepo.insert(
+      makeEvent({ tenantId: 'team-alpha', action: 'promoted', memoryId: randomUUID() }),
+    );
 
     const res = await app.inject({
       method: 'GET',
-      url: '/api/audit?action=promoted',
+      url: '/api/audit?tenantId=team-alpha&action=promoted',
     });
     expect(res.statusCode).toBe(200);
     const events = res.json<Array<{ action: string }>>();
@@ -92,33 +109,30 @@ describe('GET /api/audit', () => {
     expect(events.length).toBe(2);
   });
 
-  it('multiple events for the same memory are all returned', async () => {
+  it('SECURITY: a memoryId owned by another tenant is NOT leaked', async () => {
     const memoryId = randomUUID();
-    auditRepo.insert(makeEvent({ memoryId, action: 'promoted' }));
-    auditRepo.insert(makeEvent({ memoryId, action: 'demoted' }));
-    auditRepo.insert(makeEvent({ memoryId, action: 'archived' }));
+    // Same memoryId exists under team-other; caller is scoped to team-alpha.
+    auditRepo.insert(makeEvent({ memoryId, tenantId: 'team-other', action: 'archived' }));
 
     const res = await app.inject({
       method: 'GET',
-      url: `/api/audit?memoryId=${memoryId}`,
+      url: `/api/audit?tenantId=team-alpha&memoryId=${memoryId}`,
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json<unknown[]>().length).toBe(3);
+    // The cross-tenant row must NOT come back — this is the leak tr08.21 closes.
+    expect(res.json<unknown[]>()).toEqual([]);
   });
 
-  it('memoryId filter takes precedence over tenantId when both provided', async () => {
-    const memoryId = randomUUID();
-    // This event has a different tenant but the memoryId matches
-    auditRepo.insert(makeEvent({ memoryId, tenantId: 'team-other', action: 'archived' }));
+  it('SECURITY: an action query does not leak other tenants rows', async () => {
     auditRepo.insert(makeEvent({ tenantId: 'team-alpha', action: 'promoted' }));
+    auditRepo.insert(makeEvent({ tenantId: 'team-other', action: 'promoted' }));
 
     const res = await app.inject({
       method: 'GET',
-      url: `/api/audit?memoryId=${memoryId}&tenantId=team-alpha`,
+      url: '/api/audit?tenantId=team-alpha&action=promoted',
     });
-    const events = res.json<Array<{ memoryId: string }>>();
-    // memoryId wins — only the event with that memoryId is returned
-    expect(events.every((e) => e.memoryId === memoryId)).toBe(true);
+    const events = res.json<Array<{ tenantId: string }>>();
+    expect(events.every((e) => e.tenantId === 'team-alpha')).toBe(true);
     expect(events.length).toBe(1);
   });
 });

--- a/apps/api/src/routes/audit.ts
+++ b/apps/api/src/routes/audit.ts
@@ -5,11 +5,13 @@ import type { AuditRepository } from '@qmd-team-intent-kb/store';
  * Register audit event query routes.
  * The audit log is append-only; this endpoint only supports reads.
  *
- * GET /api/audit — query by tenantId, memoryId, or action (query params)
+ * GET /api/audit — query the tenant's audit events (query params)
  *
- * When multiple filters are supplied the most specific wins:
- * memoryId > action > tenantId. If none are supplied an empty array
- * is returned — a tenant scope is recommended for production use.
+ * TENANT SCOPING (bead tr08.21): `tenantId` is REQUIRED. Every result is scoped
+ * to that tenant. `memoryId` and `action` further narrow WITHIN the tenant —
+ * they never widen across tenants. Without `tenantId` the endpoint returns 400,
+ * not a global cross-tenant dump. This closes the prior leak where a bare
+ * `memoryId` / `action` query returned rows regardless of ownership.
  */
 export function registerAuditRoutes(app: FastifyInstance, repo: AuditRepository): void {
   app.get(
@@ -17,9 +19,10 @@ export function registerAuditRoutes(app: FastifyInstance, repo: AuditRepository)
     {
       schema: {
         tags: ['audit'],
-        summary: 'Query the immutable audit event log',
+        summary: 'Query the immutable audit event log (tenant-scoped)',
         description:
-          'Filter precedence: `memoryId` > `action` > `tenantId`. Returns `[]` if no filter is provided.',
+          '`tenantId` is REQUIRED. `memoryId` or `action` narrow within that tenant. ' +
+          'Omitting `tenantId` returns 400 — this endpoint never serves cross-tenant rows.',
       },
     },
     async (request, reply) => {
@@ -29,19 +32,24 @@ export function registerAuditRoutes(app: FastifyInstance, repo: AuditRepository)
         action?: string;
       };
 
+      // Tenant scope is mandatory — refuse rather than leak across tenants.
+      if (tenantId === undefined || tenantId.length === 0) {
+        return reply.code(400).send({
+          error: 'tenantId is required',
+          message: 'Audit queries are tenant-scoped; supply a tenantId query parameter.',
+        });
+      }
+
+      // memoryId / action narrow WITHIN the tenant via tenant-scoped lookups.
       if (memoryId !== undefined && memoryId.length > 0) {
-        return reply.send(repo.findByMemory(memoryId));
+        return reply.send(repo.findByMemoryAndTenant(memoryId, tenantId));
       }
 
       if (action !== undefined && action.length > 0) {
-        return reply.send(repo.findByAction(action));
+        return reply.send(repo.findByTenantAndAction(tenantId, action));
       }
 
-      if (tenantId !== undefined && tenantId.length > 0) {
-        return reply.send(repo.findByTenant(tenantId));
-      }
-
-      return reply.send([]);
+      return reply.send(repo.findByTenant(tenantId));
     },
   );
 }

--- a/packages/store/src/__tests__/audit-repository.test.ts
+++ b/packages/store/src/__tests__/audit-repository.test.ts
@@ -144,4 +144,35 @@ describe('AuditRepository — aggregation queries', () => {
     repo.insert(makeAuditEvent({ tenantId: 'team-alpha', memoryId: randomUUID() }));
     expect(repo.countByTenantAndAction('team-unknown')).toEqual({});
   });
+
+  // Tenant-scoped lookups (bead tr08.21) — the safe path for single-tenant callers.
+
+  it('findByMemoryAndTenant returns only the matching tenant rows for a memory', () => {
+    const memoryId = randomUUID();
+    repo.insert(makeAuditEvent({ memoryId, tenantId: 'team-alpha' }));
+    repo.insert(makeAuditEvent({ memoryId, tenantId: 'team-other' }));
+
+    const alpha = repo.findByMemoryAndTenant(memoryId, 'team-alpha');
+    expect(alpha).toHaveLength(1);
+    expect(alpha[0]?.tenantId).toBe('team-alpha');
+  });
+
+  it('findByMemoryAndTenant returns [] when the memory belongs to another tenant', () => {
+    const memoryId = randomUUID();
+    repo.insert(makeAuditEvent({ memoryId, tenantId: 'team-other' }));
+    expect(repo.findByMemoryAndTenant(memoryId, 'team-alpha')).toEqual([]);
+  });
+
+  it('findByTenantAndAction scopes an action query to one tenant', () => {
+    repo.insert(
+      makeAuditEvent({ tenantId: 'team-alpha', action: 'promoted', memoryId: randomUUID() }),
+    );
+    repo.insert(
+      makeAuditEvent({ tenantId: 'team-other', action: 'promoted', memoryId: randomUUID() }),
+    );
+
+    const alpha = repo.findByTenantAndAction('team-alpha', 'promoted');
+    expect(alpha).toHaveLength(1);
+    expect(alpha[0]?.tenantId).toBe('team-alpha');
+  });
 });

--- a/packages/store/src/repositories/audit-repository.ts
+++ b/packages/store/src/repositories/audit-repository.ts
@@ -98,8 +98,10 @@ function rowToEvent(row: unknown): AuditEvent {
 export class AuditRepository {
   private readonly stmtInsert: Database.Statement;
   private readonly stmtFindByMemory: Database.Statement;
+  private readonly stmtFindByMemoryAndTenant: Database.Statement;
   private readonly stmtFindByTenant: Database.Statement;
   private readonly stmtFindByAction: Database.Statement;
+  private readonly stmtFindByTenantAndAction: Database.Statement;
   private readonly stmtCountByAction: Database.Statement;
   private readonly stmtFindInRange: Database.Statement;
   private readonly stmtCountByTenantAndAction: Database.Statement;
@@ -137,12 +139,25 @@ export class AuditRepository {
       SELECT * FROM audit_events WHERE memory_id = ? ORDER BY timestamp ASC
     `);
 
+    // Tenant-scoped memory lookup — the safe path for any caller serving a
+    // single tenant (e.g. an HTTP read API). Prevents a cross-tenant leak where
+    // a known memory_id returns rows the caller's tenant does not own.
+    this.stmtFindByMemoryAndTenant = db.prepare(`
+      SELECT * FROM audit_events WHERE memory_id = ? AND tenant_id = ? ORDER BY timestamp ASC
+    `);
+
     this.stmtFindByTenant = db.prepare(`
       SELECT * FROM audit_events WHERE tenant_id = ? ORDER BY timestamp ASC
     `);
 
     this.stmtFindByAction = db.prepare(`
       SELECT * FROM audit_events WHERE action = ? ORDER BY timestamp ASC
+    `);
+
+    // Tenant-scoped action lookup — the safe path; an unscoped action query
+    // returns every tenant's rows for that action.
+    this.stmtFindByTenantAndAction = db.prepare(`
+      SELECT * FROM audit_events WHERE tenant_id = ? AND action = ? ORDER BY timestamp ASC
     `);
 
     this.stmtCountByAction = db.prepare(`
@@ -208,9 +223,26 @@ export class AuditRepository {
     return this.stmtFindAllChronological.all() as AuditChainRow[];
   }
 
-  /** Return all events associated with the given memory, in chronological order. */
+  /**
+   * Return all events associated with the given memory, in chronological order.
+   *
+   * NOTE: this is NOT tenant-scoped — it returns rows across all tenants for the
+   * given memory_id. Any caller serving a single tenant (e.g. an HTTP read API)
+   * MUST use {@link findByMemoryAndTenant} instead to avoid leaking another
+   * tenant's audit rows. This unscoped method exists for internal /
+   * operator-global use only.
+   */
   findByMemory(memoryId: string): AuditEvent[] {
     const rows = this.stmtFindByMemory.all(memoryId);
+    return rows.map(rowToEvent);
+  }
+
+  /**
+   * Tenant-scoped memory lookup — the safe path for single-tenant callers.
+   * Returns only the given tenant's audit events for the memory.
+   */
+  findByMemoryAndTenant(memoryId: string, tenantId: string): AuditEvent[] {
+    const rows = this.stmtFindByMemoryAndTenant.all(memoryId, tenantId);
     return rows.map(rowToEvent);
   }
 
@@ -220,9 +252,23 @@ export class AuditRepository {
     return rows.map(rowToEvent);
   }
 
-  /** Return all events of the given action type, in chronological order. */
+  /**
+   * Return all events of the given action type, in chronological order.
+   *
+   * NOTE: NOT tenant-scoped — returns every tenant's rows for the action.
+   * Single-tenant callers MUST use {@link findByTenantAndAction}.
+   */
   findByAction(action: string): AuditEvent[] {
     const rows = this.stmtFindByAction.all(action);
+    return rows.map(rowToEvent);
+  }
+
+  /**
+   * Tenant-scoped action lookup — the safe path for single-tenant callers.
+   * Returns only the given tenant's audit events for the action.
+   */
+  findByTenantAndAction(tenantId: string, action: string): AuditEvent[] {
+    const rows = this.stmtFindByTenantAndAction.all(tenantId, action);
     return rows.map(rowToEvent);
   }
 


### PR DESCRIPTION
Bead `bd_000-projects-tr08.21`. **GET /api/audit returned rows by memoryId/action with NO tenant filter** — any caller could read another tenant's audit events. Real cross-tenant leak in a live route.

- Route: `tenantId` now REQUIRED (400 without it — no global dump); memoryId/action narrow WITHIN the tenant.
- Store: new `findByMemoryAndTenant` + `findByTenantAndAction` (AND tenant_id = ?). Unscoped variants kept for internal use, documented as not tenant-safe.
- Left `findAllChronological`/`verifyAuditChain` global by design (single append-only ledger; returns counts/break-metadata, not bulk rows).

Tests: api — 9 incl. two **SECURITY** cases proving a cross-tenant memoryId/action returns nothing; the old test that codified the leak was replaced. store — 3 for the scoped methods. Full store (128) + api (109) suites green.

Scope: closes the exposed read-path leak; SQLite row-level security remains out of scope (QMD multi-tenancy is app-level WHERE filtering).

Refs `bd_000-projects-tr08.21`.

- Jeremy Longshore
intentsolutions.io