### PR TITLE
feat(qmd-adapter): native FTS5 (BM25) keyword backend, no external binary (0t9.2)

### DIFF
--- a/packages/qmd-adapter/package.json
+++ b/packages/qmd-adapter/package.json
@@ -20,6 +20,10 @@
   },
   "dependencies": {
     "@qmd-team-intent-kb/schema": "workspace:*",
-    "@qmd-team-intent-kb/common": "workspace:*"
+    "@qmd-team-intent-kb/common": "workspace:*",
+    "better-sqlite3": "^12.10.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.11"
   }
 }

--- a/packages/qmd-adapter/src/__tests__/fts5-backend.test.ts
+++ b/packages/qmd-adapter/src/__tests__/fts5-backend.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Fts5Backend, fts5RetrievalFn, buildFts5MatchQuery } from '../native/fts5-backend.js';
+import { runEval } from '../eval/run-eval.js';
+import type { EvalDataset } from '../eval/eval-types.js';
+
+describe('buildFts5MatchQuery', () => {
+  it('quotes each word token and joins with implicit AND', () => {
+    expect(buildFts5MatchQuery('security audit')).toBe('"security" "audit"');
+  });
+
+  it('neutralizes FTS5 operators and punctuation (no injection / syntax error)', () => {
+    expect(buildFts5MatchQuery('foo AND bar OR (baz*) "qux"')).toBe(
+      '"foo" "AND" "bar" "OR" "baz" "qux"',
+    );
+  });
+
+  it('returns empty string when there are no usable tokens', () => {
+    expect(buildFts5MatchQuery('   --- ')).toBe('');
+  });
+});
+
+describe('Fts5Backend', () => {
+  let fts: Fts5Backend;
+
+  beforeEach(() => {
+    fts = new Fts5Backend();
+    // d1 and d2 both contain "security" + "audit"; d2 repeats "audit" (same length, 5 tokens).
+    fts.index([
+      { id: 'd1', collection: 'kb', content: 'security audit log review notes' },
+      { id: 'd2', collection: 'kb', content: 'security audit audit findings report' },
+      { id: 'd3', collection: 'kb', content: 'cooking recipes for dinner now' },
+    ]);
+  });
+
+  afterEach(() => fts.close());
+
+  it('indexes documents and reports the count', () => {
+    expect(fts.count()).toBe(3);
+  });
+
+  it('returns only docs that match the keywords', () => {
+    const hits = fts.search('cooking', 10);
+    expect(hits.map((h) => h.id)).toEqual(['d3']);
+    expect(hits[0]?.collection).toBe('kb');
+    expect(hits[0]?.score).toBeGreaterThan(0); // higher = more relevant
+  });
+
+  it('enforces AND semantics — a doc must contain every query term (qmd parity)', () => {
+    // d3 has "cooking" but not "security"; d1/d2 have "security" but not "cooking" → none match both.
+    expect(fts.search('security cooking', 10)).toEqual([]);
+  });
+
+  it('ranks higher term frequency first at equal doc length (d2 repeats "audit")', () => {
+    const hits = fts.search('security audit', 10);
+    expect(hits.map((h) => h.id)).toEqual(['d2', 'd1']);
+    expect(hits[0]?.score).toBeGreaterThan(hits[1]!.score);
+  });
+
+  it('respects the k cutoff', () => {
+    expect(fts.search('security', 1)).toHaveLength(1);
+    expect(fts.search('security', 10)).toHaveLength(2);
+  });
+
+  it('returns [] for a query with no usable tokens', () => {
+    expect(fts.search('!!! ---', 10)).toEqual([]);
+  });
+
+  it('does not throw on an operator-laden query', () => {
+    expect(() => fts.search('security AND OR NOT *', 10)).not.toThrow();
+  });
+
+  it('upserts by id — re-indexing a doc replaces its content', () => {
+    expect(fts.search('cooking', 10).map((h) => h.id)).toEqual(['d3']);
+    fts.index([{ id: 'd3', collection: 'kb', content: 'security incident response' }]);
+    expect(fts.count()).toBe(3); // not 4
+    expect(fts.search('cooking', 10)).toEqual([]); // old content gone
+    expect(fts.search('incident', 10).map((h) => h.id)).toEqual(['d3']); // new content searchable
+  });
+
+  it('clear() empties the index', () => {
+    fts.clear();
+    expect(fts.count()).toBe(0);
+    expect(fts.search('security', 10)).toEqual([]);
+  });
+});
+
+describe('fts5RetrievalFn + eval harness integration', () => {
+  it('runs through runEval and scores recall on the gold docs', async () => {
+    const fts = new Fts5Backend();
+    fts.index([
+      {
+        id: 'qmd://kb/audit.md',
+        content: 'the audit trail is a hash chain proving the record was not altered',
+      },
+      { id: 'qmd://kb/lifecycle.md', content: 'retire or deprecate a memory when it is outdated' },
+      { id: 'qmd://kb/noise.md', content: 'unrelated content about gardening' },
+    ]);
+
+    const dataset: EvalDataset = {
+      name: 'fts5-integration',
+      idSpace: 'qmd:// citation',
+      queries: [
+        {
+          id: 'q1',
+          kind: 'lexical',
+          query: 'audit trail hash chain',
+          relevant: ['qmd://kb/audit.md'],
+        },
+        {
+          id: 'q2',
+          kind: 'lexical',
+          query: 'deprecate memory outdated',
+          relevant: ['qmd://kb/lifecycle.md'],
+        },
+      ],
+    };
+
+    const report = await runEval(dataset, fts5RetrievalFn(fts), { k: 10, backend: 'fts5' });
+    fts.close();
+
+    expect(report.backend).toBe('fts5');
+    expect(report.queryCount).toBe(2);
+    expect(report.meanRecallAtK).toBe(1); // both gold docs retrieved by keyword
+    expect(report.meanNdcgAtK).toBe(1); // and each at rank 1
+  });
+});

--- a/packages/qmd-adapter/src/index.ts
+++ b/packages/qmd-adapter/src/index.ts
@@ -78,3 +78,7 @@ export type {
   QueryEvalResult,
   EvalReport,
 } from './eval/index.js';
+
+// Native FTS5 — model-free keyword backend, no external binary (bead 0t9.2)
+export { Fts5Backend, fts5RetrievalFn, buildFts5MatchQuery } from './native/index.js';
+export type { IndexedDoc, Fts5SearchHit } from './native/index.js';

--- a/packages/qmd-adapter/src/native/fts5-backend.ts
+++ b/packages/qmd-adapter/src/native/fts5-backend.ts
@@ -1,0 +1,114 @@
+import Database from 'better-sqlite3';
+import type { RetrievalFn } from '../eval/eval-types.js';
+
+/**
+ * Native FTS5 (BM25) retrieval backend — bead 0t9.2.
+ *
+ * A keyword retriever built on SQLite's FTS5 full-text index, ranked by BM25. It
+ * is a model-free, in-process alternative to qmd's `qmd search` that drops the
+ * external Bun binary dependency entirely (the council's "lean" path; ADR 038).
+ * Same shape as `QmdSearchResult` (file→id, score, snippet, collection), so it
+ * slots behind the adapter's retrieval seam and runs through the eval harness
+ * (bead 0t9.6) against the same datasets as qmd BM25, for a comparable number.
+ *
+ * Semantic recall (dense vectors) is a SEPARATE concern (bead 0t9.3) — this is
+ * the keyword half only.
+ */
+
+export interface IndexedDoc {
+  /** Stable doc identifier (e.g. the qmd:// citation / file path). */
+  id: string;
+  content: string;
+  collection?: string;
+}
+
+export interface Fts5SearchHit {
+  id: string;
+  /** BM25 relevance, higher = more relevant (FTS5's bm25() negated). */
+  score: number;
+  snippet: string;
+  collection: string;
+}
+
+/**
+ * Build a safe FTS5 MATCH expression from a free-text query: extract word tokens
+ * and quote each as a literal term joined by implicit AND. Quoting neutralizes
+ * FTS5 operators (`AND` / `OR` / `NOT` / `*` / `"`), so a user query can never be
+ * a query-injection or a syntax error. Returns '' when there are no usable tokens.
+ */
+export function buildFts5MatchQuery(query: string): string {
+  const tokens = query.match(/[\p{L}\p{N}]+/gu) ?? [];
+  return tokens.map((t) => `"${t}"`).join(' ');
+}
+
+interface SearchRow {
+  id: string;
+  collection: string;
+  snippet: string;
+  rank: number;
+}
+
+export class Fts5Backend {
+  private readonly db: Database.Database;
+  private readonly insertStmt: Database.Statement;
+  private readonly deleteStmt: Database.Statement;
+  private readonly searchStmt: Database.Statement;
+  private readonly countStmt: Database.Statement;
+
+  constructor(opts: { path?: string } = {}) {
+    this.db = new Database(opts.path ?? ':memory:');
+    this.db.pragma('journal_mode = WAL');
+    this.db.exec(
+      'CREATE VIRTUAL TABLE IF NOT EXISTS docs USING fts5(id UNINDEXED, collection UNINDEXED, content)',
+    );
+    this.insertStmt = this.db.prepare('INSERT INTO docs(id, collection, content) VALUES (?, ?, ?)');
+    this.deleteStmt = this.db.prepare('DELETE FROM docs WHERE id = ?');
+    this.searchStmt = this.db.prepare(
+      "SELECT id, collection, snippet(docs, 2, '', '', '…', 16) AS snippet, bm25(docs) AS rank " +
+        'FROM docs WHERE docs MATCH ? ORDER BY rank LIMIT ?',
+    );
+    this.countStmt = this.db.prepare('SELECT count(*) AS n FROM docs');
+  }
+
+  /** Index documents (upsert by id — a re-indexed doc replaces its prior copy). */
+  index(docs: readonly IndexedDoc[]): void {
+    const tx = this.db.transaction((items: readonly IndexedDoc[]) => {
+      for (const doc of items) {
+        this.deleteStmt.run(doc.id);
+        this.insertStmt.run(doc.id, doc.collection ?? '', doc.content);
+      }
+    });
+    tx(docs);
+  }
+
+  /** Remove every indexed document. */
+  clear(): void {
+    this.db.exec('DELETE FROM docs');
+  }
+
+  /** BM25 keyword search → top-k hits, most relevant first. */
+  search(query: string, k = 10): Fts5SearchHit[] {
+    const match = buildFts5MatchQuery(query);
+    if (match.length === 0) return [];
+    const rows = this.searchStmt.all(match, k) as SearchRow[];
+    return rows.map((r) => ({
+      id: r.id,
+      collection: r.collection,
+      snippet: r.snippet,
+      score: -r.rank, // FTS5 bm25() is negative (best = most negative); negate so higher = better
+    }));
+  }
+
+  count(): number {
+    return (this.countStmt.get() as { n: number }).n;
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}
+
+/** Adapt an `Fts5Backend` to the eval harness's `RetrievalFn` (ranked ids only). */
+export function fts5RetrievalFn(backend: Fts5Backend): RetrievalFn {
+  return (query: string, k: number) => Promise.resolve(backend.search(query, k).map((h) => h.id));
+}

--- a/packages/qmd-adapter/src/native/index.ts
+++ b/packages/qmd-adapter/src/native/index.ts
@@ -1,0 +1,2 @@
+export { Fts5Backend, fts5RetrievalFn, buildFts5MatchQuery } from './fts5-backend.js';
+export type { IndexedDoc, Fts5SearchHit } from './fts5-backend.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,6 +313,13 @@ importers:
       '@qmd-team-intent-kb/schema':
         specifier: workspace:*
         version: link:../schema
+      better-sqlite3:
+        specifier: ^12.10.0
+        version: 12.10.0
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.11
+        version: 7.6.13
 
   packages/repo-resolver:
     dependencies:
@@ -1754,9 +1761,6 @@ packages:
 
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
-  '@types/node@22.19.15':
-    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
@@ -3939,9 +3943,6 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
@@ -5369,7 +5370,7 @@ snapshots:
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.6.0
 
   '@types/chai@5.2.3':
     dependencies:
@@ -5398,10 +5399,6 @@ snapshots:
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
-
-  '@types/node@22.19.15':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/node@25.6.0':
     dependencies:
@@ -7884,8 +7881,6 @@ snapshots:
   underscore@1.13.8: {}
 
   undici-types@5.26.5: {}
-
-  undici-types@6.21.0: {}
 
   undici-types@7.19.2: {}
 


### PR DESCRIPTION
Implements bead **qmd-team-intent-kb-0t9.2** — the native FTS5 keyword backend. A model-free, in-process retriever on SQLite FTS5 ranked by BM25, the "lean" path from ADR 038 that **drops qmd's external Bun binary** for keyword search.

**What:**
- `Fts5Backend` — `index` (upsert by id, transactional), `search` (FTS5 `MATCH` + `bm25()`, negated so higher = more relevant, with `snippet()`), `clear`, `count`, `close`. Same result shape as `QmdSearchResult` (`id`/`score`/`snippet`/`collection`), so it sits behind the adapter's retrieval seam.
- `buildFts5MatchQuery` — extracts word tokens and quotes each → **implicit AND** (keyword parity with qmd's AND-semantics) **and** neutralizes FTS5 operators (`AND`/`OR`/`NOT`/`*`/`"`), so a user query can never be an injection or a syntax error.
- `fts5RetrievalFn` — adapts the backend to the `0t9.6` eval harness's `RetrievalFn`, so FTS5 and qmd-BM25 run the **same datasets** for a comparable Recall@10/nDCG@10.

**Tests:** 13 FTS5 tests (AND semantics, controlled term-frequency ranking, k-cutoff, operator safety, upsert-by-id, clear, end-to-end `runEval` integration). Full qmd-adapter suite **114 green**, typecheck clean. Adds `better-sqlite3` (already a workspace dep via `store`; FTS5 is bundled in its SQLite).

This is the keyword half. Dense semantic recall (sqlite-vec + EmbeddingGemma-300M) stays separate — bead `0t9.3`, gated by the eval (`0t9.6`) and the pinned weights (`0t9.5`).

- Jeremy Longshore
intentsolutions.io
