### PR TITLE
feat(qmd-adapter): pin retrieval-model weights by SHA-256, fail closed (0t9.5)

### DIFF
--- a/packages/common/src/hash.ts
+++ b/packages/common/src/hash.ts
@@ -1,6 +1,24 @@
 import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
 
 /** Compute a SHA-256 hex hash of the given content string */
 export function computeContentHash(content: string): string {
   return createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+/**
+ * Compute a SHA-256 hex hash of a file by streaming it through the digest.
+ *
+ * Streams rather than reading the whole file into memory so it stays bounded for
+ * GB-scale artifacts (e.g. the GGUF model weights this is used to pin). Rejects
+ * if the file cannot be read.
+ */
+export function computeFileHash(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256');
+    const stream = createReadStream(filePath);
+    stream.on('error', reject);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('end', () => resolve(hash.digest('hex')));
+  });
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,6 +1,6 @@
 export type { Result } from './result.js';
 export { ok, err } from './result.js';
-export { computeContentHash } from './hash.js';
+export { computeContentHash, computeFileHash } from './hash.js';
 export { DEFAULT_TEAMKB_BASE, getTeamKbBasePath, resolveTeamKbPath } from './paths.js';
 export { isPathSafe } from './path-safety.js';
 export type { PathSafetyResult } from './path-safety.js';

--- a/packages/qmd-adapter/src/__tests__/verify-weights.test.ts
+++ b/packages/qmd-adapter/src/__tests__/verify-weights.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { tmpdir, homedir } from 'node:os';
+import { join } from 'node:path';
+import {
+  verifyWeights,
+  assertWeightsVerified,
+  resolveQmdModelsDir,
+  WeightIntegrityError,
+  type WeightsManifest,
+} from '../weights/verify-weights.js';
+
+const sha256 = (s: string): string => createHash('sha256').update(s).digest('hex');
+
+describe('verifyWeights / assertWeightsVerified', () => {
+  let dir: string;
+  let manifest: WeightsManifest;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'qmd-weights-'));
+    writeFileSync(join(dir, 'model-a.gguf'), 'AAAA'); // 4 bytes
+    writeFileSync(join(dir, 'model-b.gguf'), 'BBBBBB'); // 6 bytes
+    manifest = {
+      schemaVersion: 1,
+      qmd: { npmPackage: '@tobilu/qmd', version: 'test' },
+      models: [
+        { id: 'a', role: 'embedding', file: 'model-a.gguf', sha256: sha256('AAAA'), size: 4 },
+        { id: 'b', role: 'reranker', file: 'model-b.gguf', sha256: sha256('BBBBBB'), size: 6 },
+      ],
+    };
+  });
+
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('passes when every weight matches the pin', async () => {
+    const r = await verifyWeights(manifest, dir);
+    expect(r.ok).toBe(true);
+    expect(r.results.map((x) => x.status)).toEqual(['ok', 'ok']);
+    expect(r.results[0]?.actualSha256).toBe(sha256('AAAA'));
+  });
+
+  it('flags a hash mismatch when content changed but size is identical', async () => {
+    writeFileSync(join(dir, 'model-a.gguf'), 'XXXX'); // 4 bytes, different content
+    const r = await verifyWeights(manifest, dir);
+    expect(r.ok).toBe(false);
+    expect(r.results.find((x) => x.id === 'a')?.status).toBe('hash-mismatch');
+    expect(r.results.find((x) => x.id === 'b')?.status).toBe('ok');
+  });
+
+  it('flags a size mismatch and short-circuits before hashing', async () => {
+    writeFileSync(join(dir, 'model-b.gguf'), 'BBB'); // 3 bytes, pinned 6
+    const r = await verifyWeights(manifest, dir);
+    expect(r.ok).toBe(false);
+    const b = r.results.find((x) => x.id === 'b');
+    expect(b?.status).toBe('size-mismatch');
+    expect(b?.actualSize).toBe(3);
+    expect(b?.actualSha256).toBeUndefined();
+  });
+
+  it('flags a missing weight', async () => {
+    rmSync(join(dir, 'model-a.gguf'));
+    const r = await verifyWeights(manifest, dir);
+    expect(r.ok).toBe(false);
+    expect(r.results.find((x) => x.id === 'a')?.status).toBe('missing');
+  });
+
+  it('assertWeightsVerified returns the passing result', async () => {
+    const r = await assertWeightsVerified(manifest, dir);
+    expect(r.ok).toBe(true);
+    expect(r.results).toHaveLength(2);
+  });
+
+  it('assertWeightsVerified throws WeightIntegrityError on mismatch (fail closed)', async () => {
+    writeFileSync(join(dir, 'model-a.gguf'), 'XXXX');
+    await expect(assertWeightsVerified(manifest, dir)).rejects.toBeInstanceOf(WeightIntegrityError);
+  });
+
+  it('WeightIntegrityError carries the verify result and names the bad model', async () => {
+    rmSync(join(dir, 'model-b.gguf'));
+    try {
+      await assertWeightsVerified(manifest, dir);
+      expect.unreachable('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(WeightIntegrityError);
+      const err = e as WeightIntegrityError;
+      expect(err.result.ok).toBe(false);
+      expect(err.message).toContain('b [missing]');
+    }
+  });
+});
+
+describe('resolveQmdModelsDir', () => {
+  it('honors XDG_CACHE_HOME', () => {
+    expect(resolveQmdModelsDir({ XDG_CACHE_HOME: '/x/cache' })).toBe('/x/cache/qmd/models');
+  });
+
+  it('falls back to ~/.cache when XDG_CACHE_HOME is unset', () => {
+    expect(resolveQmdModelsDir({})).toBe(join(homedir(), '.cache', 'qmd', 'models'));
+  });
+
+  it('treats a blank XDG_CACHE_HOME as unset', () => {
+    expect(resolveQmdModelsDir({ XDG_CACHE_HOME: '   ' })).toBe(
+      join(homedir(), '.cache', 'qmd', 'models'),
+    );
+  });
+});

--- a/packages/qmd-adapter/src/index.ts
+++ b/packages/qmd-adapter/src/index.ts
@@ -43,3 +43,19 @@ export { checkHealth } from './health/health-check.js';
 
 // Facade
 export { QmdAdapter } from './adapter.js';
+
+// Weights — retrieval-model integrity pinning (bead 0t9.5)
+export {
+  verifyWeights,
+  assertWeightsVerified,
+  resolveQmdModelsDir,
+  WeightIntegrityError,
+  QMD_WEIGHTS_MANIFEST,
+} from './weights/index.js';
+export type {
+  PinnedModel,
+  WeightsManifest,
+  ModelVerifyStatus,
+  ModelVerifyResult,
+  WeightsVerifyResult,
+} from './weights/index.js';

--- a/packages/qmd-adapter/src/weights/index.ts
+++ b/packages/qmd-adapter/src/weights/index.ts
@@ -1,0 +1,14 @@
+export {
+  verifyWeights,
+  assertWeightsVerified,
+  resolveQmdModelsDir,
+  WeightIntegrityError,
+} from './verify-weights.js';
+export type {
+  PinnedModel,
+  WeightsManifest,
+  ModelVerifyStatus,
+  ModelVerifyResult,
+  WeightsVerifyResult,
+} from './verify-weights.js';
+export { QMD_WEIGHTS_MANIFEST } from './weights-manifest.js';

--- a/packages/qmd-adapter/src/weights/verify-weights.ts
+++ b/packages/qmd-adapter/src/weights/verify-weights.ts
@@ -1,0 +1,150 @@
+import { existsSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { computeFileHash } from '@qmd-team-intent-kb/common';
+
+/**
+ * Model-weight integrity pinning for the retrieval brain.
+ *
+ * qmd's semantic path (hybrid `qmd query` / `qmd embed`, and the future native
+ * sqlite-vec backend) runs GGUF model weights via llama.cpp. Those weights are
+ * downloaded to a local cache and, until now, were neither signed nor pinned —
+ * a govern-by-receipts product cannot run an unverified retrieval brain.
+ *
+ * This module pins each weight by SHA-256 + byte size in a manifest and verifies
+ * the on-disk copies against it. `assertWeightsVerified` is the **fail-closed**
+ * gate: any semantic path MUST call it before touching the models, and it throws
+ * on any mismatch rather than silently using a tampered/swapped weight.
+ *
+ * See ADR `000-docs/038-AT-DECR` and bead `qmd-team-intent-kb-0t9.5`.
+ */
+
+/** One pinned model weight. */
+export interface PinnedModel {
+  /** Stable id (embedding | reranker | query-expansion). */
+  id: string;
+  /** Role in the retrieval pipeline. */
+  role: 'embedding' | 'reranker' | 'query-expansion';
+  /** File name as stored in the qmd models cache. */
+  file: string;
+  /** Pinned SHA-256 (hex) of the file. */
+  sha256: string;
+  /** Pinned byte size — a cheap pre-check before hashing GB-scale files. */
+  size: number;
+  /** Hugging Face source repo (informational provenance). */
+  hfRepo?: string;
+}
+
+/** The pinned weight manifest — the "receipts" for the retrieval brain. */
+export interface WeightsManifest {
+  schemaVersion: number;
+  /** The qmd package + version these weights belong to. */
+  qmd: { npmPackage: string; version: string };
+  /** Free-text caveat (e.g. which qmd version the hashes were captured under). */
+  note?: string;
+  models: PinnedModel[];
+}
+
+export type ModelVerifyStatus = 'ok' | 'missing' | 'size-mismatch' | 'hash-mismatch';
+
+export interface ModelVerifyResult {
+  id: string;
+  file: string;
+  status: ModelVerifyStatus;
+  expectedSha256: string;
+  actualSha256?: string;
+  expectedSize: number;
+  actualSize?: number;
+}
+
+export interface WeightsVerifyResult {
+  ok: boolean;
+  modelsDir: string;
+  results: ModelVerifyResult[];
+}
+
+/** Thrown by `assertWeightsVerified` when one or more weights fail the pin. */
+export class WeightIntegrityError extends Error {
+  constructor(public readonly result: WeightsVerifyResult) {
+    const bad = result.results.filter((r) => r.status !== 'ok');
+    super(
+      `qmd model-weight integrity check FAILED (fail-closed) in ${result.modelsDir}: ` +
+        bad.map((r) => `${r.id} [${r.status}]`).join(', ') +
+        ". The retrieval brain's weights do not match the pinned manifest — refusing to use them.",
+    );
+    this.name = 'WeightIntegrityError';
+  }
+}
+
+/**
+ * Resolve qmd's GGUF models directory. qmd stores them under its XDG cache, so
+ * this honors `XDG_CACHE_HOME` (matching the adapter's per-tenant XDG isolation)
+ * and falls back to `~/.cache`.
+ */
+export function resolveQmdModelsDir(env: NodeJS.ProcessEnv = process.env): string {
+  const cacheHome = env['XDG_CACHE_HOME']?.trim() || join(homedir(), '.cache');
+  return join(cacheHome, 'qmd', 'models');
+}
+
+/**
+ * Verify every pinned weight against its on-disk copy. Pure check: returns the
+ * per-model result and never throws (use `assertWeightsVerified` to fail closed).
+ * Order of checks per model: existence → size → SHA-256 (so a cheap size diff
+ * short-circuits before hashing a multi-GB file).
+ */
+export async function verifyWeights(
+  manifest: WeightsManifest,
+  modelsDir: string = resolveQmdModelsDir(),
+): Promise<WeightsVerifyResult> {
+  const results: ModelVerifyResult[] = [];
+
+  for (const model of manifest.models) {
+    const path = join(modelsDir, model.file);
+    const base: ModelVerifyResult = {
+      id: model.id,
+      file: model.file,
+      status: 'ok',
+      expectedSha256: model.sha256,
+      expectedSize: model.size,
+    };
+
+    if (!existsSync(path)) {
+      results.push({ ...base, status: 'missing' });
+      continue;
+    }
+
+    const actualSize = statSync(path).size;
+    base.actualSize = actualSize;
+    if (actualSize !== model.size) {
+      results.push({ ...base, status: 'size-mismatch' });
+      continue;
+    }
+
+    const actualSha256 = await computeFileHash(path);
+    base.actualSha256 = actualSha256;
+    if (actualSha256 !== model.sha256) {
+      results.push({ ...base, status: 'hash-mismatch' });
+      continue;
+    }
+
+    results.push(base);
+  }
+
+  return { ok: results.every((r) => r.status === 'ok'), modelsDir, results };
+}
+
+/**
+ * Fail-closed gate. Verifies the weights and THROWS `WeightIntegrityError` on any
+ * mismatch. Call this before ANY semantic retrieval path (qmd query / embed /
+ * native vector backend) loads the models. Returns the (passing) result on success.
+ */
+export async function assertWeightsVerified(
+  manifest: WeightsManifest,
+  modelsDir: string = resolveQmdModelsDir(),
+): Promise<WeightsVerifyResult> {
+  const result = await verifyWeights(manifest, modelsDir);
+  if (!result.ok) {
+    throw new WeightIntegrityError(result);
+  }
+  return result;
+}

--- a/packages/qmd-adapter/src/weights/weights-manifest.ts
+++ b/packages/qmd-adapter/src/weights/weights-manifest.ts
@@ -1,0 +1,48 @@
+import type { WeightsManifest } from './verify-weights.js';
+
+/**
+ * Pinned SHA-256 hashes of qmd's GGUF retrieval-model weights — the integrity
+ * "receipts" for the retrieval brain. `assertWeightsVerified` checks the on-disk
+ * weights against these before any semantic path uses them, failing closed on a
+ * mismatch.
+ *
+ * Hashes were captured from the qmd model cache (`~/.cache/qmd/models`). Hugging
+ * Face artifacts are immutable, so the SHA-256 is the canonical pin.
+ *
+ * CAVEAT: captured under qmd 2.0.1's downloads, while the canonical pin is
+ * `@tobilu/qmd` 2.5.3 (see `gsb.lock.json` + this package). Re-confirm these
+ * against 2.5.3's model set when the semantic backend (bead 0t9.3) ships, and
+ * regenerate via a small hashing script. The verification primitive is correct
+ * regardless of which values are pinned; only the pinned values need confirming.
+ */
+export const QMD_WEIGHTS_MANIFEST: WeightsManifest = {
+  schemaVersion: 1,
+  qmd: { npmPackage: '@tobilu/qmd', version: '2.5.3' },
+  note: 'Hashes captured under qmd 2.0.1; re-confirm against the canonical 2.5.3 model set before the semantic path ships (bead 0t9.3).',
+  models: [
+    {
+      id: 'embedding',
+      role: 'embedding',
+      file: 'hf_ggml-org_embeddinggemma-300M-Q8_0.gguf',
+      sha256: 'b5ce9d77a3fc4b3b39ccb5643c36777911cc4eb46a66962eadfa3f5f60490d63',
+      size: 333590944,
+      hfRepo: 'ggml-org/embeddinggemma-300M-GGUF',
+    },
+    {
+      id: 'reranker',
+      role: 'reranker',
+      file: 'hf_ggml-org_qwen3-reranker-0.6b-q8_0.gguf',
+      sha256: '22c9979ce4fbcdc5acdc310c6641c32797eff1aa980b8f7a2db8a8ea23429a48',
+      size: 639153184,
+      hfRepo: 'ggml-org/qwen3-reranker-0.6B-GGUF',
+    },
+    {
+      id: 'query-expansion',
+      role: 'query-expansion',
+      file: 'hf_tobil_qmd-query-expansion-1.7B-q4_k_m.gguf',
+      sha256: '000dfb1c06efa6a049e9f64ba921c3740e2454f62abab6fa10e77bd30bb2bcc0',
+      size: 1282438912,
+      hfRepo: 'tobil/qmd-query-expansion-1.7B-GGUF',
+    },
+  ],
+};


### PR DESCRIPTION
Implements bead **qmd-team-intent-kb-0t9.5** (P1) — the ml-intern's non-negotiable from the retrieval ADR (`038-AT-DECR`).

**Why:** the retrieval brain runs ~2.2 GB of GGUF weights (EmbeddingGemma-300M, Qwen3-reranker-0.6B, qmd-query-expansion-1.7B) via llama.cpp, downloaded to a local cache and — until now — **neither signed nor pinned**. The audit manifest hashes the governance spool but never the retrieval weights: a govern-by-receipts product was running an unverified brain.

**What:**
- `common`: `computeFileHash` — streaming SHA-256 for GB-scale artifacts (bounded memory).
- `qmd-adapter/weights`:
  - `QMD_WEIGHTS_MANIFEST` — pinned SHA-256 + byte size per model (verified against the real files, no typo).
  - `verifyWeights` — pure check, order existence → size → hash (a cheap size diff short-circuits before hashing a multi-GB file).
  - `assertWeightsVerified` — the **fail-closed gate**: throws `WeightIntegrityError` on any mismatch. The semantic path (bead **0t9.3**) MUST call this before loading the models.
  - `resolveQmdModelsDir` — honors `XDG_CACHE_HOME`.

**Tests:** 10 unit tests (ok / hash-mismatch / size-mismatch / missing / fail-closed throw / error payload / XDG resolution). Typecheck clean.

**Caveats (documented in the manifest):** hashes captured under qmd 2.0.1 — re-confirm against the canonical 2.5.3 model set when 0t9.3 ships. The qmd binary is **version-pinned** (2.5.3); per-platform binary hashing is a follow-up.

Unblocks 0t9.3 (the lean sqlite-vec semantic path), which now has an integrity gate to call.

- Jeremy Longshore
intentsolutions.io
