### PR TITLE
chore(dependabot): group routine updates to cut PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,22 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     labels:
       - 'dependencies'
+    # Batch routine updates into a few PRs instead of one-per-package. Majors stay
+    # ungrouped (individual PRs) so breaking bumps still get reviewed on their own.
+    groups:
+      dev-dependencies:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'
+      production-dependencies:
+        dependency-type: 'production'
+        update-types:
+          - 'minor'
+          - 'patch'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -16,3 +29,7 @@ updates:
     labels:
       - 'dependencies'
       - 'ci'
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## What

Adds `groups` to `.github/dependabot.yml` so routine dependency bumps arrive batched
instead of one PR per package:

- **npm dev-dependencies** (minor/patch) → one grouped PR
- **npm production-dependencies** (minor/patch) → one grouped PR
- **github-actions** (all) → one grouped PR
- **majors** → stay ungrouped (individual PRs) so breaking bumps get their own review
- npm `open-pull-requests-limit` 10 → 5

## Why

The repo had 12 simultaneous open dependabot PRs — each a single-package bump. Grouping
collapses a typical week into ~2-3 PRs while keeping risky majors visible on their own.

Config-only; no code change.

- Jeremy Longshore
intentsolutions.io


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to optimize the handling of npm package updates, reducing simultaneous pull requests and introducing organized grouping for development and production dependencies, as well as GitHub Actions updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->