### PR TITLE
docs: refresh README to v0.7.0 + reindex 000-docs (031-039) + align thesis-doc license

### DIFF
--- a/000-docs/000-INDEX.md
+++ b/000-docs/000-INDEX.md
@@ -15,6 +15,11 @@
 - `003-AT-DSGN-system-thesis.md` — Problem statement and design rationale
 - `007-AT-DSGN-data-model-draft.md` — Domain model draft (Zod schemas planned)
 - `026-AT-DSGN-repo-resolver-design.md` — repo-resolver package design (RepoContext, tenant derivation, caching)
+- `034-AT-NTRP-ecosystem-thesis.md` — "Compile, Then Govern" thesis paper (byte-identical cross-repo copy)
+- `035-AT-DECR-post-thesis-build-direction-2026-05-23.md` — Post-thesis build direction executive council decision record
+- `036-AT-THRT-spool-boundary-threat-model.md` — Spool boundary threat model
+- `037-AT-DSGN-qmd-adapter-source-index-separation.md` — qmd-adapter source/index separation ADR
+- `038-AT-DECR-retrieval-backend-decision-2026-06-18.md` — Retrieval backend decision (thinker-canon council)
 
 ### TQ — Testing & Quality
 
@@ -58,41 +63,53 @@
 - `021-AA-AACR-phase7-reporting.md` — Phase 7 reporting after action review
 - `022-AA-AACR-phase8-security.md` — Phase 8 security hardening after action review
 - `023-AA-AACR-phase9-release-readiness.md` — Phase 9 release readiness after action review
+- `031-AA-AACR-v0.6.0-release-aar.md` — v0.6.0 release report / after action review
+
+### RL — Release
+
+- `039-RL-REPT-qmd-team-intent-kb-release-v0.7.0.md` — v0.7.0 release report
 
 ## Chronological Listing
 
-| #   | Code    | File                        | Description                    |
-| --- | ------- | --------------------------- | ------------------------------ |
-| 000 | PP-PLAN | mega-blueprint              | Canonical project blueprint    |
-| 001 | AT-ARCH | repo-blueprint              | Repository structure           |
-| 002 | AT-ARCH | architecture-overview       | System architecture            |
-| 003 | AT-DSGN | system-thesis               | Design rationale               |
-| 004 | PP-RMAP | phase-plan                  | Implementation roadmap         |
-| 005 | TQ-TEST | testing-ci-strategy         | Testing and CI                 |
-| 006 | TQ-SECU | security-governance         | Security and threats           |
-| 007 | AT-DSGN | data-model-draft            | Domain model                   |
-| 008 | OD-RELS | release-versioning-policy   | Release policy                 |
-| 009 | DR-GUID | contribution-workflow       | Contributor guide              |
-| 010 | WA-WFLW | internal-claude-operations  | Claude workflows               |
-| 011 | PM-RISK | risk-register               | Risk tracking                  |
-| 012 | AA-AACR | initial-aar                 | Phase 0 AAR                    |
-| 013 | AA-AACR | phase1-schema               | Phase 1 AAR                    |
-| 014 | AA-AACR | phase2-runtime              | Phase 2 AAR                    |
-| 015 | AA-AACR | phase3-adapter              | Phase 3 AAR                    |
-| 016 | OD-OPSM | branch-protection-checklist | Branch protection setup        |
-| 017 | AA-AACR | phase4-api                  | Phase 4 AAR                    |
-| 018 | AA-AACR | phase5-curator              | Phase 5 AAR                    |
-| 019 | AA-AACR | phase6-exporter             | Phase 6 AAR                    |
-| 020 | OD-RELS | v1-release-checklist        | v1 release checklist           |
-| 021 | AA-AACR | phase7-reporting            | Phase 7 AAR                    |
-| 022 | AA-AACR | phase8-security             | Phase 8 AAR                    |
-| 023 | AA-AACR | phase9-release-readiness    | Phase 9 AAR                    |
-| 024 | PP-CLOS | v1-scope-closeout           | v1 scope closeout              |
-| 025 | AA-AACR | v0.3.0-release-report       | v0.3.0 release report          |
-| 026 | AT-DSGN | repo-resolver-design        | repo-resolver package design   |
-| 027 | OD-OPSM | edge-daemon-runbook         | edge-daemon operations runbook |
-| 028 | OD-SECU | release-signing             | Release supply-chain signing   |
-| 029 | OD-RELS | npm-publishing-strategy     | npm publishing strategy        |
-| 030 | DR-GUID | import-conversion-recipes   | Import from various sources    |
+| #   | Code    | File                                | Description                    |
+| --- | ------- | ----------------------------------- | ------------------------------ |
+| 000 | PP-PLAN | mega-blueprint                      | Canonical project blueprint    |
+| 001 | AT-ARCH | repo-blueprint                      | Repository structure           |
+| 002 | AT-ARCH | architecture-overview               | System architecture            |
+| 003 | AT-DSGN | system-thesis                       | Design rationale               |
+| 004 | PP-RMAP | phase-plan                          | Implementation roadmap         |
+| 005 | TQ-TEST | testing-ci-strategy                 | Testing and CI                 |
+| 006 | TQ-SECU | security-governance                 | Security and threats           |
+| 007 | AT-DSGN | data-model-draft                    | Domain model                   |
+| 008 | OD-RELS | release-versioning-policy           | Release policy                 |
+| 009 | DR-GUID | contribution-workflow               | Contributor guide              |
+| 010 | WA-WFLW | internal-claude-operations          | Claude workflows               |
+| 011 | PM-RISK | risk-register                       | Risk tracking                  |
+| 012 | AA-AACR | initial-aar                         | Phase 0 AAR                    |
+| 013 | AA-AACR | phase1-schema                       | Phase 1 AAR                    |
+| 014 | AA-AACR | phase2-runtime                      | Phase 2 AAR                    |
+| 015 | AA-AACR | phase3-adapter                      | Phase 3 AAR                    |
+| 016 | OD-OPSM | branch-protection-checklist         | Branch protection setup        |
+| 017 | AA-AACR | phase4-api                          | Phase 4 AAR                    |
+| 018 | AA-AACR | phase5-curator                      | Phase 5 AAR                    |
+| 019 | AA-AACR | phase6-exporter                     | Phase 6 AAR                    |
+| 020 | OD-RELS | v1-release-checklist                | v1 release checklist           |
+| 021 | AA-AACR | phase7-reporting                    | Phase 7 AAR                    |
+| 022 | AA-AACR | phase8-security                     | Phase 8 AAR                    |
+| 023 | AA-AACR | phase9-release-readiness            | Phase 9 AAR                    |
+| 024 | PP-CLOS | v1-scope-closeout                   | v1 scope closeout              |
+| 025 | AA-AACR | v0.3.0-release-report               | v0.3.0 release report          |
+| 026 | AT-DSGN | repo-resolver-design                | repo-resolver package design   |
+| 027 | OD-OPSM | edge-daemon-runbook                 | edge-daemon operations runbook |
+| 028 | OD-SECU | release-signing                     | Release supply-chain signing   |
+| 029 | OD-RELS | npm-publishing-strategy             | npm publishing strategy        |
+| 030 | DR-GUID | import-conversion-recipes           | Import from various sources    |
+| 031 | AA-AACR | v0.6.0-release-aar                  | v0.6.0 release report          |
+| 034 | AT-NTRP | ecosystem-thesis                    | Compile, Then Govern thesis    |
+| 035 | AT-DECR | post-thesis-build-direction         | Post-thesis council decision   |
+| 036 | AT-THRT | spool-boundary-threat-model         | Spool boundary threat model    |
+| 037 | AT-DSGN | qmd-adapter-source-index-separation | qmd-adapter source/index ADR   |
+| 038 | AT-DECR | retrieval-backend-decision          | Retrieval backend decision     |
+| 039 | RL-REPT | qmd-team-intent-kb-release-v0.7.0   | v0.7.0 release report          |
 
-## Next Available Sequence: 031
+## Next Available Sequence: 040

--- a/000-docs/034-AT-NTRP-ecosystem-thesis.md
+++ b/000-docs/034-AT-NTRP-ecosystem-thesis.md
@@ -10,7 +10,7 @@ audience: engineering managers, platform-team leads, team-knowledge stewards
 cross_repo: byte-identical copy at qmd-team-intent-kb/000-docs/034-AT-NTRP-ecosystem-thesis.md
 parent_bead_ico: intentional-cognition-os-ziz
 parent_bead_intkb: qmd-team-intent-kb-oaa
-license: MIT
+license: Apache-2.0
 ---
 
 # Compile, Then Govern

--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ qmd-team-intent-kb/
 
 ## Status
 
-**v0.6.0 — Production-ready platform with full Intent Solutions Testing SOP enforced in CI.**
+**v0.7.0 — Production-ready platform with full Intent Solutions Testing SOP enforced in CI.**
+
+**v0.7.0 marquee:** native FTS5/BM25 retrieval backend (model-free, in-process) · Recall@10/nDCG@10 eval harness · MCP tool surface (`teamkb_search` / `teamkb_propose`) · hash-chained tamper-evident audit receipts with an external chain-head anchor.
 
 All core subsystems functional. 1,313 unit tests + 4 testcontainers-based L4 integration tests passing. CI enforces 10 gates per PR: typecheck → lint → format → architecture (dep-cruiser) → complexity (CRAP) → unit tests → coverage 80% line / 70% branch → secrets (gitleaks) → npm audit (when deps change) → SAST (Semgrep advisory). Policy artifacts hash-pinned via `scripts/harness-pin.sh` so the testing-SOP is self-defending against silent AI policy edits.
 


### PR DESCRIPTION
Documentation consistency sweep following the v0.7.0 release.

- **README Status banner** bumped `v0.6.0 → v0.7.0`, plus a tight v0.7.0 marquee line: native FTS5/BM25 retrieval backend, Recall@10/nDCG@10 eval harness, MCP tool surface (`teamkb_search` / `teamkb_propose`), and hash-chained tamper-evident audit receipts with an external chain-head anchor.
- **`000-docs/000-INDEX.md`** was ~9 docs stale (listed through 030; on-disk goes to 039). Added entries for 031, 034, 035, 036, 037, 038, 039 (032/033 do not exist on disk) to both the categorized lists and the chronological table; footer `Next Available Sequence` corrected `031 → 040`. New ADR `038-AT-DECR` and release report `039-RL-REPT` are included.
- **`000-docs/034-AT-NTRP-ecosystem-thesis.md`** frontmatter `license: MIT → license: Apache-2.0` (single-line change) to keep the thesis byte-identical to ICO's copy.

- Jeremy Longshore
intentsolutions.io