### PR TITLE
fix(ci): soft-fail Codecov upload on dependabot PRs (unblocks 12 dep updates)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,10 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
-          fail_ci_if_error: true
+          # Dependabot PRs run with secrets withheld (empty CODECOV_TOKEN), so a
+          # token-less upload errors. Keep the strict gate for human PRs; soft-fail
+          # only for dependabot so dependency-update PRs aren't blocked by it.
+          fail_ci_if_error: ${{ github.actor != 'dependabot[bot]' }}
           verbose: true
 
       - name: Upload test results to Codecov Test Analytics


### PR DESCRIPTION
## Problem

All 12 open dependabot PRs (#142, #172–#183) fail the required `validate` job — every one at the
**"Upload coverage to Codecov"** step (`ci.yml`), exit 1. The tests pass; the upload fails.

**Root cause:** GitHub withholds repository secrets from Dependabot-triggered `pull_request` runs
(security policy). So `secrets.CODECOV_TOKEN` is empty on those runs, the token-less Codecov upload
errors, and `fail_ci_if_error: true` turns that into a job failure. It's structural — no dependency
bump can pass this step as written, so the whole dependency-update queue is stuck.

## Fix

Gate `fail_ci_if_error` on the actor:

```yaml
fail_ci_if_error: ${{ github.actor != 'dependabot[bot]' }}
```

- **Human PRs** (`actor != dependabot[bot]`) → `true`: the strict gate is unchanged; a real Codecov
  failure still blocks.
- **Dependabot PRs** → `false`: the upload still runs, but a token-less error no longer fails the job.

One line + an explanatory comment. The second Codecov step (test-results-action) already uses
`fail_ci_if_error: false`, so this only aligns the coverage-upload step.

## After merge

The 12 dependabot PRs need a re-run (push an empty commit or re-trigger) to pick up the fixed
workflow and go green.

- Jeremy Longshore
intentsolutions.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to improve code coverage upload handling and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->