### PR TITLE
feat(api): weekly cited-query count per teammate report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,19 @@ SQLite via better-sqlite3 with 5 tables: `candidates`, `curated_memories`, `gove
 
 ### API (apps/api)
 
-Fastify 5 with dependency injection via `buildApp(deps: AppDependencies)`. Middleware stack: rate-limiter → api-key-auth → input-sanitizer. Routes: `/api/candidates`, `/api/memories`, `/api/policies`, `/api/audit`, `/health`.
+Fastify 5 with dependency injection via `buildApp(deps: AppDependencies)`. Middleware stack: rate-limiter → api-key-auth → input-sanitizer. Routes: `/api/candidates`, `/api/memories`, `/api/policies`, `/api/audit`, `/api/search`, `/health`.
+
+#### Cited-query report (brain adoption KPI)
+
+`POST /api/search` emits one structured `query-access` access-log line per read (`{ actor, query, scope, resultCount, citations }`) — deliberately a log line, _not_ a governance `AuditEvent`, so the hash-chained trail stays pure for `ico audit verify`. `apps/api/src/reports/` aggregates those lines into the **weekly cited-query count per teammate** (a _cited_ query = one that returned ≥1 `qmd://` citation):
+
+```bash
+pnpm build                              # produce apps/api/dist
+pnpm report:cited-queries               # last 7 days, human table
+pnpm report:cited-queries --days 30 --json   # JSON for the notification hub
+```
+
+The aggregator (`cited-queries.ts`) is pure and source-agnostic; the CLI (`weekly-cited-queries-cli.ts`) is the only piece that reads the systemd **user** journal (`teamkb-brain-api.service`, persistent journald = the durable access log). `--stdin` pipes lines from any source instead. Intended to run weekly via cron or the notification hub.
 
 ### Curator (apps/curator)
 

--- a/apps/api/src/__tests__/cited-queries.test.ts
+++ b/apps/api/src/__tests__/cited-queries.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from 'vitest';
+import type { SpawnSyncReturns } from 'node:child_process';
+import {
+  parseQueryAccessLine,
+  summarizeCitedQueries,
+  rollingWindow,
+  formatReport,
+  QUERY_ACCESS_EVENT,
+  type ReportWindow,
+} from '../reports/cited-queries.js';
+import {
+  parseArgs,
+  runReport,
+  readJournalLines,
+  formatSince,
+  DEFAULT_UNIT,
+  type SpawnFn,
+} from '../reports/weekly-cited-queries-cli.js';
+
+/** Build a query-access access-log line like routes/search.ts emits. */
+function accessLine(o: {
+  actor: string;
+  time: number;
+  citations?: string[];
+  event?: string;
+}): string {
+  return JSON.stringify({
+    level: 30,
+    event: o.event ?? QUERY_ACCESS_EVENT,
+    actor: o.actor,
+    query: 'q',
+    scope: 'curated',
+    resultCount: o.citations?.length ?? 0,
+    citations: o.citations ?? [],
+    time: o.time,
+    msg: 'teamkb query',
+  });
+}
+
+const WIDE: ReportWindow = { sinceMs: 0, untilMs: 1e15 };
+
+describe('parseQueryAccessLine', () => {
+  it('parses a well-formed query-access line', () => {
+    const line = accessLine({ actor: 'ope', time: 1781492917643, citations: ['qmd://a.md'] });
+    expect(parseQueryAccessLine(line)).toEqual({
+      actor: 'ope',
+      citations: ['qmd://a.md'],
+      time: 1781492917643,
+    });
+  });
+
+  it('returns undefined for an empty / whitespace line', () => {
+    expect(parseQueryAccessLine('')).toBeUndefined();
+    expect(parseQueryAccessLine('   ')).toBeUndefined();
+  });
+
+  it('returns undefined for non-JSON', () => {
+    expect(parseQueryAccessLine('Server listening on 3847')).toBeUndefined();
+  });
+
+  it('returns undefined for JSON that is not an object', () => {
+    expect(parseQueryAccessLine('42')).toBeUndefined();
+    expect(parseQueryAccessLine('null')).toBeUndefined();
+    expect(parseQueryAccessLine('"a string"')).toBeUndefined();
+  });
+
+  it('returns undefined for other pino events', () => {
+    expect(
+      parseQueryAccessLine(accessLine({ actor: 'ope', time: 1, event: 'request' })),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when actor is missing or non-string', () => {
+    expect(
+      parseQueryAccessLine(JSON.stringify({ event: QUERY_ACCESS_EVENT, time: 1 })),
+    ).toBeUndefined();
+    expect(
+      parseQueryAccessLine(JSON.stringify({ event: QUERY_ACCESS_EVENT, actor: 5, time: 1 })),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when time is missing or non-number', () => {
+    expect(
+      parseQueryAccessLine(JSON.stringify({ event: QUERY_ACCESS_EVENT, actor: 'ope' })),
+    ).toBeUndefined();
+    expect(
+      parseQueryAccessLine(JSON.stringify({ event: QUERY_ACCESS_EVENT, actor: 'ope', time: '1' })),
+    ).toBeUndefined();
+  });
+
+  it('defaults citations to [] when absent and filters non-string entries', () => {
+    expect(
+      parseQueryAccessLine(JSON.stringify({ event: QUERY_ACCESS_EVENT, actor: 'ope', time: 1 })),
+    ).toEqual({ actor: 'ope', citations: [], time: 1 });
+    expect(
+      parseQueryAccessLine(
+        JSON.stringify({
+          event: QUERY_ACCESS_EVENT,
+          actor: 'ope',
+          time: 1,
+          citations: ['ok', 7, null],
+        }),
+      ),
+    ).toEqual({ actor: 'ope', citations: ['ok'], time: 1 });
+  });
+});
+
+describe('summarizeCitedQueries', () => {
+  it('counts total, cited, and citations-returned per actor', () => {
+    const lines = [
+      accessLine({ actor: 'ope', time: 10, citations: ['qmd://a.md', 'qmd://b.md'] }),
+      accessLine({ actor: 'ope', time: 11, citations: [] }),
+      accessLine({ actor: 'jeremy', time: 12, citations: ['qmd://c.md'] }),
+    ];
+    const report = summarizeCitedQueries(lines, WIDE);
+
+    expect(report.totalQueries).toBe(3);
+    expect(report.totalCitedQueries).toBe(2);
+    // ope & jeremy tie at citedQueries=1 → alphabetical tiebreak (jeremy first).
+    expect(report.perActor).toEqual([
+      { actor: 'jeremy', totalQueries: 1, citedQueries: 1, citationsReturned: 1 },
+      { actor: 'ope', totalQueries: 2, citedQueries: 1, citationsReturned: 2 },
+    ]);
+  });
+
+  it('ignores lines that are not query-access events', () => {
+    const lines = ['boot banner', accessLine({ actor: 'ope', time: 5, citations: ['qmd://a.md'] })];
+    expect(summarizeCitedQueries(lines, WIDE).totalQueries).toBe(1);
+  });
+
+  it('includes events exactly on both window boundaries and excludes those outside', () => {
+    const window: ReportWindow = { sinceMs: 100, untilMs: 200 };
+    const lines = [
+      accessLine({ actor: 'a', time: 99, citations: ['x'] }), // just before — excluded
+      accessLine({ actor: 'a', time: 100, citations: ['x'] }), // on since — included
+      accessLine({ actor: 'a', time: 200, citations: ['x'] }), // on until — included
+      accessLine({ actor: 'a', time: 201, citations: ['x'] }), // just after — excluded
+    ];
+    expect(summarizeCitedQueries(lines, window).totalQueries).toBe(2);
+  });
+
+  it('sorts actors by citedQueries desc, then actor name asc', () => {
+    const lines = [
+      accessLine({ actor: 'zoe', time: 1, citations: ['x'] }),
+      accessLine({ actor: 'zoe', time: 2, citations: ['x'] }),
+      accessLine({ actor: 'amy', time: 3, citations: ['x'] }),
+      accessLine({ actor: 'bob', time: 4, citations: ['x'] }), // amy & bob tie at 1 → amy first
+    ];
+    expect(summarizeCitedQueries(lines, WIDE).perActor.map((a) => a.actor)).toEqual([
+      'zoe',
+      'amy',
+      'bob',
+    ]);
+  });
+
+  it('returns an empty report for no in-window events', () => {
+    const report = summarizeCitedQueries([], WIDE);
+    expect(report).toEqual({
+      sinceMs: WIDE.sinceMs,
+      untilMs: WIDE.untilMs,
+      perActor: [],
+      totalQueries: 0,
+      totalCitedQueries: 0,
+    });
+  });
+});
+
+describe('rollingWindow', () => {
+  it('spans exactly `days` ending at now (default 7)', () => {
+    const now = 1_000_000_000_000;
+    expect(rollingWindow(now)).toEqual({ sinceMs: now - 7 * 86_400_000, untilMs: now });
+    expect(rollingWindow(now, 1)).toEqual({ sinceMs: now - 86_400_000, untilMs: now });
+  });
+});
+
+describe('formatReport', () => {
+  it('shows the no-data sentinel when no actors', () => {
+    const text = formatReport(summarizeCitedQueries([], WIDE));
+    expect(text).toContain('(no queries in window)');
+    expect(text).toContain('Total: 0 cited / 0 queries');
+  });
+
+  it('renders one row per actor with cited/total and citation totals', () => {
+    const text = formatReport(
+      summarizeCitedQueries([accessLine({ actor: 'ope', time: 1, citations: ['x', 'y'] })], WIDE),
+    );
+    expect(text).toContain('ope');
+    expect(text).toContain('1 / 1');
+    expect(text).toContain('Total: 1 cited / 1 queries');
+  });
+});
+
+describe('parseArgs', () => {
+  it('uses sensible defaults', () => {
+    expect(parseArgs([])).toEqual({ days: 7, json: false, unit: DEFAULT_UNIT, stdin: false });
+  });
+
+  it('accepts --json, --stdin, --days N, --unit NAME', () => {
+    expect(parseArgs(['--json', '--stdin', '--days', '30', '--unit', 'x.service'])).toEqual({
+      days: 30,
+      json: true,
+      unit: 'x.service',
+      stdin: true,
+    });
+  });
+
+  it('rejects a non-positive or non-integer --days', () => {
+    expect(() => parseArgs(['--days', '0'])).toThrow(/positive integer/);
+    expect(() => parseArgs(['--days', '-3'])).toThrow(/positive integer/);
+    expect(() => parseArgs(['--days', 'abc'])).toThrow(/positive integer/);
+  });
+
+  it('rejects a missing --unit value', () => {
+    expect(() => parseArgs(['--unit'])).toThrow(/requires a unit name/);
+  });
+
+  it('rejects unknown arguments', () => {
+    expect(() => parseArgs(['--nope'])).toThrow(/unknown argument/);
+  });
+});
+
+describe('formatSince', () => {
+  it('formats a local instant as YYYY-MM-DD HH:MM:SS (TZ-stable via local Date parts)', () => {
+    const local = new Date(2026, 5, 14, 9, 5, 3); // 2026-06-14 09:05:03 local
+    expect(formatSince(local.getTime())).toBe('2026-06-14 09:05:03');
+  });
+});
+
+describe('runReport', () => {
+  const lines = [accessLine({ actor: 'ope', time: 50, citations: ['x'] })];
+
+  it('emits a human table by default', () => {
+    const out = runReport(lines, 100, { days: 7, json: false, unit: DEFAULT_UNIT, stdin: false });
+    expect(out).toContain('Weekly cited-query count per teammate');
+    expect(out).toContain('ope');
+  });
+
+  it('emits parseable JSON with --json', () => {
+    const out = runReport(lines, 100, { days: 7, json: true, unit: DEFAULT_UNIT, stdin: false });
+    const parsed = JSON.parse(out);
+    expect(parsed.totalCitedQueries).toBe(1);
+    expect(parsed.perActor[0].actor).toBe('ope');
+  });
+});
+
+describe('readJournalLines', () => {
+  function fakeSpawn(ret: Partial<SpawnSyncReturns<string>>): SpawnFn {
+    return () =>
+      ({
+        pid: 1,
+        output: [],
+        stdout: '',
+        stderr: '',
+        status: 0,
+        signal: null,
+        ...ret,
+      }) as SpawnSyncReturns<string>;
+  }
+
+  it('passes the unit and a --since bound to journalctl and splits stdout into lines', () => {
+    let capturedArgs: readonly string[] = [];
+    const spawn: SpawnFn = (_cmd, args) => {
+      capturedArgs = args;
+      return {
+        pid: 1,
+        output: [],
+        stdout: 'a\nb',
+        stderr: '',
+        status: 0,
+        signal: null,
+      } as SpawnSyncReturns<string>;
+    };
+    const lines = readJournalLines('u.service', 0, spawn);
+    expect(lines).toEqual(['a', 'b']);
+    expect(capturedArgs).toContain('u.service');
+    expect(capturedArgs).toContain('--since');
+  });
+
+  it('throws when spawn reports an error', () => {
+    const spawn = fakeSpawn({ error: new Error('ENOENT') });
+    expect(() => readJournalLines('u', 0, spawn)).toThrow(/failed to read journal: ENOENT/);
+  });
+
+  it('throws on a non-zero exit status', () => {
+    const spawn = fakeSpawn({ status: 1, stderr: 'no such unit' });
+    expect(() => readJournalLines('u', 0, spawn)).toThrow(/journalctl exited 1: no such unit/);
+  });
+});

--- a/apps/api/src/reports/cited-queries.ts
+++ b/apps/api/src/reports/cited-queries.ts
@@ -1,0 +1,163 @@
+/**
+ * Weekly cited-query report — the governed brain's adoption KPI.
+ *
+ * The search route emits one `query-access` access-log line per read (see
+ * `routes/search.ts`): `{ event, actor, query, scope, resultCount, citations }`.
+ * This module aggregates those lines into a per-teammate count of how many
+ * queries each person ran and how many came back with at least one `qmd://`
+ * citation — the "weekly cited-query count per teammate" the brain is judged on.
+ *
+ * Pure and I/O-free on purpose: it takes raw log lines (strings) plus an
+ * explicit time window, so it behaves identically whether the lines come from
+ * journald, a teed file, or a test fixture. The CLI
+ * (`weekly-cited-queries-cli.ts`) is the only piece that touches the journal.
+ */
+
+/** The fields the report needs out of one parsed `query-access` event. */
+export interface QueryAccessEvent {
+  /** Audit actor — the teammate (or agent) the bearer token resolved to. */
+  actor: string;
+  /** The `qmd://` citations returned for this query (empty = uncited). */
+  citations: string[];
+  /** Event timestamp, epoch milliseconds (pino `time`). */
+  time: number;
+}
+
+/** Per-teammate roll-up for the window. */
+export interface ActorCitedSummary {
+  actor: string;
+  /** Every query-access event in-window for this actor. */
+  totalQueries: number;
+  /** Queries that returned at least one citation. */
+  citedQueries: number;
+  /** Sum of citations returned across all this actor's in-window queries. */
+  citationsReturned: number;
+}
+
+/** The full report over a window. */
+export interface CitedQueryReport {
+  sinceMs: number;
+  untilMs: number;
+  /** Actors, sorted by citedQueries desc then actor asc (stable, deterministic). */
+  perActor: ActorCitedSummary[];
+  totalQueries: number;
+  totalCitedQueries: number;
+}
+
+/** A half-open-free, inclusive window `[sinceMs, untilMs]`. */
+export interface ReportWindow {
+  sinceMs: number;
+  untilMs: number;
+}
+
+/** The pino `event` value the search route stamps on every read. */
+export const QUERY_ACCESS_EVENT = 'query-access';
+
+/** Milliseconds in one day. */
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Parse one access-log line into a {@link QueryAccessEvent}, or `undefined` if
+ * the line is not a well-formed query-access event. Defensive by design:
+ * journald interleaves startup banners, other pino lines, and fields we ignore.
+ */
+export function parseQueryAccessLine(line: string): QueryAccessEvent | undefined {
+  const trimmed = line.trim();
+  if (trimmed === '') return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return undefined;
+
+  const rec = parsed as Record<string, unknown>;
+  if (rec.event !== QUERY_ACCESS_EVENT) return undefined;
+  if (typeof rec.actor !== 'string') return undefined;
+  if (typeof rec.time !== 'number') return undefined;
+
+  const citations = Array.isArray(rec.citations)
+    ? rec.citations.filter((c): c is string => typeof c === 'string')
+    : [];
+
+  return { actor: rec.actor, citations, time: rec.time };
+}
+
+/**
+ * Aggregate access-log lines into a per-actor cited-query report, counting only
+ * events whose timestamp falls within the inclusive window `[since, until]`.
+ */
+export function summarizeCitedQueries(
+  lines: Iterable<string>,
+  window: ReportWindow,
+): CitedQueryReport {
+  const byActor = new Map<string, ActorCitedSummary>();
+  let totalQueries = 0;
+  let totalCitedQueries = 0;
+
+  for (const line of lines) {
+    const event = parseQueryAccessLine(line);
+    if (event === undefined) continue;
+    if (event.time < window.sinceMs || event.time > window.untilMs) continue;
+
+    let summary = byActor.get(event.actor);
+    if (summary === undefined) {
+      summary = { actor: event.actor, totalQueries: 0, citedQueries: 0, citationsReturned: 0 };
+      byActor.set(event.actor, summary);
+    }
+
+    summary.totalQueries += 1;
+    summary.citationsReturned += event.citations.length;
+    totalQueries += 1;
+
+    if (event.citations.length > 0) {
+      summary.citedQueries += 1;
+      totalCitedQueries += 1;
+    }
+  }
+
+  const perActor = [...byActor.values()].sort(
+    (a, b) => b.citedQueries - a.citedQueries || a.actor.localeCompare(b.actor),
+  );
+
+  return {
+    sinceMs: window.sinceMs,
+    untilMs: window.untilMs,
+    perActor,
+    totalQueries,
+    totalCitedQueries,
+  };
+}
+
+/** A rolling N-day window ending at `nowMs`. `days` defaults to 7 ("weekly"). */
+export function rollingWindow(nowMs: number, days = 7): ReportWindow {
+  return { sinceMs: nowMs - days * MS_PER_DAY, untilMs: nowMs };
+}
+
+/** Render a report as a fixed-width human table. Pure (returns the string). */
+export function formatReport(report: CitedQueryReport): string {
+  const out: string[] = [];
+  out.push('Weekly cited-query count per teammate');
+  out.push(
+    `Window: ${new Date(report.sinceMs).toISOString()} -> ${new Date(report.untilMs).toISOString()}`,
+  );
+  out.push('');
+
+  if (report.perActor.length === 0) {
+    out.push('(no queries in window)');
+  } else {
+    out.push('actor             cited / total   citations');
+    out.push('----------------- -------------   ---------');
+    for (const a of report.perActor) {
+      const actor = a.actor.padEnd(17);
+      const ratio = `${a.citedQueries} / ${a.totalQueries}`.padEnd(13);
+      out.push(`${actor} ${ratio}   ${a.citationsReturned}`);
+    }
+  }
+
+  out.push('');
+  out.push(`Total: ${report.totalCitedQueries} cited / ${report.totalQueries} queries`);
+  return out.join('\n');
+}

--- a/apps/api/src/reports/weekly-cited-queries-cli.ts
+++ b/apps/api/src/reports/weekly-cited-queries-cli.ts
@@ -1,0 +1,124 @@
+/**
+ * CLI: weekly cited-query count per teammate.
+ *
+ *   node dist/reports/weekly-cited-queries-cli.js [--days N] [--json] [--unit NAME] [--stdin]
+ *
+ * Reads the `teamkb-brain-api` access log from the systemd **user** journal and
+ * prints (or emits JSON for) the per-actor cited-query report. journald on the
+ * brain host is persistent, so the journal *is* the durable access log — no
+ * extra store needed. If the access log is ever teed to a file, pass `--stdin`
+ * and pipe it in; the aggregator ({@link summarizeCitedQueries}) is
+ * source-agnostic.
+ *
+ * Intended to be run weekly (cron or the notification hub, spine-zm9) with
+ * `--json` to post the roll-up to ntfy/Slack.
+ */
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { summarizeCitedQueries, rollingWindow, formatReport } from './cited-queries.js';
+
+/** Parsed command-line options. */
+export interface CliOptions {
+  days: number;
+  json: boolean;
+  unit: string;
+  stdin: boolean;
+}
+
+/** The default systemd user unit the brain API runs under. */
+export const DEFAULT_UNIT = 'teamkb-brain-api.service';
+
+/** Parse argv (after `node script.js`) into {@link CliOptions}. Pure. */
+export function parseArgs(argv: readonly string[]): CliOptions {
+  const opts: CliOptions = { days: 7, json: false, unit: DEFAULT_UNIT, stdin: false };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--json') {
+      opts.json = true;
+    } else if (arg === '--stdin') {
+      opts.stdin = true;
+    } else if (arg === '--days') {
+      const value = Number(argv[i + 1]);
+      if (!Number.isInteger(value) || value <= 0) {
+        throw new Error('--days requires a positive integer');
+      }
+      opts.days = value;
+      i++;
+    } else if (arg === '--unit') {
+      const value = argv[i + 1];
+      if (value === undefined || value === '') {
+        throw new Error('--unit requires a unit name');
+      }
+      opts.unit = value;
+      i++;
+    } else {
+      throw new Error(`unknown argument: ${String(arg)}`);
+    }
+  }
+
+  return opts;
+}
+
+/** A spawn function shaped like {@link spawnSync} — injectable for tests. */
+export type SpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: { encoding: 'utf8' },
+) => SpawnSyncReturns<string>;
+
+/** Format an epoch-ms instant as a local `YYYY-MM-DD HH:MM:SS` for journalctl `--since`. */
+export function formatSince(sinceMs: number): string {
+  const d = new Date(sinceMs);
+  const p = (n: number): string => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+}
+
+/**
+ * Read access-log lines from the user journal for `unit` since `sinceMs`.
+ *
+ * `--since` is only a coarse pre-filter to bound how much journald scans; the
+ * aggregator re-filters by exact event timestamp, so the window is precise even
+ * if journald rounds the `--since` boundary.
+ */
+export function readJournalLines(
+  unit: string,
+  sinceMs: number,
+  spawn: SpawnFn = spawnSync,
+): string[] {
+  const result = spawn(
+    'journalctl',
+    ['--user', '-u', unit, '--since', formatSince(sinceMs), '-o', 'cat', '--no-pager'],
+    { encoding: 'utf8' },
+  );
+  if (result.error) {
+    throw new Error(`failed to read journal: ${result.error.message}`);
+  }
+  if (typeof result.status === 'number' && result.status !== 0) {
+    throw new Error(`journalctl exited ${result.status}: ${(result.stderr ?? '').trim()}`);
+  }
+  return (result.stdout ?? '').split('\n');
+}
+
+/**
+ * Build the report and render it. Pure relative to its inputs (no journal/stdin
+ * read) so it is fully unit-testable; `main()` supplies `lines` and `nowMs`.
+ */
+export function runReport(lines: Iterable<string>, nowMs: number, opts: CliOptions): string {
+  const report = summarizeCitedQueries(lines, rollingWindow(nowMs, opts.days));
+  return opts.json ? JSON.stringify(report, null, 2) : formatReport(report);
+}
+
+/** CLI entrypoint. Thin glue over the tested functions above. */
+export function main(argv: readonly string[], nowMs: number): void {
+  const opts = parseArgs(argv);
+  const lines = opts.stdin
+    ? readFileSync(0, 'utf8').split('\n')
+    : readJournalLines(opts.unit, rollingWindow(nowMs, opts.days).sinceMs);
+  process.stdout.write(`${runReport(lines, nowMs, opts)}\n`);
+}
+
+// Run only when invoked directly (not when imported by tests).
+if (process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2), Date.now());
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:coverage": "vitest run --coverage",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:mutation": "stryker run",
+    "report:cited-queries": "node apps/api/dist/reports/weekly-cited-queries-cli.js",
     "depcruise": "depcruise --config .dependency-cruiser.cjs apps packages",
     "crap": "tsx scripts/crap-score.ts",
     "harness-pin": "bash scripts/harness-pin.sh --verify",


### PR DESCRIPTION
## What

Completes the governed brain's adoption KPI: a **weekly cited-query count per teammate** — how many queries each person ran and how many returned ≥1 `qmd://` citation. This is the second half of the `spine-3t7` done-means (the first half, `ico audit verify --json → ok:true`, is verified green: 2,266 events, 0 breaks).

`POST /api/search` already emits one structured `query-access` access-log line per read (`{ actor, query, scope, resultCount, citations }`). This PR turns that existing stream into the metric — no new storage, no new endpoint.

## How

- **`apps/api/src/reports/cited-queries.ts`** — pure, I/O-free aggregator + formatter. Parses pino access-log lines, filters by an explicit `[since, until]` window, rolls up per actor (total / cited / citations-returned), sorts deterministically (cited desc, then actor asc).
- **`apps/api/src/reports/weekly-cited-queries-cli.ts`** — thin CLI over the systemd **user** journal (`teamkb-brain-api.service`; persistent journald = the durable access log). The journald read is dependency-injected so it stays unit-testable. `--stdin` pipes lines from any source; `--json` feeds the notification hub (spine-zm9); `--days N` widens the window.
- **`pnpm report:cited-queries`** root script + a CLAUDE.md operator section.

## Why a log line, not an AuditEvent

The access log is **deliberately not** a governance `AuditEvent` — the hash-chained memory trail must stay pure for `ico audit verify`. The report consumes the access stream; the governance chain is untouched.

## Tests

27 unit tests, **95% line / 92% branch** on the new files — window-boundary inclusivity, tiebreak ordering, malformed/non-JSON/other-event lines, citation filtering, and full arg-parse coverage (including injected-spawn journald error paths).

## Live run (evidence)

```
Weekly cited-query count per teammate
Window: 2026-06-09 -> 2026-06-16

actor             cited / total   citations
----------------- -------------   ---------
ope               7 / 12          27

Total: 7 cited / 12 queries
```

## Note on CI

Two pre-existing `packages/repo-resolver` test failures exist **only on the author's dev box** (git-availability / non-git-dir env quirks) — confirmed present on clean `main` with none of this PR's code, and documented in the prior commit `ae50058`. They are untouched by this PR (isolated to `apps/api/reports/` + docs) and expected to pass in CI's clean environment.

Closes the cited-query-count half of `spine-3t7`.

- Jeremy Longshore
intentsolutions.io