### PR TITLE
docs: settle DECR 035 license to Apache-2.0 + canonicalize umbrella name

### DIFF
--- a/000-docs/035-AT-DECR-post-thesis-build-direction-2026-05-23.md
+++ b/000-docs/035-AT-DECR-post-thesis-build-direction-2026-05-23.md
@@ -11,8 +11,15 @@ cross_repo: byte-identical copy at qmd-team-intent-kb/000-docs/035-AT-DECR-post-
 seats_convened: [CTO, GC, CFO, CSO, CISO, 'VP DevRel', CMO]
 seats_muted_in_synthesis: [CMO]
 status: binding decision record — supersedes only by explicit later DECR
-license: MIT
+license: Apache-2.0
 ---
+
+> **Editorial note (2026-06-16):** the General Counsel's license-posture line in
+> §2.2 ("MIT on both projects") reflects the state on 2026-05-23. ICO and INTKB
+> have since been **relicensed MIT → Apache-2.0** — see each repo's `LICENSE` and
+> this record's `license:` frontmatter (now `Apache-2.0`). The historical quote is
+> preserved unaltered; this note supersedes its license claim. Applied identically
+> to the byte-identical INTKB copy.
 
 # Post-Thesis Build Direction — Executive Council Decision Record
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Turn ephemeral Claude Code session insights into persistent, governed, team-wide memory. qmd-team-intent-kb captures institutional knowledge generated during AI-assisted development, applies deterministic governance policies, and makes curated knowledge searchable through qmd's local full-text indexing.
 
-> **Part of the [Compile-Then-Govern](https://github.com/intent-solutions-io/compile-then-govern) stack** — INTKB is the **govern** layer. Upstream, [intentional-cognition-os](https://github.com/jeremylongshore/intentional-cognition-os) (compile) emits the spool it consumes; downstream, [qmd](https://github.com/tobi/qmd) (retrieve) serves the curated result with `qmd://` citations. → [Ecosystem overview](https://github.com/intent-solutions-io/compile-then-govern)
+> **Part of the [Compile-Then-Govern](https://github.com/intent-solutions-io/governed-second-brain) stack** — INTKB is the **govern** layer. Upstream, [intentional-cognition-os](https://github.com/jeremylongshore/intentional-cognition-os) (compile) emits the spool it consumes; downstream, [qmd](https://github.com/tobi/qmd) (retrieve) serves the curated result with `qmd://` citations. → [Ecosystem overview](https://github.com/intent-solutions-io/governed-second-brain)
 
 ## Positioning
 


### PR DESCRIPTION
Part of the Governed Second Brain productization (license + version consistency, bead compile-then-govern-qy7.12).

**What & why**
- `000-docs/035-AT-DECR-...md` frontmatter `license: MIT` -> `Apache-2.0`. Every LICENSE file, `package.json`, and README badge across ICO / INTKB / the umbrella / the plugin is already Apache-2.0; the DECR frontmatter was the last contradicting signal (a stated publish blocker).
- Added a **marked editorial note** recording the MIT -> Apache-2.0 relicense. The General Counsel's dated `MIT on both projects` quote (§2.2) is **preserved unaltered** — it was accurate on 2026-05-23; the note supersedes its license claim without rewriting history.
- `README.md` now points at the canonical umbrella repo name `intent-solutions-io/governed-second-brain` (renamed from `compile-then-govern`; the old name still redirects).

Docs-only. No code, tests, or behavior touched.