### PR TITLE
feat(store): external anchor log for the audit chain — detect silent full rewrites

### DIFF
--- a/packages/store/src/audit-anchor.test.ts
+++ b/packages/store/src/audit-anchor.test.ts
@@ -1,0 +1,120 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { appendAnchor, readAnchors, verifyAnchors } from './audit-anchor.js';
+import { computeEntryHash } from './audit-chain.js';
+import { verifyAuditChain } from './audit-verify.js';
+import type { AuditRepository, AuditChainRow } from './repositories/audit-repository.js';
+
+/** Build a VALID hash chain (correct entry_hash + prev links) from a list of reasons. */
+function buildChain(reasons: string[]): AuditChainRow[] {
+  const rows: AuditChainRow[] = [];
+  let prev: string | null = null;
+  reasons.forEach((reason, i) => {
+    const base = {
+      id: `id-${i}`,
+      action: 'promoted',
+      memory_id: `mem-${i}`,
+      tenant_id: 'local',
+      actor_json: '{"type":"ai","id":"curator"}',
+      reason,
+      details_json: '{}',
+      timestamp: `2026-06-17T00:00:0${i}.000Z`,
+    };
+    const entry_hash = computeEntryHash({ ...base, prev_entry_hash: prev });
+    rows.push({ ...base, prev_entry_hash: prev, entry_hash });
+    prev = entry_hash;
+  });
+  return rows;
+}
+
+/** Minimal AuditRepository: verifyAuditChain + the anchor module only call findAllChronological. */
+function mockRepo(rows: AuditChainRow[]): AuditRepository {
+  return { findAllChronological: () => rows } as unknown as AuditRepository;
+}
+
+describe('audit-anchor', () => {
+  let anchorPath: string;
+  beforeEach(() => {
+    anchorPath = join(
+      tmpdir(),
+      `gsb-anchor-${Date.now()}-${Math.random().toString(36).slice(2)}.jsonl`,
+    );
+  });
+  afterEach(() => {
+    if (existsSync(anchorPath)) rmSync(anchorPath);
+  });
+
+  it('appendAnchor snapshots the chain head and links the log', () => {
+    const rows = buildChain(['a', 'b', 'c']);
+    const repo = mockRepo(rows);
+
+    const first = appendAnchor(repo, anchorPath, {
+      tenantId: 'local',
+      nowFn: () => '2026-06-17T01:00:00.000Z',
+    });
+    expect(first.chainedRows).toBe(3);
+    expect(first.chainHead).toBe(rows[2]!.entry_hash);
+    expect(first.prevAnchorHash).toBeNull();
+
+    const grown = mockRepo(buildChain(['a', 'b', 'c', 'd', 'e']));
+    const second = appendAnchor(grown, anchorPath, {
+      tenantId: 'local',
+      nowFn: () => '2026-06-17T02:00:00.000Z',
+    });
+    expect(second.chainedRows).toBe(5);
+    expect(second.prevAnchorHash).toBe(first.anchorHash);
+    expect(readAnchors(anchorPath)).toHaveLength(2);
+  });
+
+  it('verifyAnchors passes on a clean chain + intact log', () => {
+    const repo = mockRepo(buildChain(['a', 'b', 'c']));
+    appendAnchor(repo, anchorPath, { tenantId: 'local' });
+    const result = verifyAnchors(repo, anchorPath);
+    expect(result.ok).toBe(true);
+    expect(result.chain.breaks).toHaveLength(0);
+    expect(result.anchorBreaks).toHaveLength(0);
+  });
+
+  it('catches a SILENT FULL REWRITE that verifyAuditChain alone passes clean', () => {
+    // Anchor a clean 3-row chain.
+    const original = mockRepo(buildChain(['a', 'b', 'c']));
+    appendAnchor(original, anchorPath, { tenantId: 'local' });
+
+    // Attacker edits the FIRST event and re-hashes the whole chain forward.
+    const rewritten = buildChain(['TAMPERED', 'b', 'c']);
+    const rewrittenRepo = mockRepo(rewritten);
+
+    // verifyAuditChain is fooled — the rewrite is internally consistent.
+    expect(verifyAuditChain(rewrittenRepo).breaks).toHaveLength(0);
+
+    // verifyAnchors is NOT fooled — the anchored head no longer matches.
+    const result = verifyAnchors(rewrittenRepo, anchorPath);
+    expect(result.ok).toBe(false);
+    expect(result.anchorBreaks.map((b) => b.reason)).toContain('HISTORY_REWRITTEN');
+  });
+
+  it('flags a truncated chain (rows deleted since anchor)', () => {
+    appendAnchor(mockRepo(buildChain(['a', 'b', 'c'])), anchorPath, { tenantId: 'local' });
+    const result = verifyAnchors(mockRepo(buildChain(['a', 'b'])), anchorPath);
+    expect(result.ok).toBe(false);
+    expect(result.anchorBreaks.map((b) => b.reason)).toContain('HISTORY_TRUNCATED');
+  });
+
+  it('flags an edited anchor record (anchor log itself tampered)', () => {
+    const repo = mockRepo(buildChain(['a', 'b', 'c']));
+    appendAnchor(repo, anchorPath, { tenantId: 'local' });
+
+    // Edit the anchored chainHead without recomputing anchorHash.
+    const rec = JSON.parse(readFileSync(anchorPath, 'utf8').trim()) as Record<string, unknown>;
+    rec['chainHead'] = 'forged';
+    writeFileSync(anchorPath, JSON.stringify(rec) + '\n');
+
+    const result = verifyAnchors(repo, anchorPath);
+    expect(result.ok).toBe(false);
+    expect(result.anchorBreaks.map((b) => b.reason)).toContain('ANCHOR_HASH_MISMATCH');
+  });
+});

--- a/packages/store/src/audit-anchor.ts
+++ b/packages/store/src/audit-anchor.ts
@@ -1,0 +1,212 @@
+/**
+ * External anchoring for the audit hash chain.
+ *
+ * `verifyAuditChain` proves the chain is *internally* consistent — but it
+ * re-anchors on each row's stored `entry_hash`, so a writer with local access
+ * who edits an early event AND re-hashes every later row forward produces a
+ * chain that still verifies clean. That is tamper-DETECTION of accidental or
+ * partial edits, not protection against a deliberate full rewrite.
+ *
+ * This module closes that gap by periodically snapshotting the chain head into
+ * an **append-only, hash-chained anchor log** (a JSONL file). Each anchor records
+ * the number of chained rows and the head `entry_hash` at that moment, linked to
+ * the previous anchor by `prevAnchorHash` (so the anchor log is itself a hash
+ * chain). `verifyAnchors` then cross-checks the *current* chain against every
+ * anchored snapshot: if history before an anchored position was rewritten, the
+ * recomputed head no longer matches the value frozen in the anchor — a
+ * `HISTORY_REWRITTEN` break that `verifyAuditChain` alone cannot see.
+ *
+ * The anchor log becomes externally tamper-EVIDENT only when committed somewhere
+ * an offline editor cannot quietly rewrite — e.g. `git commit` + push of the
+ * anchor file (git's own content-addressed history on a remote), or an
+ * OpenTimestamps proof of the latest `anchorHash`. This module owns the log +
+ * verification; the caller owns the external commit. Trust model: local =
+ * integrity + ordering + rewrite-detection-since-last-anchor; cross-actor
+ * non-repudiation still requires the external commit + per-actor signatures.
+ *
+ * @module audit-anchor
+ */
+
+import { createHash } from 'node:crypto';
+import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+
+import { verifyAuditChain, type AuditVerifyResult } from './audit-verify.js';
+import type { AuditRepository, AuditChainRow } from './repositories/audit-repository.js';
+
+/** One snapshot of the audit chain head, linked into an append-only log. */
+export interface AnchorRecord {
+  schemaVersion: 1;
+  /** ISO-8601 timestamp the anchor was taken. */
+  anchoredAt: string;
+  tenantId: string;
+  /** Number of CHAINED rows (entry_hash != null) at anchor time. */
+  chainedRows: number;
+  /** The head row's entry_hash (empty string when there were no chained rows). */
+  chainHead: string;
+  /** anchorHash of the previous anchor in the log (null for the first). */
+  prevAnchorHash: string | null;
+  /** sha256 over the canonical body (everything above) — this record's identity. */
+  anchorHash: string;
+}
+
+type AnchorBody = Omit<AnchorRecord, 'anchorHash'>;
+
+/** Canonical body serialisation — fixed key order, like canonicalRowJson. */
+function anchorBodyJson(b: AnchorBody): string {
+  return JSON.stringify({
+    schemaVersion: b.schemaVersion,
+    anchoredAt: b.anchoredAt,
+    tenantId: b.tenantId,
+    chainedRows: b.chainedRows,
+    chainHead: b.chainHead,
+    prevAnchorHash: b.prevAnchorHash,
+  });
+}
+
+/** SHA-256 hex digest identifying an anchor record (over its canonical body). */
+export function computeAnchorHash(body: AnchorBody): string {
+  return createHash('sha256').update(anchorBodyJson(body), 'utf8').digest('hex');
+}
+
+function chainedRowsOf(repo: AuditRepository): AuditChainRow[] {
+  return repo.findAllChronological().filter((r) => r.entry_hash !== null);
+}
+
+/** Parse the append-only anchor log. Returns [] when the file is absent. */
+export function readAnchors(anchorPath: string): AnchorRecord[] {
+  if (!existsSync(anchorPath)) return [];
+  return readFileSync(anchorPath, 'utf8')
+    .split('\n')
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as AnchorRecord);
+}
+
+export interface AppendAnchorOptions {
+  tenantId: string;
+  /** Injectable clock for deterministic tests. */
+  nowFn?: () => string;
+}
+
+/**
+ * Snapshot the current chain head and append it to the anchor log. The new
+ * record links to the prior one by `prevAnchorHash`, extending the anchor-log
+ * hash chain. Returns the record written.
+ *
+ * After calling this, commit the anchor file externally (git push / OTS) to
+ * make the snapshot tamper-EVIDENT against a later local rewrite.
+ */
+export function appendAnchor(
+  repo: AuditRepository,
+  anchorPath: string,
+  opts: AppendAnchorOptions,
+): AnchorRecord {
+  const now = opts.nowFn ?? (() => new Date().toISOString());
+  const rows = chainedRowsOf(repo);
+  const head = rows.length > 0 ? (rows[rows.length - 1]!.entry_hash ?? '') : '';
+  const existing = readAnchors(anchorPath);
+  const prevAnchorHash = existing.length > 0 ? existing[existing.length - 1]!.anchorHash : null;
+
+  const body: AnchorBody = {
+    schemaVersion: 1,
+    anchoredAt: now(),
+    tenantId: opts.tenantId,
+    chainedRows: rows.length,
+    chainHead: head,
+    prevAnchorHash,
+  };
+  const record: AnchorRecord = { ...body, anchorHash: computeAnchorHash(body) };
+  appendFileSync(anchorPath, JSON.stringify(record) + '\n', { mode: 0o600 });
+  return record;
+}
+
+/** A discrepancy between the live chain and the anchored snapshots, or within the log. */
+export interface AnchorBreak {
+  /** Zero-indexed position in the anchor log. */
+  index: number;
+  anchoredAt: string;
+  reason:
+    | 'ANCHOR_HASH_MISMATCH' // an anchor record itself was edited
+    | 'ANCHOR_LINK_MISMATCH' // the anchor log was reordered / spliced
+    | 'HISTORY_TRUNCATED' // chain now has fewer rows than were anchored
+    | 'HISTORY_REWRITTEN'; // the head at an anchored position changed — the rewrite verifyAuditChain misses
+  detail: string;
+}
+
+export interface AnchorVerifyResult {
+  /** The underlying intra-chain verification. */
+  chain: AuditVerifyResult;
+  anchorCount: number;
+  anchorBreaks: AnchorBreak[];
+  /** True iff the chain is internally clean AND consistent with every anchor. */
+  ok: boolean;
+}
+
+/**
+ * Verify the audit chain against its anchor log. Detects (a) anchor records
+ * that were edited, (b) a reordered/spliced anchor log, and — crucially — (c) a
+ * silent full rewrite of history before any anchored position, which
+ * `verifyAuditChain` cannot detect on its own. Never throws on tamper.
+ */
+export function verifyAnchors(repo: AuditRepository, anchorPath: string): AnchorVerifyResult {
+  const chain = verifyAuditChain(repo);
+  const anchors = readAnchors(anchorPath);
+  const rows = chainedRowsOf(repo);
+  const anchorBreaks: AnchorBreak[] = [];
+
+  let expectedPrev: string | null = null;
+  for (let i = 0; i < anchors.length; i++) {
+    const a = anchors[i]!;
+
+    const recomputed = computeAnchorHash({
+      schemaVersion: a.schemaVersion,
+      anchoredAt: a.anchoredAt,
+      tenantId: a.tenantId,
+      chainedRows: a.chainedRows,
+      chainHead: a.chainHead,
+      prevAnchorHash: a.prevAnchorHash,
+    });
+    if (recomputed !== a.anchorHash) {
+      anchorBreaks.push({
+        index: i,
+        anchoredAt: a.anchoredAt,
+        reason: 'ANCHOR_HASH_MISMATCH',
+        detail: 'anchor record content does not match its anchorHash',
+      });
+    }
+    if (a.prevAnchorHash !== expectedPrev) {
+      anchorBreaks.push({
+        index: i,
+        anchoredAt: a.anchoredAt,
+        reason: 'ANCHOR_LINK_MISMATCH',
+        detail: `prevAnchorHash ${a.prevAnchorHash ?? 'null'} != expected ${expectedPrev ?? 'null'}`,
+      });
+    }
+    expectedPrev = a.anchorHash;
+
+    if (rows.length < a.chainedRows) {
+      anchorBreaks.push({
+        index: i,
+        anchoredAt: a.anchoredAt,
+        reason: 'HISTORY_TRUNCATED',
+        detail: `anchored ${a.chainedRows} chained rows; chain now has ${rows.length}`,
+      });
+    } else if (a.chainedRows > 0) {
+      const actualHead = rows[a.chainedRows - 1]!.entry_hash;
+      if (actualHead !== a.chainHead) {
+        anchorBreaks.push({
+          index: i,
+          anchoredAt: a.anchoredAt,
+          reason: 'HISTORY_REWRITTEN',
+          detail: `row ${a.chainedRows} head ${actualHead ?? 'null'} != anchored ${a.chainHead}`,
+        });
+      }
+    }
+  }
+
+  return {
+    chain,
+    anchorCount: anchors.length,
+    anchorBreaks,
+    ok: chain.breaks.length === 0 && anchorBreaks.length === 0,
+  };
+}

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -9,6 +9,13 @@ export type { AuditChainRow } from './repositories/audit-repository.js';
 export { verifyAuditChain, type AuditVerifyResult, type AuditChainBreak } from './audit-verify.js';
 export { computeEntryHash, canonicalRowJson } from './audit-chain.js';
 export type { CanonicalAuditRow } from './audit-chain.js';
+export { appendAnchor, verifyAnchors, computeAnchorHash, readAnchors } from './audit-anchor.js';
+export type {
+  AnchorRecord,
+  AnchorVerifyResult,
+  AnchorBreak,
+  AppendAnchorOptions,
+} from './audit-anchor.js';
 export { ExportStateRepository } from './repositories/export-state-repository.js';
 export type { ExportState } from './repositories/export-state-repository.js';
 export { MemoryLinksRepository } from './repositories/memory-links-repository.js';


### PR DESCRIPTION
## The gap

`verifyAuditChain` re-anchors on each row's *stored* `entry_hash` (audit-verify.ts:136-138), so a writer with local access who edits an event **and re-hashes the chain forward** produces a chain that still verifies clean. That's tamper-**detection** of accidental/partial edits — not protection against a deliberate full rewrite. (This is exactly the honesty caveat in the Governed Second Brain README's "what the receipt does *not* do" box.)

## The fix — `packages/store/src/audit-anchor.ts`

- **`appendAnchor(repo, anchorPath, {tenantId, nowFn?})`** — snapshot the chain head (chained-row count + head `entry_hash`) into an **append-only, hash-chained JSONL log**; each anchor links to the prior by `prevAnchorHash`, so the log is itself a hash chain.
- **`verifyAnchors(repo, anchorPath)`** — verify the chain **and** cross-check every anchored snapshot against the live chain. Catches:
  - `HISTORY_REWRITTEN` / `HISTORY_TRUNCATED` — the rewrite/deletion `verifyAuditChain` alone cannot see,
  - `ANCHOR_HASH_MISMATCH` / `ANCHOR_LINK_MISMATCH` — tampering with the log itself.

The log becomes externally tamper-**evident** once committed where an offline editor can't quietly rewrite it (git push of the anchor file, or an OpenTimestamps proof of the latest `anchorHash`) — the caller owns that external commit. Trust model unchanged: local = integrity + ordering + rewrite-detection-since-last-anchor; cross-actor non-repudiation still needs the external commit + per-actor signatures.

## Verification

5/5 tests green — the headline one proves a full re-hash-forward rewrite passes `verifyAuditChain` (**0 breaks**) yet `verifyAnchors` flags **`HISTORY_REWRITTEN`**. Typecheck + eslint clean. Purely additive (new module + exports); no changes to existing audit code.