### PR TITLE
chore(deps): bump @intentsolutions/audit-harness to 1.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
-    "@intentsolutions/audit-harness": "^0.1.0",
+    "@intentsolutions/audit-harness": "^1.1.5",
     "@qmd-team-intent-kb/store": "workspace:*",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/typescript-checker": "^9.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@intentsolutions/audit-harness':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^1.1.5
+        version: 1.1.5
       '@qmd-team-intent-kb/store':
         specifier: workspace:*
         version: link:packages/store
@@ -1068,8 +1068,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@intentsolutions/audit-harness@0.1.0':
-    resolution: {integrity: sha512-7YNrX4KLEPwJUT41yKa4w94/bqWS3Bdcvxa57GfQOEF/yUtu39Yl59t+bijx+7lO3HmWS5gc/llU1Nca1+QGtg==}
+  '@intentsolutions/audit-harness@1.1.5':
+    resolution: {integrity: sha512-VbE4gPR/wtp2czWT0/Wjo5ZEtX3SRxeWMBS5nx1LhgyxdrKdZdo+deP5/km3Cl5PMyf4XbwXtVt7pDjXi0w1mQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4805,7 +4805,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@intentsolutions/audit-harness@0.1.0': {}
+  '@intentsolutions/audit-harness@1.1.5': {}
 
   '@intentsolutions/core@0.1.1':
     dependencies:


### PR DESCRIPTION
Bumps `@intentsolutions/audit-harness` from `^0.1.0` to `^1.1.5` (newly published to npm with sigstore provenance). Part of `/sync-testing-harness` ecosystem propagation.

The 0.x → 1.x bump was validated non-breaking on intent-eval-core (harness-hash format stable; no re-init needed). Verified here via the repo-canonical `pnpm run harness-pin` (policy-pin verify), which reports `harness-pin: OK` — no `.harness-hash` re-init required.

Changes:
- `package.json`: `@intentsolutions/audit-harness` `^0.1.0` → `^1.1.5`
- `pnpm-lock.yaml`: relocked (installed 1.1.5)

- Jeremy Longshore
intentsolutions.io